### PR TITLE
fix(parallel_git): skip empty chunks instead of panicking

### DIFF
--- a/sources/parallel_git.go
+++ b/sources/parallel_git.go
@@ -69,6 +69,13 @@ func (s *ParallelGit) Fragments(ctx context.Context, yield FragmentsFunc) error 
 	g, gctx := errgroup.WithContext(ctx)
 	for i := range workers {
 		start := i * chunkSize
+		// When workers*chunkSize > count (common: count=10, workers=8
+		// gives chunkSize=2 and start grows past count on workers 6+),
+		// the slice expression commits[start:end] otherwise panicked
+		// with 'slice bounds out of range [12:10]'. Skip empty tails.
+		if start >= count {
+			break
+		}
 		end := min(start+chunkSize, count)
 		chunk := commits[start:end]
 		g.Go(func() error {


### PR DESCRIPTION
Fixes betterleaks/betterleaks#98.

## Problem

Chunk sizing uses `chunkSize = ceil(N/W)`, so for e.g. `N=10` commits across `W=8` workers `chunkSize=2` and worker 6 lands at `start=12 > count`. `commits[start:end]` then panicked:

```
panic: runtime error: slice bounds out of range [12:10]
sources.(*ParallelGit).Fragments parallel_git.go:73
```

This blocked `--git-parallel` for many real repos (observed for Siemens' gitlab mirrors in the linked issue).

## Fix

Break out of the loop as soon as `start >= count` so no worker is ever handed an empty / out-of-range chunk. Happy-path workers that have commits are unchanged.

## Test

`go test ./sources/...` passes locally.