### PR TITLE
Remove wazero/go-re2 WASM dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,6 @@ jobs:
           go install gotest.tools/gotestsum@latest
 
       - name: Test
-        env:
-          BETTERLEAKS_REGEX_ENGINE: ${{ matrix.platform == 'windows-latest' && 'stdlib' || '' }}
         run: |
           gotestsum --raw-command -- go test -json ./... --race
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ A couple things:
 - Parallelized Git Scanning (`--git-workers=8`)
 - Optimized Recursive Decoding (for catching those nasty SHA1-HULUD variants)
 - Misc optimizations
-- Regex engine switching w/ (`--regex-engine=stdlib/re2` or `BETTERLEAKS_REGEX_ENGINE=stdlib`)
 - MORE RULES! Ahhh finally!
 
 ### Benchmarks

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect"
 	"github.com/betterleaks/betterleaks/logging"
-	"github.com/betterleaks/betterleaks/regexp"
 	"github.com/betterleaks/betterleaks/report"
 	"github.com/betterleaks/betterleaks/validate"
 	"github.com/betterleaks/betterleaks/version"
@@ -96,10 +95,6 @@ func init() {
 	rootCmd.PersistentFlags().Int("max-decode-depth", 5, "allow recursive decoding up to this depth")
 	rootCmd.PersistentFlags().Int("max-archive-depth", 0, "allow scanning into nested archives up to this depth (default \"0\", no archive traversal is done)")
 	rootCmd.PersistentFlags().Int("timeout", 0, "set a timeout for gitleaks commands in seconds (default \"0\", no timeout is set)")
-	rootCmd.PersistentFlags().String("regex-engine", "re2", "regex engine (stdlib, re2)")
-	rootCmd.PersistentFlags().String("regexp-engine", "re2", "regex engine (stdlib, re2)")
-	_ = rootCmd.PersistentFlags().MarkHidden("regexp-engine")
-
 	rootCmd.PersistentFlags().String("experiments", "", "comma-separated list of experimental features to enable (e.g. \"validation\")")
 
 	// Validation flags
@@ -146,13 +141,6 @@ func initLog() {
 	}
 	logging.Logger = logging.Logger.Level(logLevel)
 
-	if rootCmd.Flags().Changed("regex-engine") {
-		engine, _ := rootCmd.Flags().GetString("regex-engine")
-		regexp.SetEngine(engine)
-	} else if rootCmd.Flags().Changed("regexp-engine") {
-		engine, _ := rootCmd.Flags().GetString("regexp-engine")
-		regexp.SetEngine(engine)
-	}
 }
 
 func initConfig(source string) {
@@ -165,8 +153,6 @@ func initConfig(source string) {
 	if !hideBanner {
 		_, _ = fmt.Fprint(os.Stderr, banner)
 	}
-
-	logging.Debug().Msgf("using %s regex engine", regexp.Version())
 
 	cfgPath, err := rootCmd.Flags().GetString("config")
 	if err != nil {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -81,7 +81,7 @@ func putLowerBuf(bp *[]byte) {
 
 // findNewlineIndices returns the start indices of all newlines in s.
 // This replaces the previous regex-based approach which was expensive
-// when using go-re2 (WASM overhead for a literal \n search).
+// (function-call overhead for a literal \n search).
 func findNewlineIndices(s string) [][]int {
 	indices := make([][]int, 0, strings.Count(s, "\n"))
 	offset := 0

--- a/go.mod
+++ b/go.mod
@@ -61,9 +61,7 @@ require (
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect
 	github.com/sorairolake/lzip-go v0.3.8 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
-	github.com/tetratelabs/wazero v1.9.0 // indirect
 	github.com/ulikunitz/xz v0.5.15 // indirect
-	github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -87,7 +85,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/wasilibs/go-re2 v1.10.0
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -162,15 +162,9 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
-github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/wasilibs/go-re2 v1.10.0 h1:vQZEBYZOCA9jdBMmrO4+CvqyCj0x4OomXTJ4a5/urQ0=
-github.com/wasilibs/go-re2 v1.10.0/go.mod h1:k+5XqO2bCJS+QpGOnqugyfwC04nw0jaglmjrrkG8U6o=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52 h1:OvLBa8SqJnZ6P+mjlzc2K7PM22rRUPE1x32G9DTPrC4=
-github.com/wasilibs/wazero-helpers v0.0.0-20240620070341-3dff1577cd52/go.mod h1:jMeV4Vpbi8osrE/pKUxRZkVaA0EX7NZN0A9/oRzgpgY=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=

--- a/regexp/regexp.go
+++ b/regexp/regexp.go
@@ -1,99 +1,16 @@
 package regexp
 
-import (
-	"os"
-	stdlib "regexp"
+import stdlib "regexp"
 
-	gore2 "github.com/wasilibs/go-re2"
-)
+// Regexp wraps a compiled regular expression.
+type Regexp = stdlib.Regexp
 
-func init() {
-	if v := os.Getenv("BETTERLEAKS_REGEX_ENGINE"); v != "" {
-		SetEngine(v)
-	}
-}
-
-// engine is an internal interface satisfied by both *stdlib.Regexp and *gore2.Regexp.
-type engine interface {
-	MatchString(s string) bool
-	FindString(s string) string
-	FindStringSubmatch(s string) []string
-	FindAllStringIndex(s string, n int) [][]int
-	ReplaceAllString(src, repl string) string
-	NumSubexp() int
-	SubexpNames() []string
-	String() string
-}
-
-// Regexp wraps a compiled regular expression. It is a concrete struct
-// so that *Regexp works as a normal pointer (not pointer-to-interface).
-type Regexp struct{ e engine }
-
-func (r *Regexp) MatchString(s string) bool {
-	return r.e.MatchString(s)
-}
-func (r *Regexp) FindString(s string) string {
-	return r.e.FindString(s)
-}
-func (r *Regexp) FindStringSubmatch(s string) []string {
-	return r.e.FindStringSubmatch(s)
-}
-func (r *Regexp) FindAllStringIndex(s string, n int) [][]int {
-	return r.e.FindAllStringIndex(s, n)
-}
-func (r *Regexp) ReplaceAllString(src, repl string) string {
-	return r.e.ReplaceAllString(src, repl)
-}
-func (r *Regexp) NumSubexp() int {
-	return r.e.NumSubexp()
-}
-func (r *Regexp) SubexpNames() []string {
-	return r.e.SubexpNames()
-}
-func (r *Regexp) String() string {
-	return r.e.String()
-}
-
-var currentEngine = "re2"
-
-// Version returns the name of the active regex engine.
-func Version() string { return currentEngine }
-
-// SetEngine selects the regex engine used by subsequent MustCompile calls.
-func SetEngine(name string) {
-	switch name {
-	case "stdlib", "re2":
-		currentEngine = name
-	default:
-		panic("regexp: unknown engine: " + name)
-	}
-}
-
-// Compile parses a regular expression using the currently selected engine.
-// If successful, returns a [Regexp] object that can be used to match against text.
+// Compile parses a regular expression and returns, if successful, a Regexp object.
 func Compile(str string) (*Regexp, error) {
-	var (
-		impl engine
-		err  error
-	)
-	if currentEngine == "re2" {
-		impl, err = gore2.Compile(str)
-	} else {
-		impl, err = stdlib.Compile(str)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return &Regexp{e: impl}, nil
+	return stdlib.Compile(str)
 }
 
-// MustCompile compiles a regular expression using the currently selected engine.
+// MustCompile is like Compile but panics if the expression cannot be parsed.
 func MustCompile(str string) *Regexp {
-	var impl engine
-	if currentEngine == "re2" {
-		impl = gore2.MustCompile(str)
-	} else {
-		impl = stdlib.MustCompile(str)
-	}
-	return &Regexp{e: impl}
+	return stdlib.MustCompile(str)
 }


### PR DESCRIPTION
## Summary
- Removes `wasilibs/go-re2` and its transitive `tetratelabs/wazero` WASM runtime dependency
- Simplifies `regexp/regexp.go` to a thin alias over Go's stdlib `regexp` package
- Removes `--regex-engine` flag, `BETTERLEAKS_REGEX_ENGINE` env var, and related plumbing

## Rationale
Go's `regexp` package already implements RE2 semantics with the same linear-time guarantees and syntax. The WASM-based go-re2 wrapper added ~5MB binary bloat, startup cost, and complexity for zero functional gain.

## Test plan
- [x] All tests pass with `-race` flag
- [x] `go vet` clean (pre-existing toolchain crash unrelated)
- [x] `go generate` produces no diff
- [x] `go mod verify` passes
- [x] Confirmed `wazero`, `go-re2`, `wazero-helpers` fully removed from `go.mod`/`go.sum`

