### PR TITLE
promote validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Refer to the default [betterleaks config](https://github.com/betterleaks/betterl
 ## Additional Configuration
 
 ## Secrets Validation
-Secrets Validation is an new feature in Betterleaks. By default, validation is disabled. To enable it, pass the `--validation` flag.
+Secrets Validation is a new feature in Betterleaks. By default, validation is disabled. To enable it, pass the `--validation` flag.
 
 Betterleaks can automatically verify if a detected secret is live by making an HTTP request defined in the rule's validate field. Validation runs asynchronously, and responses are cached in-memory so duplicate secrets only trigger a single network request.
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Refer to the default [betterleaks config](https://github.com/betterleaks/betterl
 ## Additional Configuration
 
 ## Secrets Validation
-**⚠️ Secrets Validation is an experimental feature. To enable it, pass --experiments=validation.**
+Secrets Validation is an new feature in Betterleaks. By default, validation is disabled. To enable it, pass the `--validation` flag.
 
 Betterleaks can automatically verify if a detected secret is live by making an HTTP request defined in the rule's validate field. Validation runs asynchronously, and responses are cached in-memory so duplicate secrets only trigger a single network request.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,7 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().String("regexp-engine", "re2", "regex engine (stdlib, re2)")
 	_ = rootCmd.PersistentFlags().MarkHidden("regexp-engine")
 
-	rootCmd.PersistentFlags().String("experiments", "", "comma-separated list of experimental features to enable (e.g. \"validation\")")
+	rootCmd.PersistentFlags().String("experiments", "", "comma-separated list of experimental features to enable")
 
 	// Validation flags
 	rootCmd.PersistentFlags().Bool("validation", false, "enable validation of findings against live APIs")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -104,7 +103,7 @@ func init() {
 	rootCmd.PersistentFlags().String("experiments", "", "comma-separated list of experimental features to enable (e.g. \"validation\")")
 
 	// Validation flags
-	rootCmd.PersistentFlags().Bool("validation", true, "enable validation of findings against live APIs")
+	rootCmd.PersistentFlags().Bool("validation", false, "enable validation of findings against live APIs")
 	rootCmd.PersistentFlags().String("validation-status", "", "comma-separated list of validation statuses to include: valid, invalid, revoked, error, unknown, none (none = rules without validation)")
 	rootCmd.PersistentFlags().Duration("validation-timeout", 10*time.Second, "per-request timeout for validation")
 	rootCmd.PersistentFlags().Bool("validation-debug", false, "include raw HTTP response in validation output")
@@ -501,16 +500,6 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 // pool, and wires status-filter settings onto the detector.
 func setupValidation(cmd *cobra.Command, cfg config.Config, detector *detect.Detector) {
 	enableValidation := mustGetBoolFlag(cmd, "validation")
-
-	experimentsStr := mustGetStringFlag(cmd, "experiments")
-	experimentsSlice := []string{}
-	if experimentsStr != "" {
-		experimentsSlice = strings.Split(experimentsStr, ",")
-	}
-
-	if !slices.Contains(experimentsSlice, "validation") {
-		enableValidation = false
-	}
 
 	if !enableValidation {
 		return


### PR DESCRIPTION
Promote validation to a standard feature rather than experimental. By default it is disabled since enabling it can result in network requests.