### PR TITLE
Add Fedora Linux install to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Great question. Check out what we're cookin in the [v2 branch](https://github.co
 brew install betterleaks
 brew install betterleaks/tap/betterleaks
 
+# Fedora Linux
+sudo dnf install betterleaks
+
 # Containers
 docker pull ghcr.io/betterleaks/betterleaks:latest
 


### PR DESCRIPTION
Betterleaks is [available on Fedora Linux](https://packages.fedoraproject.org/pkgs/betterleaks/betterleaks/) :tada: 

```
$ sudo dnf install betterleaks
...                                                                                                                                                                                         
Repositories loaded.
Package                                   Arch    Version       Repository            Size
Installing:
 betterleaks                              x86_64  1.0.1-1.fc43  updates           34.8 MiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 10 MiB. Need to download 10 MiB.
After this operation, 35 MiB extra will be used (install 35 MiB, remove 0 B).
Is this ok [y/N]: y
[1/1] betterleaks-0:1.0.1-1.fc43.x86_64            100% |  24.7 MiB/s |  10.2 MiB |  00m00s
-------------------------------------------------------------------------------------------
[1/1] Total                                        100% |  16.3 MiB/s |  10.2 MiB |  00m01s
Running transaction
[1/3] Verify package files                         100% |  13.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction                          100% |   4.0   B/s |   1.0   B |  00m00s
[3/3] Installing betterleaks-0:1.0.1-1.fc43.x86_64 100% |  74.6 MiB/s |  34.8 MiB |  00m00s
Complete!
```