### PR TITLE
refactor(validate): type validation statuses

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -536,12 +536,12 @@ func setupValidation(cmd *cobra.Command, cfg config.Config, detector *detect.Det
 
 	statusFilter, _ := cmd.Flags().GetString("validation-status")
 	if statusFilter != "" {
-		detector.ValidationStatusFilter = make(map[string]struct{})
+		detector.ValidationStatusFilter = make(map[report.ValidationStatus]struct{})
 		for s := range strings.SplitSeq(statusFilter, ",") {
 			s = strings.TrimSpace(s)
 			s = strings.ToLower(s)
 			if s != "" {
-				detector.ValidationStatusFilter[s] = struct{}{}
+				detector.ValidationStatusFilter[report.ValidationStatus(s)] = struct{}{}
 			}
 		}
 	}
@@ -582,11 +582,11 @@ func findingSummaryAndExit(detector *detect.Detector, findings []report.Finding,
 
 	if detector.ValidationPool != nil {
 		logging.Info().
-			Int("valid", detector.ValidationCounts["valid"]).
-			Int("invalid", detector.ValidationCounts["invalid"]).
-			Int("revoked", detector.ValidationCounts["revoked"]).
-			Int("unknown", detector.ValidationCounts["unknown"]).
-			Int("errors", detector.ValidationCounts["error"]).
+			Int("valid", detector.ValidationCounts[report.ValidationStatusValid]).
+			Int("invalid", detector.ValidationCounts[report.ValidationStatusInvalid]).
+			Int("revoked", detector.ValidationCounts[report.ValidationStatusRevoked]).
+			Int("unknown", detector.ValidationCounts[report.ValidationStatusUnknown]).
+			Int("errors", detector.ValidationCounts[report.ValidationStatusError]).
 			Msg("validation complete")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -536,15 +536,28 @@ func setupValidation(cmd *cobra.Command, cfg config.Config, detector *detect.Det
 
 	statusFilter, _ := cmd.Flags().GetString("validation-status")
 	if statusFilter != "" {
-		detector.ValidationStatusFilter = make(map[report.ValidationStatus]struct{})
-		for s := range strings.SplitSeq(statusFilter, ",") {
-			s = strings.TrimSpace(s)
-			s = strings.ToLower(s)
-			if s != "" {
-				detector.ValidationStatusFilter[report.ValidationStatus(s)] = struct{}{}
-			}
+		filter, err := parseValidationStatusFilter(statusFilter)
+		if err != nil {
+			logging.Fatal().Err(err).Send()
+		}
+		detector.ValidationStatusFilter = filter
+	}
+}
+
+func parseValidationStatusFilter(statusFilter string) (map[report.ValidationStatus]struct{}, error) {
+	filter := make(map[report.ValidationStatus]struct{})
+	for s := range strings.SplitSeq(statusFilter, ",") {
+		status, ok := report.ParseValidationStatus(s)
+		switch {
+		case status == "":
+			continue
+		case ok || status == report.ValidationStatusNone:
+			filter[status] = struct{}{}
+		default:
+			return nil, fmt.Errorf("unknown --validation-status value %q (valid: valid, invalid, revoked, error, unknown, none)", status)
 		}
 	}
+	return filter, nil
 }
 
 func bytesConvert(bytes uint64) string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/betterleaks/betterleaks/report"
+)
+
+func TestParseValidationStatusFilter(t *testing.T) {
+	filter, err := parseValidationStatusFilter(" valid,INVALID, none,,unknown ")
+	if err != nil {
+		t.Fatalf("parseValidationStatusFilter returned error: %v", err)
+	}
+
+	for _, status := range []report.ValidationStatus{
+		report.ValidationStatusValid,
+		report.ValidationStatusInvalid,
+		report.ValidationStatusNone,
+		report.ValidationStatusUnknown,
+	} {
+		if _, ok := filter[status]; !ok {
+			t.Fatalf("expected filter to include %q", status)
+		}
+	}
+	if _, ok := filter[report.ValidationStatus("")]; ok {
+		t.Fatal("expected empty validation status to be ignored")
+	}
+}
+
+func TestParseValidationStatusFilterRejectsUnknownValue(t *testing.T) {
+	if _, err := parseValidationStatusFilter("valid,not-a-status"); err == nil {
+		t.Fatal("expected unknown validation status to return an error")
+	}
+}

--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -204,7 +204,7 @@ func (d *Detector) shouldVerbosePrint(f report.Finding) bool {
 		return true
 	}
 	if f.ValidationStatus == "" {
-		_, ok := d.ValidationStatusFilter["none"]
+		_, ok := d.ValidationStatusFilter[report.ValidationStatusNone]
 		return ok
 	}
 	_, ok := d.ValidationStatusFilter[f.ValidationStatus]
@@ -218,7 +218,7 @@ func (d *Detector) FilterByStatus(findings []report.Finding) []report.Finding {
 	if len(d.ValidationStatusFilter) == 0 {
 		return findings
 	}
-	_, includeNone := d.ValidationStatusFilter["none"]
+	_, includeNone := d.ValidationStatusFilter[report.ValidationStatusNone]
 	var filtered []report.Finding
 	for _, f := range findings {
 		if f.ValidationStatus == "" {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -65,7 +65,7 @@ type Detector struct {
 
 	// ValidationStatusFilter, when non-empty, restricts which findings are
 	// printed in verbose mode. Parsed from --validation-status.
-	ValidationStatusFilter map[string]struct{}
+	ValidationStatusFilter map[report.ValidationStatus]struct{}
 
 	// ValidationPool is the CEL validation worker pool.
 	ValidationPool *validate.Pool
@@ -73,7 +73,7 @@ type Detector struct {
 	// ValidationCounts tracks how many findings were returned for each
 	// ValidationStatus value. Populated by the Run/DetectSource consumer;
 	// safe to read after the scan returns.
-	ValidationCounts map[string]int
+	ValidationCounts map[report.ValidationStatus]int
 
 	// ValidationExtractEmpty controls whether empty values from extractors
 	// are included in validation output.
@@ -181,7 +181,7 @@ func NewDetectorContext(ctx context.Context, cfg config.Config) *Detector {
 	return &Detector{
 		gitleaksIgnore:   make(map[string]struct{}),
 		findings:         make([]report.Finding, 0),
-		ValidationCounts: make(map[string]int),
+		ValidationCounts: make(map[report.ValidationStatus]int),
 		Config:           cfg,
 		prefilter:        *ahocorasick.NewTrieBuilder().AddStrings(maps.Keys(cfg.Keywords)).Build(),
 		Sema:             semgroup.NewGroup(ctx, 40),
@@ -233,7 +233,7 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 		resultsCh := make(chan Result, 1000)
 
 		if d.ValidationCounts == nil {
-			d.ValidationCounts = make(map[string]int)
+			d.ValidationCounts = make(map[report.ValidationStatus]int)
 		} else {
 			clear(d.ValidationCounts)
 		}

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -377,7 +377,7 @@ func printValidation(f report.Finding, noColor bool) {
 
 	statusStyle := validationStyle(f.ValidationStatus, noColor)
 
-	fmt.Printf("%-12s %s", "Validation:", statusStyle.Render(strings.ToUpper(f.ValidationStatus)))
+	fmt.Printf("%-12s %s", "Validation:", statusStyle.Render(strings.ToUpper(f.ValidationStatus.String())))
 	if f.ValidationReason != "" {
 		fmt.Printf("  (%s)", f.ValidationReason)
 	}
@@ -393,20 +393,20 @@ func printValidation(f report.Finding, noColor bool) {
 	}
 }
 
-func validationStyle(status string, noColor bool) color.Style {
+func validationStyle(status report.ValidationStatus, noColor bool) color.Style {
 	if noColor {
 		return color.New()
 	}
 	switch status {
-	case "valid":
+	case report.ValidationStatusValid:
 		return color.New().Bold().Foreground("#00d26a")
-	case "invalid":
+	case report.ValidationStatusInvalid:
 		return color.New().Foreground("#888888")
-	case "revoked":
+	case report.ValidationStatusRevoked:
 		return color.New().Foreground("#f5d445")
-	case "unknown":
+	case report.ValidationStatusUnknown:
 		return color.New().Foreground("#c0c0c0")
-	case "error":
+	case report.ValidationStatusError:
 		return color.New().Foreground("#f05c07")
 	default:
 		return color.New()

--- a/report/finding.go
+++ b/report/finding.go
@@ -52,8 +52,8 @@ type Finding struct {
 	// Each set is one complete group of components that can be validated independently.
 	RequiredSets []RequiredSet `json:",omitempty"`
 
-	ValidationStatus string `json:",omitempty"`
-	ValidationReason string `json:",omitempty"`
+	ValidationStatus ValidationStatus `json:",omitempty"`
+	ValidationReason string           `json:",omitempty"`
 	// TODO maybe just use the Attribute map
 	ValidationMeta map[string]any `json:",omitempty"`
 
@@ -90,7 +90,7 @@ type Finding struct {
 // independently and carries its own validation result.
 type RequiredSet struct {
 	Components       []*RequiredFinding `json:"components"`
-	ValidationStatus string             `json:"validationStatus,omitempty"`
+	ValidationStatus ValidationStatus   `json:"validationStatus,omitempty"`
 	ValidationReason string             `json:"validationReason,omitempty"`
 }
 
@@ -273,24 +273,24 @@ func truncateSecret(s string) string {
 }
 
 // formatSetStatus returns a styled status string for a required set header.
-func formatSetStatus(status string, noColor bool) string {
+func formatSetStatus(status ValidationStatus, noColor bool) string {
 	if noColor {
-		return "[" + strings.ToUpper(status) + "]"
+		return "[" + strings.ToUpper(status.String()) + "]"
 	}
 	var style color.Style
 	switch status {
-	case "valid":
+	case ValidationStatusValid:
 		style = color.New().Foreground("#00d26a")
-	case "invalid":
+	case ValidationStatusInvalid:
 		style = color.New().Foreground("#888888")
-	case "revoked":
+	case ValidationStatusRevoked:
 		style = color.New().Foreground("#f5d445")
-	case "error":
+	case ValidationStatusError:
 		style = color.New().Foreground("#f05c07")
 	default:
 		style = color.New().Foreground("#c0c0c0")
 	}
-	return style.Render("[" + strings.ToUpper(status) + "]")
+	return style.Render("[" + strings.ToUpper(status.String()) + "]")
 }
 
 func (f Finding) Print(noColor bool, redact uint) {
@@ -432,7 +432,7 @@ func printValidation(f Finding, noColor bool) {
 
 	statusStyle := validationStyle(f.ValidationStatus, noColor)
 
-	fmt.Printf("%-12s %s", "Validation:", statusStyle.Render(strings.ToUpper(f.ValidationStatus)))
+	fmt.Printf("%-12s %s", "Validation:", statusStyle.Render(strings.ToUpper(f.ValidationStatus.String())))
 	if f.ValidationReason != "" {
 		fmt.Printf("  (%s)", f.ValidationReason)
 	}
@@ -448,20 +448,20 @@ func printValidation(f Finding, noColor bool) {
 	}
 }
 
-func validationStyle(status string, noColor bool) color.Style {
+func validationStyle(status ValidationStatus, noColor bool) color.Style {
 	if noColor {
 		return color.New()
 	}
 	switch status {
-	case "valid":
+	case ValidationStatusValid:
 		return color.New().Bold().Foreground("#00d26a")
-	case "invalid":
+	case ValidationStatusInvalid:
 		return color.New().Foreground("#888888")
-	case "revoked":
+	case ValidationStatusRevoked:
 		return color.New().Foreground("#f5d445")
-	case "unknown":
+	case ValidationStatusUnknown:
 		return color.New().Foreground("#c0c0c0")
-	case "error":
+	case ValidationStatusError:
 		return color.New().Foreground("#f05c07")
 	default:
 		return color.New()

--- a/report/validation_status.go
+++ b/report/validation_status.go
@@ -1,0 +1,36 @@
+package report
+
+import "strings"
+
+// ValidationStatus is the normalized status produced by secret validation.
+type ValidationStatus string
+
+const (
+	ValidationStatusValid   ValidationStatus = "valid"
+	ValidationStatusInvalid ValidationStatus = "invalid"
+	ValidationStatusRevoked ValidationStatus = "revoked"
+	ValidationStatusUnknown ValidationStatus = "unknown"
+	ValidationStatusError   ValidationStatus = "error"
+
+	// ValidationStatusNone is a CLI filter pseudo-status for findings that did
+	// not run validation. It is not written to Finding.ValidationStatus.
+	ValidationStatusNone ValidationStatus = "none"
+)
+
+var validationStatuses = map[ValidationStatus]struct{}{
+	ValidationStatusValid:   {},
+	ValidationStatusInvalid: {},
+	ValidationStatusRevoked: {},
+	ValidationStatusUnknown: {},
+	ValidationStatusError:   {},
+}
+
+func ParseValidationStatus(status string) (ValidationStatus, bool) {
+	normalized := ValidationStatus(strings.ToLower(strings.TrimSpace(status)))
+	_, ok := validationStatuses[normalized]
+	return normalized, ok
+}
+
+func (s ValidationStatus) String() string {
+	return string(s)
+}

--- a/report/validation_status_test.go
+++ b/report/validation_status_test.go
@@ -1,0 +1,26 @@
+package report
+
+import "testing"
+
+func TestParseValidationStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want ValidationStatus
+		ok   bool
+	}{
+		{name: "valid", in: "valid", want: ValidationStatusValid, ok: true},
+		{name: "trims and normalizes", in: " Revoked ", want: ValidationStatusRevoked, ok: true},
+		{name: "none is filter only", in: "none", want: ValidationStatusNone, ok: false},
+		{name: "unknown value", in: "fake", want: ValidationStatus("fake"), ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := ParseValidationStatus(tt.in)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("ParseValidationStatus(%q) = %q, %v; want %q, %v", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/validate/cache.go
+++ b/validate/cache.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/betterleaks/betterleaks/report"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -73,7 +74,7 @@ func (c *Cache) GetOrDo(key string, fn func() (*Result, error)) (*Result, error)
 		}
 
 		// Cache non-error validation results.
-		if result.Status != "error" {
+		if result.Status != report.ValidationStatusError {
 			c.mu.Lock()
 			c.store[key] = result
 			c.mu.Unlock()

--- a/validate/pool.go
+++ b/validate/pool.go
@@ -94,7 +94,7 @@ func (p *Pool) worker() {
 			// Simple path: no required components, validate the secret with its own captures.
 			result, err := p.evalWithCaptures(job.program, job.finding.RuleID, job.finding.Secret, job.captures)
 			if err != nil {
-				f.ValidationStatus = "error"
+				f.ValidationStatus = report.ValidationStatusError
 				f.ValidationReason = err.Error()
 			} else {
 				f.ValidationStatus = result.Status
@@ -111,7 +111,7 @@ func (p *Pool) worker() {
 		// each, write per-set status, and roll up to a finding-level status.
 		setResults := make(map[string]*Result, len(f.RequiredSets))
 		var (
-			overallStatus string
+			overallStatus report.ValidationStatus
 			bestResult    *Result
 		)
 
@@ -137,7 +137,7 @@ func (p *Pool) worker() {
 				var err error
 				result, err = p.evalWithCacheKey(cacheKey, job.program, job.finding.Secret, merged)
 				if err != nil {
-					result = &Result{Status: "error", Reason: err.Error(), Metadata: map[string]any{}}
+					result = &Result{Status: report.ValidationStatusError, Reason: err.Error(), Metadata: map[string]any{}}
 				}
 				setResults[cacheKey] = result
 			}
@@ -179,7 +179,7 @@ func (p *Pool) evalWithCacheKey(cacheKey string, program cel.Program, secret str
 	return p.cache.GetOrDo(cacheKey, func() (*Result, error) {
 		val, evalErr := p.env.Eval(program, secret, captures)
 		if evalErr != nil {
-			return &Result{Status: "error", Reason: evalErr.Error(), Metadata: map[string]any{}}, nil
+			return &Result{Status: report.ValidationStatusError, Reason: evalErr.Error(), Metadata: map[string]any{}}, nil
 		}
 		r := ParseResult(val)
 		if p.env.DebugResponse {

--- a/validate/result.go
+++ b/validate/result.go
@@ -3,27 +3,18 @@ package validate
 import (
 	"fmt"
 	"reflect"
-	"strings"
 
+	"github.com/betterleaks/betterleaks/report"
 	"github.com/google/cel-go/common/types/ref"
 )
 
 var mapAnyType = reflect.TypeFor[map[string]any]()
 
-// validStatuses is the set of recognised validation statuses.
-var validStatuses = map[string]bool{
-	"valid":   true,
-	"invalid": true,
-	"revoked": true,
-	"unknown": true,
-	"error":   true,
-}
-
 // Result holds the outcome of a CEL validation evaluation.
 type Result struct {
-	Status   string         // "valid", "invalid", "revoked", "unknown", "error"
-	Reason   string         // human-readable explanation
-	Metadata map[string]any // extra fields from the CEL result map
+	Status   report.ValidationStatus // "valid", "invalid", "revoked", "unknown", "error"
+	Reason   string                  // human-readable explanation
+	Metadata map[string]any          // extra fields from the CEL result map
 }
 
 // ParseResult interprets the CEL output value into a Result.
@@ -40,7 +31,7 @@ func ParseResult(val ref.Val) *Result {
 			}
 		}
 		return &Result{
-			Status:   "error",
+			Status:   report.ValidationStatusError,
 			Reason:   fmt.Sprintf("expression returned unexpected type: %T", val.Value()),
 			Metadata: map[string]any{},
 		}
@@ -49,20 +40,20 @@ func ParseResult(val ref.Val) *Result {
 
 // statusPriority defines precedence for status rollup.
 // Higher value = higher priority. "valid" wins over everything; "" loses to everything.
-var statusPriority = map[string]int{
-	"":        0,
-	"error":   1,
-	"invalid": 2,
-	"unknown": 3,
-	"revoked": 4,
-	"valid":   5,
+var statusPriority = map[report.ValidationStatus]int{
+	"":                             0,
+	report.ValidationStatusError:   1,
+	report.ValidationStatusInvalid: 2,
+	report.ValidationStatusUnknown: 3,
+	report.ValidationStatusRevoked: 4,
+	report.ValidationStatusValid:   5,
 }
 
 // BetterStatus returns whichever of a or b has higher priority.
 // Priority order: valid > revoked > unknown > invalid > error > "".
 // This is used for rolling up per-component validation results into an
 // overall finding-level status for composite rules.
-func BetterStatus(a, b string) string {
+func BetterStatus(a, b report.ValidationStatus) report.ValidationStatus {
 	if statusPriority[b] > statusPriority[a] {
 		return b
 	}
@@ -77,19 +68,19 @@ var reservedKeys = map[string]bool{
 // parseResultMap interprets a map result from a CEL expression.
 //
 // The expected form is {"result": "<status>", ...} where <status> is one of
-// the validStatuses.
+// the report.ValidationStatus constants.
 func parseResultMap(m map[string]any) *Result {
 	result := &Result{
-		Status:   "unknown",
+		Status:   report.ValidationStatusUnknown,
 		Metadata: make(map[string]any),
 	}
 
 	// Primary: explicit "result" key with a string status.
 	if v, ok := m["result"]; ok {
 		if s, ok := v.(string); ok {
-			s = strings.ToLower(s)
-			if validStatuses[s] {
-				result.Status = s
+			status, ok := report.ParseValidationStatus(s)
+			if ok {
+				result.Status = status
 			}
 		}
 	}


### PR DESCRIPTION
Closes #55.

## Summary

- add `report.ValidationStatus` constants for validation result values
- use the typed status across findings, required sets, validation results, rollup priority, counters, filters, and display helpers
- preserve the existing serialized report values while removing duplicated status string literals

## Testing

- `go test ./report ./validate ./detect ./cmd`
- `go test ./...`
- `go test --race ./...`
- `go generate ./...`
- `go build ./...`