### PR TITLE
chore: fix Makefile build & test

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,7 +12,6 @@ linters:
     - err113
     - errcheck
     - exhaustive
-    - exhaustruct
     - exptostd
     - forbidigo
     - funcorder
@@ -35,7 +34,6 @@ linters:
     - nestif
     - nilerr
     - nlreturn
-    - nonamedreturns
     - paralleltest
     - perfsprint
     - prealloc

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,13 @@ format:
 	go fmt ./...
 
 test: config/betterleaks.toml format
-	go test -v ./... --race $(PKG)
+	go test -v --race ./... $(PKG)
 
 failfast: format
 	go test -failfast ./...
 
 build:
-	go build $(LDFLAGS) -o betterleaks ./cmd/betterleaks
+	go build $(LDFLAGS) -o betterleaks .
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
The Makefile for `main` wasn't working for me. I suspect it was mixed with the v2 one.
```sh
$ make build
go build -ldflags "-X=github.com/betterleaks/betterleaks/version.Version=v1.0.1" -o betterleaks ./cmd/betterleaks
stat /home/user/github.com/betterleaks/betterleaks/cmd/betterleaks: directory not found
make: *** [Makefile:22: build] Error 1

$ go test
?       github.com/betterleaks/betterleaks      [no test files]
```

Edit: also, there was an issue with the `.golangci.yaml` config:
```sh
$ make lint
golangci-lint run
Error: can't load config: linter "exhaustruct" can't be disabled and enabled at one moment
Failed executing command with error: can't load config: linter "exhaustruct" can't be disabled and enabled at one moment
make: *** [Makefile:25: lint] Error 3

$ make lint
golangci-lint run
Error: can't load config: linter "nonamedreturns" can't be disabled and enabled at one moment
Failed executing command with error: can't load config: linter "nonamedreturns" can't be disabled and enabled at one moment
make: *** [Makefile:25: lint] Error 3
```