### PR TITLE
refactor(config): adjust to new glpat routable token

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -181,6 +181,7 @@ func main() {
 		rules.GitlabOauthAppSecret(),
 		rules.GitlabPat(),
 		rules.GitlabPatRoutable(),
+		rules.GitlabPatRoutableVersioned(),
 		rules.GitlabPipelineTriggerToken(),
 		rules.GitlabRunnerRegistrationToken(),
 		rules.GitlabRunnerAuthenticationToken(),

--- a/cmd/generate/config/rules/gitlab.go
+++ b/cmd/generate/config/rules/gitlab.go
@@ -1,6 +1,9 @@
 package rules
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/betterleaks/betterleaks/cmd/generate/config/utils"
 	"github.com/betterleaks/betterleaks/cmd/generate/secrets"
 	"github.com/betterleaks/betterleaks/config"
@@ -173,6 +176,28 @@ func GitlabPatRoutable() *config.Rule {
 	tps := utils.GenerateSampleSecrets("gitlab", "glpat-"+secrets.NewSecretWithEntropy(utils.AlphaNumeric("27"), 4)+"."+secrets.NewSecret(utils.AlphaNumeric("2"))+secrets.NewSecret(utils.AlphaNumeric("7")))
 	fps := []string{
 		"glpat-xxxxxxxx-xxxxxxxxxxxxxxxxxx.xxxxxxxxx",
+	}
+	return utils.Validate(r, tps, fps)
+}
+
+func GitlabPatRoutableVersioned() *config.Rule {
+	r := config.Rule{
+		RuleID:      "gitlab-pat-routable-versioned",
+		Description: "Identified a GitLab Personal Access Token (routable, versioned), risking unauthorized access to GitLab repositories and codebase exposure.",
+		Regex:       regexp.MustCompile(`\bglpat-[0-9a-zA-Z_-]{27,300}\.[0-9a-z]{2}\.[0-9a-z]{9}\b`),
+		Entropy:     4,
+		Keywords:    []string{"glpat-"},
+		ValidateCEL: gitlabPatCEL,
+	}
+
+	// validate
+	payload := secrets.NewSecretWithEntropy(utils.AlphaNumeric("27"), 4)
+	payloadLenStr := strconv.FormatInt(int64(len(payload)), 36)
+	paddedLen := strings.Repeat("0", 2-len(payloadLenStr)) + payloadLenStr
+
+	tps := utils.GenerateSampleSecrets("gitlab", "glpat-"+payload+"."+paddedLen+"."+secrets.NewSecret(utils.AlphaNumeric("9")))
+	fps := []string{
+		"glpat-xxxxxxxx-xxxxxxxxxxxxxxxxxx.xx.xxxxxxx",
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2965,6 +2965,30 @@ cel.bind(r,
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# gitlab-pat-routable-versioned
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "gitlab-pat-routable-versioned"
+description = "Identified a GitLab Personal Access Token (routable, versioned), risking unauthorized access to GitLab repositories and codebase exposure."
+regex = '''\bglpat-[0-9a-zA-Z_-]{27,300}\.[0-9a-z]{2}\.[0-9a-z]{9}\b'''
+entropy = 4
+keywords = ["glpat-"]
+validate = '''
+cel.bind(r,
+  http.get("https://gitlab.com/api/v4/personal_access_tokens/self", {
+    "PRIVATE-TOKEN": secret
+  }),
+  r.status == 200 ? {
+    "result": "valid",
+    "name": r.json.?name.orValue("")
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : unknown(r)
+)
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # gitlab-ptt
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]


### PR DESCRIPTION
Seems like Gitlab changed the format of their routable token once again.

An example of the previous routable format would be this: "glpat-testd_Rb5_cHeWe1JH56wr2FCBA.0r1pum4t4"
and the new routable format is like this:
"glpat-TESTtokenGq5K56y8RBbu286MQp1OmFwOAk.01.0z11111is" (with two dots and a longer string)

This new regex in gitlab-pat-routable will ensure
that we match both formats of routable tokens

Spawned by https://github.com/gitleaks/gitleaks/pull/2030#issuecomment-4181054391