### PR TITLE
fix(cmd): reject unknown experiments

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,6 +60,7 @@ var (
 			}
 
 			if err := validateExperiments(mustGetStringFlag(cmd, "experiments")); err != nil {
+				cmd.SilenceUsage = true
 				return err
 			}
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,10 @@ var (
 				cmd.SetContext(ctx)
 				cobra.OnFinalize(cancel)
 			}
+
+			if err := validateExperiments(mustGetStringFlag(cmd, "experiments")); err != nil {
+				return err
+			}
 			return nil
 		},
 	}
@@ -66,6 +70,8 @@ var (
 	// and stopped after a scan completes
 	diagnosticsManager *DiagnosticsManager
 )
+
+var supportedExperiments = map[string]struct{}{}
 
 const (
 	BYTE     = 1.0
@@ -545,6 +551,23 @@ func setupValidation(cmd *cobra.Command, cfg config.Config, detector *detect.Det
 			}
 		}
 	}
+}
+
+func validateExperiments(experiments string) error {
+	for experiment := range strings.SplitSeq(experiments, ",") {
+		experiment = strings.ToLower(strings.TrimSpace(experiment))
+		if experiment == "" {
+			continue
+		}
+		if _, ok := supportedExperiments[experiment]; ok {
+			continue
+		}
+		if len(supportedExperiments) == 0 {
+			return fmt.Errorf("unknown experiment %q (no experiments are currently supported)", experiment)
+		}
+		return fmt.Errorf("unknown experiment %q", experiment)
+	}
+	return nil
 }
 
 func bytesConvert(bytes uint64) string {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,6 +71,7 @@ var (
 	diagnosticsManager *DiagnosticsManager
 )
 
+// Add experimental feature flag names here as they are introduced.
 var supportedExperiments = map[string]struct{}{}
 
 const (

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -52,5 +54,34 @@ func TestValidateExperiments(t *testing.T) {
 				t.Fatalf("validateExperiments(%q) error = %q, want substring %q", tt.value, err.Error(), tt.wantError)
 			}
 		})
+	}
+}
+
+func TestInvalidExperimentsDoesNotPrintUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	versionSilenceUsage := versionCmd.SilenceUsage
+	defer func() {
+		versionCmd.SilenceUsage = versionSilenceUsage
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(os.Stdout)
+		rootCmd.SetErr(os.Stderr)
+	}()
+
+	rootCmd.SetArgs([]string{"version", "--experiments=fewaf", "--no-banner"})
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("rootCmd.Execute() error = nil, want invalid experiment error")
+	}
+	if !strings.Contains(err.Error(), `unknown experiment "fewaf"`) {
+		t.Fatalf("rootCmd.Execute() error = %q, want invalid experiment error", err.Error())
+	}
+	if strings.Contains(stdout.String(), "Usage:") {
+		t.Fatalf("stdout contains usage: %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "Usage:") {
+		t.Fatalf("stderr contains usage: %q", stderr.String())
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExperiments(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantError string
+	}{
+		{
+			name:  "empty",
+			value: "",
+		},
+		{
+			name:  "empty tokens",
+			value: " , ",
+		},
+		{
+			name:      "unknown experiment",
+			value:     "fake",
+			wantError: `unknown experiment "fake"`,
+		},
+		{
+			name:      "validation is no longer experimental",
+			value:     "validation",
+			wantError: `unknown experiment "validation"`,
+		},
+		{
+			name:      "normalizes whitespace and case",
+			value:     " Fake ",
+			wantError: `unknown experiment "fake"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateExperiments(tt.value)
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateExperiments(%q) error = %v", tt.value, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateExperiments(%q) error = nil, want %q", tt.value, tt.wantError)
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("validateExperiments(%q) error = %q, want substring %q", tt.value, err.Error(), tt.wantError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #54.

## Summary

- validate the comma-separated `--experiments` flag during command pre-run
- reject unknown experiment names instead of silently ignoring them
- keep empty experiment values accepted since no experiments are currently supported after validation was promoted

## Testing

- `go test ./cmd`
- `go test ./...`
- `go test --race ./...`
- `go run . version --experiments=fake --no-banner`
- `go generate ./...`
- `go build ./...`