### PR TITLE
Correct program name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Available Commands:
   git         scan git repositories for secrets
   help        Help about any command
   stdin       detect secrets from stdin
-  version     display gitleaks version
+  version     display betterleaks version
 
 Flags:
   -b, --baseline-path string          path to baseline with issues that can be ignored

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,7 +13,7 @@ func init() {
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "display gitleaks version",
+	Short: "display betterleaks version",
 	Run:   runVersion,
 }
 


### PR DESCRIPTION
Just a small edit to change `gitleaks` to `betterleaks` in the help output.