### PR TITLE
regex > regexp, keeping package name the same bc golang regexp

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
           go install gotest.tools/gotestsum@latest
 
       - name: Test
+        env:
+          BETTERLEAKS_REGEX_ENGINE: ${{ matrix.platform == 'windows-latest' && 'stdlib' || '' }}
         run: |
           gotestsum --raw-command -- go test -json ./... --race
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A couple things:
 - Optimized Recursive Decoding (for catching those nasty SHA1-HULUD variants)
 - [Token Efficiency Filter](https://lookingatcomputer.substack.com/p/rare-not-random)
 - Misc optimizations
-- Regex engine switching w/ (`--regexp-engine=stdlib/re2`)
+- Regex engine switching w/ (`--regex-engine=stdlib/re2` or `BETTERLEAKS_REGEX_ENGINE=stdlib`)
 - MORE RULES! Ahhh finally!
 
 ### Benchmarks

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,9 @@ func init() {
 	rootCmd.PersistentFlags().Int("max-decode-depth", 5, "allow recursive decoding up to this depth")
 	rootCmd.PersistentFlags().Int("max-archive-depth", 0, "allow scanning into nested archives up to this depth (default \"0\", no archive traversal is done)")
 	rootCmd.PersistentFlags().Int("timeout", 0, "set a timeout for gitleaks commands in seconds (default \"0\", no timeout is set)")
+	rootCmd.PersistentFlags().String("regex-engine", "re2", "regex engine (stdlib, re2)")
 	rootCmd.PersistentFlags().String("regexp-engine", "re2", "regex engine (stdlib, re2)")
+	_ = rootCmd.PersistentFlags().MarkHidden("regexp-engine")
 
 	// Add diagnostics flags
 	rootCmd.PersistentFlags().String("diagnostics", "", "enable diagnostics (http OR comma-separated list: cpu,mem,trace). cpu=CPU prof, mem=memory prof, trace=exec tracing, http=serve via net/http/pprof")
@@ -130,7 +132,9 @@ func initLog() {
 	}
 	logging.Logger = logging.Logger.Level(logLevel)
 
-	if engine, err := rootCmd.Flags().GetString("regexp-engine"); err == nil && engine != "" {
+	if engine, err := rootCmd.Flags().GetString("regex-engine"); err == nil && engine != "" {
+		regexp.SetEngine(engine)
+	} else if engine, err := rootCmd.Flags().GetString("regexp-engine"); err == nil && engine != "" {
 		regexp.SetEngine(engine)
 	}
 }

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -1,10 +1,17 @@
 package regexp
 
 import (
+	"os"
 	stdlib "regexp"
 
 	gore2 "github.com/wasilibs/go-re2"
 )
+
+func init() {
+	if v := os.Getenv("BETTERLEAKS_REGEX_ENGINE"); v != "" {
+		SetEngine(v)
+	}
+}
 
 // engine is an internal interface satisfied by both *stdlib.Regexp and *gore2.Regexp.
 type engine interface {


### PR DESCRIPTION
We're getting flaky failures on windows runners when using re2