### PR TITLE
bugfix - printFinding output

### DIFF
--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -213,6 +213,46 @@ func TestDetect(t *testing.T) {
 				},
 			},
 		},
+		// Multiple instances of the same secret on a single line must produce
+		// findings with distinct StartColumn values pointing to each occurrence.
+		"detect finding - duplicate secret on same line": {
+			cfgName: "simple",
+			fragment: sources.Fragment{
+				Raw:      `#ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij...ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij`,
+				FilePath: "tmp.go",
+			},
+			expectedFindings: []report.Finding{
+				{
+					RuleID:      "github-pat",
+					Description: "Github Personal Access Token",
+					File:        "tmp.go",
+					Line:        `#ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij...ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij`,
+					Match:       "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+					Secret:      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+					Entropy:     5.22193,
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 2,
+					EndColumn:   41,
+					Tags:        []string{"key", "Github"},
+				},
+				{
+					RuleID:      "github-pat",
+					Description: "Github Personal Access Token",
+					File:        "tmp.go",
+					Line:        `#ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij...ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij`,
+					Match:       "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+					Secret:      "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+					Entropy:     5.22193,
+					StartLine:   0,
+					EndLine:     0,
+					StartColumn: 45,
+					EndColumn:   84,
+					Tags:        []string{"key", "Github"},
+				},
+			},
+		},
+
 		"detect finding - sidekiq env var": {
 			cfgName: "simple",
 			fragment: sources.Fragment{

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -16,6 +16,43 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// locateMatch returns the byte index of match within rawLine, using startCol
+// (1-indexed byte offset) to disambiguate duplicate occurrences. When the
+// exact position doesn't match, it searches forward then backward from the
+// expected position before falling back to the first occurrence.
+func locateMatch(rawLine, rawMatch string, startCol int) int {
+	if rawLine == "" || rawMatch == "" {
+		return -1
+	}
+
+	if startCol > 0 {
+		idx := startCol - 1 // assumes StartColumn is a 1-based byte offset
+
+		if idx >= 0 && idx+len(rawMatch) <= len(rawLine) &&
+			rawLine[idx:idx+len(rawMatch)] == rawMatch {
+			return idx
+		}
+
+		// Search near the expected position first, not from the start.
+		if idx < 0 {
+			idx = 0
+		}
+		if idx > len(rawLine) {
+			idx = len(rawLine)
+		}
+		if rel := strings.Index(rawLine[idx:], rawMatch); rel >= 0 {
+			return idx + rel
+		}
+		if prev := strings.LastIndex(rawLine[:idx], rawMatch); prev >= 0 {
+			return prev
+		}
+	}
+
+	// startCol <= 0 (no hint provided) or, redundantly, when the
+	// forward+backward searches above already covered the full line.
+	return strings.Index(rawLine, rawMatch)
+}
+
 var linkCleaner = strings.NewReplacer(
 	" ", "%20",
 	"%", "%25",
@@ -210,7 +247,7 @@ func printFinding(f report.Finding, noColor bool) {
 
 	// Matches from filenames do not have a |line| or |secret|
 	if !isFileMatch {
-		matchInLineIDX := strings.Index(f.Line, f.Match)
+		matchInLineIDX := locateMatch(f.Line, f.Match, f.StartColumn)
 		secretInMatchIdx := strings.Index(f.Match, f.Secret)
 
 		skipColor = false
@@ -227,6 +264,10 @@ func printFinding(f report.Finding, noColor bool) {
 			start = "..." + f.Line[startMatchIdx:matchInLineIDX]
 		}
 
+		if secretInMatchIdx == -1 {
+			secretInMatchIdx = 0
+		}
+
 		matchBeginning := lipgloss.NewStyle().SetString(f.Match[0:secretInMatchIdx]).Foreground(lipgloss.Color("#f5d445"))
 		secret = lipgloss.NewStyle().SetString(f.Secret).
 			Bold(true).
@@ -235,7 +276,7 @@ func printFinding(f report.Finding, noColor bool) {
 		matchEnd := lipgloss.NewStyle().SetString(f.Match[secretInMatchIdx+len(f.Secret):]).Foreground(lipgloss.Color("#f5d445"))
 
 		lineEndIdx := matchInLineIDX + len(f.Match)
-		if len(f.Line)-1 <= lineEndIdx {
+		if lineEndIdx > len(f.Line) {
 			lineEndIdx = len(f.Line)
 		}
 

--- a/detect/utils_test.go
+++ b/detect/utils_test.go
@@ -212,3 +212,77 @@ func Test_createScmLink(t *testing.T) {
 		})
 	}
 }
+
+// Test_locateMatch verifies the near-position fallback logic that
+// disambiguates duplicate occurrences of the same match on a line.
+func Test_locateMatch(t *testing.T) {
+	tests := map[string]struct {
+		rawLine  string
+		rawMatch string
+		startCol int
+		want     int
+	}{
+		"empty line": {
+			rawLine:  "",
+			rawMatch: "abc",
+			startCol: 1,
+			want:     -1,
+		},
+		"empty match": {
+			rawLine:  "abc",
+			rawMatch: "",
+			startCol: 1,
+			want:     -1,
+		},
+		"exact position hit": {
+			rawLine:  "prefix key=SECRET suffix",
+			rawMatch: "key=SECRET",
+			startCol: 8, // byte 7 is 'k', 1-indexed = 8
+			want:     7,
+		},
+		"first of duplicates via startCol": {
+			rawLine:  "tok tok",
+			rawMatch: "tok",
+			startCol: 1,
+			want:     0,
+		},
+		"second of duplicates via startCol": {
+			rawLine:  "tok tok",
+			rawMatch: "tok",
+			startCol: 5,
+			want:     4,
+		},
+		"startCol slightly off - forward search finds nearer": {
+			// startCol points 1 byte before the second "tok"
+			rawLine:  "tok ...tok",
+			rawMatch: "tok",
+			startCol: 7, // byte 6, actual second "tok" is at byte 7
+			want:     7, // forward search from byte 6 finds byte 7
+		},
+		"startCol past match - backward search finds it": {
+			rawLine:  "abc SECRET def",
+			rawMatch: "SECRET",
+			startCol: 14, // past end of "SECRET"
+			want:     4,  // backward search from byte 13 finds byte 4
+		},
+		"no startCol falls back to strings.Index": {
+			rawLine:  "tok tok",
+			rawMatch: "tok",
+			startCol: 0,
+			want:     0, // first occurrence
+		},
+		"match not in line": {
+			rawLine:  "no match here",
+			rawMatch: "SECRET",
+			startCol: 1,
+			want:     -1,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := locateMatch(tt.rawLine, tt.rawMatch, tt.startCol)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This fixes the`printFinding` output when the same secret appears multiple times on one line. The code highlighted the first occurrence because it used a plain `strings.Index`, ignoring the `StartColumn` that each finding carries.

The core algorithm, if you can call it that, is simple: first try the exact position reported by the regex engine. If whitespace trimming shifted the match, scan to the right from that position. If it is not to the right, scan to the left. If there is no position hint at all, fall back to scanning from the start, as before. I know what you're thinking... super fancy :)

Opus 4.6 was used for the tests. `locateMatch` was mostly organic human grade Go.



<img width="721" height="317" alt="Screenshot 2026-03-09 at 21 31 11" src="https://github.com/user-attachments/assets/ccf6b621-8fe4-44c0-914d-65788b94c179" />