### PR TITLE
docs: mark non-context functions deprecated

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -10,6 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkoukk/tiktoken-go"
+	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
+
 	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect/codec"
 	"github.com/betterleaks/betterleaks/logging"
@@ -17,8 +20,6 @@ import (
 	"github.com/betterleaks/betterleaks/sources"
 	"github.com/betterleaks/betterleaks/validate"
 	"github.com/betterleaks/betterleaks/words"
-	"github.com/pkoukk/tiktoken-go"
-	tiktoken_loader "github.com/pkoukk/tiktoken-go-loader"
 
 	ahocorasick "github.com/BobuSumisu/aho-corasick"
 	"github.com/fatih/semgroup"
@@ -195,6 +196,8 @@ type Detector struct {
 }
 
 // NewDetector creates a new detector with the given config
+//
+// Deprecated: use NewDetectorContext instead.
 func NewDetector(cfg config.Config) *Detector {
 	return NewDetectorContext(context.Background(), cfg)
 }
@@ -396,6 +399,8 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 }
 
 // Detect scans the given fragment and returns a list of findings
+//
+// Deprecated: use DetectContext instead.
 func (d *Detector) Detect(fragment sources.Fragment) []report.Finding {
 	return d.DetectContext(context.Background(), fragment)
 }

--- a/sources/git.go
+++ b/sources/git.go
@@ -62,6 +62,8 @@ func (br *blobReader) Close() error {
 // NewGitLogCmd returns `*DiffFilesCmd` with two channels: `<-chan *gitdiff.File` and `<-chan error`.
 // Caller should read everything from channels until receiving a signal about their closure and call
 // the `func (*DiffFilesCmd) Wait()` error in order to release resources.
+//
+// Deprecated: use NewGitLogCmdContext instead.
 func NewGitLogCmd(source string, logOpts string) (*GitCmd, error) {
 	return NewGitLogCmdContext(context.Background(), source, logOpts)
 }
@@ -127,6 +129,8 @@ func NewGitLogCmdContext(ctx context.Context, source string, logOpts string) (*G
 // NewGitDiffCmd returns `*DiffFilesCmd` with two channels: `<-chan *gitdiff.File` and `<-chan error`.
 // Caller should read everything from channels until receiving a signal about their closure and call
 // the `func (*DiffFilesCmd) Wait()` error in order to release resources.
+//
+// Deprecated: use NewGitDiffCmdContext instead.
 func NewGitDiffCmd(source string, staged bool) (*GitCmd, error) {
 	return NewGitDiffCmdContext(context.Background(), source, staged)
 }
@@ -198,6 +202,8 @@ func (c *GitCmd) String() string {
 // within the git repo used to create the GitCmd.
 //
 // The caller is responsible for closing the reader.
+//
+// Deprecated: use NewBlobReaderContext instead.
 func (c *GitCmd) NewBlobReader(commit, path string) (io.ReadCloser, error) {
 	return c.NewBlobReaderContext(context.Background(), commit, path)
 }
@@ -431,6 +437,8 @@ func (s *Git) Fragments(ctx context.Context, yield FragmentsFunc) error {
 }
 
 // NewRemoteInfo builds a new RemoteInfo for generating finding links
+//
+// Deprecated: use NewRemoteInfoContext instead.
 func NewRemoteInfo(platform scm.Platform, source string) *RemoteInfo {
 	return NewRemoteInfoContext(context.Background(), platform, source)
 }


### PR DESCRIPTION
We previously introduced context-aware methods into the API. Non-context ones are kept for backwards compatibility, but should be marked as deprecated.