### PR TITLE
fix(cmd): preserve local config handling for file targets

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -195,24 +195,14 @@ func initConfig(source string) {
 		logging.Debug().Str("content", configContent).Msg("using config from env var content")
 		return
 	} else {
-		fileInfo, err := os.Stat(source)
-		if err != nil {
+		if _, err := os.Stat(source); err != nil {
 			logging.Fatal().Msg(err.Error())
-		}
-
-		if !fileInfo.IsDir() {
-			logging.Debug().Msgf("unable to load config from %s since --source=%s is a file, using default config",
-				filepath.Join(source, ".betterleaks.toml"), source)
-			if err = viper.ReadConfig(strings.NewReader(config.DefaultConfig)); err != nil {
-				logging.Fatal().Msgf("err reading toml %s", err.Error())
-			}
-			return
 		}
 
 		// Check for config file: .betterleaks.toml first, then .gitleaks.toml
 		configFile := findConfigFile(source)
 		if configFile == "" {
-			logging.Debug().Msgf("no config found in path %s, using default config", source)
+			logging.Debug().Msgf("no config found for target %s, using default config", source)
 
 			if err = viper.ReadConfig(strings.NewReader(config.DefaultConfig)); err != nil {
 				logging.Fatal().Msgf("err reading default config toml %s", err.Error())
@@ -222,10 +212,7 @@ func initConfig(source string) {
 			logging.Debug().Msgf("using existing config %s", configFile)
 		}
 
-		viper.AddConfigPath(source)
-		// Strip the leading dot and .toml extension to get the config name
-		configName := strings.TrimSuffix(filepath.Base(configFile), ".toml")
-		viper.SetConfigName(configName)
+		viper.SetConfigFile(configFile)
 	}
 	if err := viper.ReadInConfig(); err != nil {
 		logging.Fatal().Msgf("unable to load config, err: %s", err)
@@ -244,8 +231,9 @@ func getEnvWithFallback(primary, fallback string) string {
 // findConfigFile looks for a config file in the given directory.
 // It checks for .betterleaks.toml first, then .gitleaks.toml for backwards compatibility.
 func findConfigFile(source string) string {
+	dir := lookupDir(source)
 	for _, name := range []string{".betterleaks.toml", ".gitleaks.toml"} {
-		path := filepath.Join(source, name)
+		path := filepath.Join(dir, name)
 		if _, err := os.Stat(path); err == nil {
 			return path
 		}
@@ -255,7 +243,8 @@ func findConfigFile(source string) string {
 
 // findIgnoreFile looks for an ignore file in the given directory.
 // It checks for .betterleaksignore first, then .gitleaksignore for backwards compatibility.
-func findIgnoreFile(dir string) string {
+func findIgnoreFile(source string) string {
+	dir := lookupDir(source)
 	for _, name := range []string{".betterleaksignore", ".gitleaksignore"} {
 		path := filepath.Join(dir, name)
 		if fileExists(path) {
@@ -263,6 +252,13 @@ func findIgnoreFile(dir string) string {
 		}
 	}
 	return ""
+}
+
+func lookupDir(source string) string {
+	if info, err := os.Stat(source); err == nil && !info.IsDir() {
+		return filepath.Dir(source)
+	}
+	return source
 }
 
 func initDiagnostics() {
@@ -312,7 +308,6 @@ func Config(cmd *cobra.Command) config.Config {
 	if err != nil {
 		logging.Fatal().Err(err).Msg("Failed to load config")
 	}
-	cfg.Path, _ = cmd.Flags().GetString("config")
 
 	return cfg
 }
@@ -341,16 +336,6 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 			Out:     os.Stderr,
 			NoColor: detector.NoColor,
 		}).Level(logLevel)
-	}
-	detector.Config.Path, err = cmd.Flags().GetString("config")
-	if err != nil {
-		logging.Fatal().Err(err).Send()
-	}
-
-	// if config path is not set, then use the {source}/.gitleaks.toml path.
-	// note that there may not be a `{source}/.gitleaks.toml` file, this is ok.
-	if detector.Config.Path == "" {
-		detector.Config.Path = filepath.Join(source, ".gitleaks.toml")
 	}
 	// set verbose flag
 	if detector.Verbose, err = cmd.Flags().GetBool("verbose"); err != nil {
@@ -384,17 +369,18 @@ func Detector(cmd *cobra.Command, cfg config.Config, source string) *detect.Dete
 		logging.Fatal().Err(err).Msg("could not get ignore path")
 	}
 
-	// If the flag points directly to an ignore file, use it
-	if fileExists(ignorePath) {
+	ignorePathInfo, ignorePathErr := os.Stat(ignorePath)
+	if ignorePathErr == nil && !ignorePathInfo.IsDir() {
+		// If the flag points directly to an ignore file, use it.
 		if err = detector.AddGitleaksIgnore(ignorePath); err != nil {
 			logging.Fatal().Err(err).Msg("could not load ignore file")
 		}
-	}
-
-	// Check for ignore file in the flag directory (.betterleaksignore first, then .gitleaksignore)
-	if ignoreFile := findIgnoreFile(ignorePath); ignoreFile != "" {
-		if err = detector.AddGitleaksIgnore(ignoreFile); err != nil {
-			logging.Fatal().Err(err).Msg("could not load ignore file")
+	} else {
+		// Check for ignore file in the flag directory (.betterleaksignore first, then .gitleaksignore)
+		if ignoreFile := findIgnoreFile(ignorePath); ignoreFile != "" {
+			if err = detector.AddGitleaksIgnore(ignoreFile); err != nil {
+				logging.Fatal().Err(err).Msg("could not load ignore file")
+			}
 		}
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,250 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/betterleaks/betterleaks/sources"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func TestInitConfigUsesSiblingConfigForFileTarget(t *testing.T) {
+	t.Helper()
+
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, ".betterleaks.toml")
+	targetPath := filepath.Join(projectDir, "input.txt")
+
+	if err := os.WriteFile(configPath, []byte(`
+title = "custom"
+
+[[rules]]
+id = "custom-secret"
+description = "Custom secret"
+regex = '''MYSECRET'''
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("MYSECRET\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	oldBannerPrinted := bannerPrinted
+	bannerPrinted = false
+	t.Cleanup(func() {
+		bannerPrinted = oldBannerPrinted
+	})
+
+	oldRootCmd := rootCmd
+	rootCmd = &cobra.Command{}
+	rootCmd.Flags().Bool("no-banner", false, "")
+	rootCmd.Flags().String("config", "", "")
+	t.Cleanup(func() {
+		rootCmd = oldRootCmd
+	})
+
+	if err := rootCmd.Flags().Set("no-banner", "true"); err != nil {
+		t.Fatalf("set no-banner: %v", err)
+	}
+
+	initConfig(targetPath)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("config", "", "")
+
+	cfg := Config(cmd)
+	if cfg.Path != configPath {
+		t.Fatalf("cfg.Path = %q, want %q", cfg.Path, configPath)
+	}
+	if _, ok := cfg.Rules["custom-secret"]; !ok {
+		t.Fatalf("custom rule was not loaded from discovered config")
+	}
+}
+
+func TestDetectorLoadsSiblingIgnoreForFileTarget(t *testing.T) {
+	t.Helper()
+
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, ".betterleaks.toml")
+	targetPath := filepath.Join(projectDir, "input.txt")
+	ignorePath := filepath.Join(projectDir, ".betterleaksignore")
+	isolatedIgnoreDir := t.TempDir()
+
+	if err := os.WriteFile(configPath, []byte(`
+title = "custom"
+
+[[rules]]
+id = "custom-secret"
+description = "Custom secret"
+regex = '''MYSECRET'''
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("MYSECRET\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.WriteFile(ignorePath, []byte(filepath.Clean(targetPath)+":custom-secret:1\n"), 0o600); err != nil {
+		t.Fatalf("write ignore: %v", err)
+	}
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	oldBannerPrinted := bannerPrinted
+	bannerPrinted = false
+	t.Cleanup(func() {
+		bannerPrinted = oldBannerPrinted
+	})
+
+	oldRootCmd := rootCmd
+	rootCmd = &cobra.Command{}
+	rootCmd.Flags().Bool("no-banner", false, "")
+	rootCmd.Flags().String("config", "", "")
+	t.Cleanup(func() {
+		rootCmd = oldRootCmd
+	})
+
+	if err := rootCmd.Flags().Set("no-banner", "true"); err != nil {
+		t.Fatalf("set no-banner: %v", err)
+	}
+	if err := rootCmd.Flags().Set("config", configPath); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	initConfig(targetPath)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("config", configPath, "")
+	cmd.Flags().String("gitleaks-ignore-path", isolatedIgnoreDir, "")
+	cmd.Flags().Bool("no-color", false, "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().Uint("redact", 0, "")
+	cmd.Flags().Int("max-target-megabytes", 0, "")
+	cmd.Flags().Bool("ignore-gitleaks-allow", false, "")
+	cmd.Flags().String("match-context", "", "")
+	cmd.Flags().String("baseline-path", "", "")
+	cmd.Flags().StringSlice("enable-rule", nil, "")
+	cmd.Flags().Int("max-decode-depth", 5, "")
+	cmd.Flags().Int("max-archive-depth", 0, "")
+	cmd.Flags().Bool("validation", false, "")
+	cmd.Flags().String("validation-status", "", "")
+	cmd.Flags().Duration("validation-timeout", 0, "")
+	cmd.Flags().Bool("validation-debug", false, "")
+	cmd.Flags().Int("validation-workers", 0, "")
+	cmd.Flags().Bool("validation-extract-empty", false, "")
+	cmd.Flags().String("report-path", "", "")
+	cmd.Flags().String("report-format", "", "")
+	cmd.Flags().String("report-template", "", "")
+	cmd.SetContext(context.Background())
+
+	cfg := Config(cmd)
+	detector := Detector(cmd, cfg, targetPath)
+
+	findings, err := detector.DetectSource(context.Background(), &sources.Files{
+		Config:          &cfg,
+		Path:            targetPath,
+		Sema:            detector.Sema,
+		MaxArchiveDepth: detector.MaxArchiveDepth,
+	})
+	if err != nil {
+		t.Fatalf("scan file: %v", err)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected ignored scan to yield no findings, got %d", len(findings))
+	}
+}
+
+func TestDirectoryScanSkipsAutoDiscoveredBetterleaksConfigFile(t *testing.T) {
+	t.Helper()
+
+	projectDir := t.TempDir()
+	configPath := filepath.Join(projectDir, ".betterleaks.toml")
+	targetPath := filepath.Join(projectDir, "input.txt")
+	isolatedIgnoreDir := t.TempDir()
+
+	if err := os.WriteFile(configPath, []byte(`
+title = "custom"
+
+[[rules]]
+id = "custom-secret"
+description = "Custom secret"
+regex = '''MYSECRET'''
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.WriteFile(targetPath, []byte("MYSECRET\n"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+
+	oldBannerPrinted := bannerPrinted
+	bannerPrinted = false
+	t.Cleanup(func() {
+		bannerPrinted = oldBannerPrinted
+	})
+
+	oldRootCmd := rootCmd
+	rootCmd = &cobra.Command{}
+	rootCmd.Flags().Bool("no-banner", false, "")
+	rootCmd.Flags().String("config", "", "")
+	t.Cleanup(func() {
+		rootCmd = oldRootCmd
+	})
+
+	if err := rootCmd.Flags().Set("no-banner", "true"); err != nil {
+		t.Fatalf("set no-banner: %v", err)
+	}
+
+	initConfig(projectDir)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("config", "", "")
+	cmd.Flags().String("gitleaks-ignore-path", isolatedIgnoreDir, "")
+	cmd.Flags().Bool("no-color", false, "")
+	cmd.Flags().Bool("verbose", false, "")
+	cmd.Flags().Uint("redact", 0, "")
+	cmd.Flags().Int("max-target-megabytes", 0, "")
+	cmd.Flags().Bool("ignore-gitleaks-allow", false, "")
+	cmd.Flags().String("match-context", "", "")
+	cmd.Flags().String("baseline-path", "", "")
+	cmd.Flags().StringSlice("enable-rule", nil, "")
+	cmd.Flags().Int("max-decode-depth", 5, "")
+	cmd.Flags().Int("max-archive-depth", 0, "")
+	cmd.Flags().Bool("validation", false, "")
+	cmd.Flags().String("validation-status", "", "")
+	cmd.Flags().Duration("validation-timeout", 0, "")
+	cmd.Flags().Bool("validation-debug", false, "")
+	cmd.Flags().Int("validation-workers", 0, "")
+	cmd.Flags().Bool("validation-extract-empty", false, "")
+	cmd.Flags().String("report-path", "", "")
+	cmd.Flags().String("report-format", "", "")
+	cmd.Flags().String("report-template", "", "")
+	cmd.SetContext(context.Background())
+
+	cfg := Config(cmd)
+	detector := Detector(cmd, cfg, projectDir)
+
+	findings, err := detector.DetectSource(context.Background(), &sources.Files{
+		Config:          &cfg,
+		Path:            projectDir,
+		Sema:            detector.Sema,
+		MaxArchiveDepth: detector.MaxArchiveDepth,
+	})
+	if err != nil {
+		t.Fatalf("scan directory: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("expected exactly one finding from the target file, got %d", len(findings))
+	}
+	if findings[0].File != targetPath {
+		t.Fatalf("finding file = %q, want %q", findings[0].File, targetPath)
+	}
+}


### PR DESCRIPTION
Fixes #85.

## Summary

- fix sibling config discovery for file targets by resolving local `.betterleaks.toml` / `.gitleaks.toml` from the parent directory
- preserve the active config path so auto-discovered `.betterleaks.toml` is excluded from scans
- fix sibling ignore discovery for file targets without double-loading an explicit `-i` file path
- add regression tests covering config discovery, ignore discovery, and skipping the active config file

## Testing

- `go test ./cmd`
- `go test ./...`
- `go test --race ./...`
- `go generate ./...`
