### PR TITLE
fix up validation filtering

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -458,7 +458,8 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 				}
 
 				// Check validation status and if we should filter or not
-				if d.ValidationStatusFilter != nil {
+// Check validation status and if we should filter or not
+				if len(d.ValidationStatusFilter) > 0 {
 					if res.Finding.ValidationStatus != "" {
 						if _, ok := d.ValidationStatusFilter[res.Finding.ValidationStatus]; !ok {
 							continue

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -456,6 +456,18 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 				if res.Finding.ValidationStatus != "" {
 					d.ValidationCounts[res.Finding.ValidationStatus]++
 				}
+
+				// Check validation status and if we should filter or not
+				if d.ValidationStatusFilter != nil {
+					if res.Finding.ValidationStatus != "" {
+						if _, ok := d.ValidationStatusFilter[res.Finding.ValidationStatus]; !ok {
+							continue
+						}
+					} else if _, ok := d.ValidationStatusFilter["none"]; !ok {
+						continue
+					}
+				}
+
 				if !d.SkipFindingAppend {
 					d.findings = append(d.findings, res.Finding)
 				}

--- a/validate/pool.go
+++ b/validate/pool.go
@@ -3,6 +3,7 @@ package validate
 import (
 	"context"
 	"maps"
+	"slices"
 	"sync"
 
 	"github.com/betterleaks/betterleaks/celenv"
@@ -159,6 +160,22 @@ func (p *Pool) worker() {
 			f.ValidationStatus = overallStatus
 			f.ValidationReason = bestResult.Reason
 			f.ValidationMeta = bestResult.Metadata
+		}
+
+		// When at least one required set validates, keep only valid sets on the
+		// emitted finding so reports are not cluttered with failed combinations.
+		// We build a new slice so we do not compact a backing array that other
+		// copies of this Finding may still reference.
+		if slices.ContainsFunc(f.RequiredSets, func(s report.RequiredSet) bool {
+			return s.ValidationStatus == "valid"
+		}) {
+			validOnly := make([]report.RequiredSet, 0, len(f.RequiredSets))
+			for _, s := range f.RequiredSets {
+				if s.ValidationStatus == "valid" {
+					validOnly = append(validOnly, s)
+				}
+			}
+			f.RequiredSets = validOnly
 		}
 
 		if p.Emit != nil {


### PR DESCRIPTION
This pull request introduces improvements to the findings validation and filtering logic, ensuring that only relevant and valid findings are included in reports and downstream processing. The main changes focus on filtering findings based on validation status and cleaning up the emitted data to avoid clutter.

* Added filtering in `detect/detect.go` to only process findings with validation statuses present in the optional `ValidationStatusFilter` map, including support for filtering findings with no status via the `"none"` key.
* Updated the worker logic in `validate/pool.go` to, when at least one required set is valid, emit only the valid required sets for a finding. This prevents reports from being cluttered with failed combinations and avoids mutating shared backing arrays.
