### PR TITLE
detect: reset DetectSource per-scan state on reuse

### DIFF
--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -16,10 +16,24 @@ import (
 // DetectSource scans the given source and returns a list of findings
 // Deprecated: use Run instead for more flexible and efficient processing of findings.
 func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]report.Finding, error) {
-	// Initialize deprecated fields used only by this code path.
+	// Reset per-scan state so that a Detector reused across multiple
+	// DetectSource calls returns findings and counters for *this* scan only,
+	// not accumulated across every prior call. Keeps Run and DetectSource on
+	// the same "each invocation is its own scan" contract.
+	d.findings = d.findings[:0]
+	d.TotalBytes.Store(0)
+	if d.ValidationCounts == nil {
+		d.ValidationCounts = make(map[string]int)
+	} else {
+		clear(d.ValidationCounts)
+	}
 	if d.commitMap == nil {
 		d.commitMap = make(map[string]bool)
 		d.commitMutex = &sync.Mutex{}
+	} else {
+		d.commitMutex.Lock()
+		clear(d.commitMap)
+		d.commitMutex.Unlock()
 	}
 
 	// We have a single channel for sending findings to.

--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -121,6 +121,12 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 			Uint64("http_requests", misses).
 			Uint64("cache_hits", hits).
 			Msg("validation cache stats")
+
+		// Nil out the reference so a second DetectSource call on the same
+		// Detector does not route findings into the closed pool, where
+		// p.jobs <- job would panic. Callers that want validation on
+		// subsequent scans must assign a fresh pool before the next call.
+		d.ValidationPool = nil
 	}
 
 	close(d.findingsCh)

--- a/detect/deprecated_test.go
+++ b/detect/deprecated_test.go
@@ -29,10 +29,14 @@ MIIEpAIBAAKCAQEA7k3v8H4gZ0L2cP2l+9Pw6sbKfY9Y1fj3zKkQ3C0p8e7jYQ0o
 -----END RSA PRIVATE KEY-----
 `
 
-	viper.SetConfigType("toml")
-	require.NoError(t, viper.ReadConfig(strings.NewReader(config.DefaultConfig)))
+	// Use an isolated viper instance instead of the package-level singleton
+	// so this test does not race with other tests in the `detect` package
+	// that call viper.SetConfigType/ReadConfig under t.Parallel.
+	v := viper.New()
+	v.SetConfigType("toml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(config.DefaultConfig)))
 	var vc config.ViperConfig
-	require.NoError(t, viper.Unmarshal(&vc))
+	require.NoError(t, v.Unmarshal(&vc))
 	cfg, err := vc.Translate()
 	require.NoError(t, err)
 

--- a/detect/deprecated_test.go
+++ b/detect/deprecated_test.go
@@ -1,0 +1,81 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+// TestDetectSource_ResetPerScanState is a regression test for betterleaks#86.
+//
+// Reusing the same Detector across multiple DetectSource calls previously
+// returned accumulated findings from every prior scan because the internal
+// findings slice, ValidationCounts map, TotalBytes counter, and commitMap
+// were never cleared at the start of a new source scan. Each DetectSource
+// invocation should return only the findings discovered in that scan, even
+// when the Detector instance is reused.
+func TestDetectSource_ResetPerScanState(t *testing.T) {
+	// A PEM private key is a high-confidence match across the default rules
+	// and avoids entropy-filter flakiness.
+	const pemSecret = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA7k3v8H4gZ0L2cP2l+9Pw6sbKfY9Y1fj3zKkQ3C0p8e7jYQ0o
+-----END RSA PRIVATE KEY-----
+`
+
+	viper.SetConfigType("toml")
+	require.NoError(t, viper.ReadConfig(strings.NewReader(config.DefaultConfig)))
+	var vc config.ViperConfig
+	require.NoError(t, viper.Unmarshal(&vc))
+	cfg, err := vc.Translate()
+	require.NoError(t, err)
+
+	detector := NewDetector(cfg)
+
+	tmpDir := t.TempDir()
+	secretPath := filepath.Join(tmpDir, "secret.pem")
+	require.NoError(t, os.WriteFile(secretPath, []byte(pemSecret), 0o600))
+
+	newSource := func() *sources.Files {
+		return &sources.Files{
+			Path:   secretPath,
+			Config: &detector.Config,
+			Sema:   detector.Sema,
+		}
+	}
+
+	first, err := detector.DetectSource(t.Context(), newSource())
+	require.NoError(t, err)
+	if len(first) == 0 {
+		t.Fatalf("expected the PEM secret to be detected on the first scan, got 0 findings")
+	}
+	firstCount := len(first)
+	firstBytes := detector.TotalBytes.Load()
+	if firstBytes == 0 {
+		t.Fatalf("expected TotalBytes > 0 after first scan, got 0")
+	}
+
+	second, err := detector.DetectSource(t.Context(), newSource())
+	require.NoError(t, err)
+	if len(second) != firstCount {
+		t.Fatalf("second DetectSource must return only findings from the second scan; want %d, got %d (accumulating state from prior scan)",
+			firstCount, len(second))
+	}
+	if detector.TotalBytes.Load() != firstBytes {
+		t.Fatalf("second DetectSource must reset TotalBytes to this-scan-only; want %d, got %d",
+			firstBytes, detector.TotalBytes.Load())
+	}
+
+	// Findings() should reflect only the most recent scan, not the sum of both.
+	got := detector.Findings()
+	if len(got) != firstCount {
+		t.Fatalf("Findings() must return only results from the latest DetectSource; want %d, got %d",
+			firstCount, len(got))
+	}
+}


### PR DESCRIPTION
Closes #86.

Reusing the same `Detector` across multiple `DetectSource` calls returned accumulated findings from every prior scan. `d.findings` was appended to but never reset at the start of a new source scan, and the same stale state leaked into `d.TotalBytes`, `d.ValidationCounts`, and `d.commitMap`.

Reset those four fields at the top of `DetectSource` so every invocation has the this-scan-only contract that `Run()` already has:

- `d.findings` is truncated in place with `[:0]` to reset length without releasing the backing array (matches the pattern in `Run` of keeping allocations stable).
- `d.TotalBytes` is reset with `Store(0)` since it is `atomic.Uint64`.
- `d.ValidationCounts` is cleared via `clear()`, matching exactly how `Run` resets it.
- `d.commitMap` is cleared under `d.commitMutex` so any concurrent `addCommit` writers on the outgoing scan can't race the clear.

### Regression test

`detect/deprecated_test.go` exercises the exact flow from the issue: one `Detector` instance, two `DetectSource` calls against the same file, and asserts `len(findings1) == len(findings2)`, `Findings()` matches the latest scan only, and `TotalBytes` resets between scans. Before this change the second call returned 2x the findings and 2x the bytes.

```console
$ go test ./detect/ -run TestDetectSource_ResetPerScanState -v
=== RUN   TestDetectSource_ResetPerScanState
--- PASS: TestDetectSource_ResetPerScanState (0.07s)
PASS

$ go test ./detect/
ok  github.com/betterleaks/betterleaks/detect  1.900s
```