### PR TITLE
fix: do not pass filenames to betterleaks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,3 +17,4 @@
   description: Detect hardcoded secrets using Betterleaks
   entry: betterleaks git --pre-commit --redact --staged --verbose
   language: system
+  pass_filenames: false


### PR DESCRIPTION
I ran into the following error:

```plaintext
betterleaks..............................................................Failed
- hook id: betterleaks
- exit code: 1

  Error: accepts at most 1 arg(s), received 23
```