### PR TITLE
Feat/s3 source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ betterleaks github https://github.com/cooluser123456789 --include issues,prs,act
 # Scan specific resource, like a PR... but exclude the description (only scan comments)
 betterleaks github https://github.com/betterleaks/betterleaks/pull/113
 
-# Scan an S3 bucket (works for any S3-compatible store: AWS, R2, MinIO, etc.)
-betterleaks s3 s3://my-bucket/logs/
-# Enumerate every bucket the credentials can list, then scan each
-betterleaks s3 's3://*'
+# Scan a public s3 dataset (Common Crawl).
+betterleaks s3 https://commoncrawl.s3.us-east-1.amazonaws.com/crawl-data/CC-MAIN-2018-17/segments/1524125937193.1/warc/
+# Enumerate and scan every bucket in a Cloudflare R2 account
+betterleaks s3 'https://<account-id>.r2.cloudflarestorage.com/*'
 
 # Scan stdin
 cat some_file.txt | betterleaks stdin -v

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ betterleaks github https://github.com/cooluser123456789 --include issues,prs,act
 # Scan specific resource, like a PR... but exclude the description (only scan comments)
 betterleaks github https://github.com/betterleaks/betterleaks/pull/113
 
+# Scan an S3 bucket (works for any S3-compatible store: AWS, R2, MinIO, etc.)
+betterleaks s3 s3://my-bucket/logs/
+# Enumerate every bucket the credentials can list, then scan each
+betterleaks s3 's3://*'
+
 # Scan stdin
 cat some_file.txt | betterleaks stdin -v
 ```

--- a/celenv/bindings_aws.go
+++ b/celenv/bindings_aws.go
@@ -1,19 +1,16 @@
 package celenv
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/xml"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/google/cel-go/common/functions"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+
+	"github.com/betterleaks/betterleaks/sigv4"
 )
 
 // STS = Security Token Service
@@ -66,8 +63,7 @@ func awsValidateBinding(e *ValidationEnvironment) functions.FunctionOp {
 			endpoint = defaultSTSEndpoint
 		}
 
-		now := time.Now().UTC()
-		result := callSTS(e, endpoint, string(accessKeyID), string(secretAccessKey), now)
+		result := callSTS(e, endpoint, string(accessKeyID), string(secretAccessKey))
 		return types.DefaultTypeAdapter.NativeToValue(result)
 	}
 }
@@ -75,47 +71,20 @@ func awsValidateBinding(e *ValidationEnvironment) functions.FunctionOp {
 // callSTS performs a SigV4-signed POST to the STS endpoint and returns a
 // response map with {status, arn, account, userid}. The CEL expression is
 // responsible for interpreting the status code and building the final result.
-func callSTS(e *ValidationEnvironment, endpoint, accessKeyID, secretAccessKey string, now time.Time) map[string]any {
+func callSTS(e *ValidationEnvironment, endpoint, accessKeyID, secretAccessKey string) map[string]any {
 	body := stsRequestBody
-	bodyHash := sha256Hex([]byte(body))
-
-	amzDate := now.Format("20060102T150405Z")
-	dateStamp := now.Format("20060102")
-	region := "us-east-1"
-	service := "sts"
-
-	// Determine host from endpoint.
-	host := "sts.amazonaws.com"
-	if strings.Contains(endpoint, "://") {
-		parts := strings.SplitN(endpoint, "://", 2)
-		host = strings.TrimRight(parts[1], "/")
-	}
-
-	// Canonical request.
-	canonicalHeaders := fmt.Sprintf("content-type:application/x-www-form-urlencoded\nhost:%s\nx-amz-date:%s\n", host, amzDate)
-	signedHeaders := "content-type;host;x-amz-date"
-	canonicalRequest := fmt.Sprintf("POST\n/\n\n%s\n%s\n%s", canonicalHeaders, signedHeaders, bodyHash)
-
-	// String to sign.
-	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, service)
-	stringToSign := fmt.Sprintf("AWS4-HMAC-SHA256\n%s\n%s\n%s", amzDate, credentialScope, sha256Hex([]byte(canonicalRequest)))
-
-	// Signing key.
-	signingKey := deriveSigningKey(secretAccessKey, dateStamp, region, service)
-	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
-
-	// Authorization header.
-	authorization := fmt.Sprintf("AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		accessKeyID, credentialScope, signedHeaders, signature)
 
 	req, err := http.NewRequest("POST", endpoint, strings.NewReader(body))
 	if err != nil {
 		return map[string]any{"status": int64(0)}
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Host", host)
-	req.Header.Set("X-Amz-Date", amzDate)
-	req.Header.Set("Authorization", authorization)
+	if err := sigv4.Sign(req, []byte(body), "us-east-1", "sts", sigv4.Credentials{
+		AccessKey: accessKeyID,
+		SecretKey: secretAccessKey,
+	}); err != nil {
+		return map[string]any{"status": int64(0)}
+	}
 
 	resp, err := e.client.Do(req)
 	if err != nil {
@@ -156,24 +125,4 @@ func callSTS(e *ValidationEnvironment, endpoint, accessKeyID, secretAccessKey st
 		}
 	}
 	return result
-}
-
-// deriveSigningKey derives the SigV4 signing key.
-func deriveSigningKey(secretKey, dateStamp, region, service string) []byte {
-	kDate := hmacSHA256([]byte("AWS4"+secretKey), []byte(dateStamp))
-	kRegion := hmacSHA256(kDate, []byte(region))
-	kService := hmacSHA256(kRegion, []byte(service))
-	kSigning := hmacSHA256(kService, []byte("aws4_request"))
-	return kSigning
-}
-
-func hmacSHA256(key, data []byte) []byte {
-	h := hmac.New(sha256.New, key)
-	h.Write(data)
-	return h.Sum(nil)
-}
-
-func sha256Hex(data []byte) string {
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:])
 }

--- a/celenv/bindings_aws_test.go
+++ b/celenv/bindings_aws_test.go
@@ -1,31 +1,11 @@
 package celenv
 
 import (
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 )
-
-func TestDeriveSigningKey(t *testing.T) {
-	// AWS SigV4 test vector from AWS documentation.
-	key := deriveSigningKey("wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20120215", "us-east-1", "iam")
-	got := hex.EncodeToString(key)
-	want := "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
-	if got != want {
-		t.Errorf("deriveSigningKey:\n got  %s\n want %s", got, want)
-	}
-}
-
-func TestSHA256Hex(t *testing.T) {
-	got := sha256Hex([]byte(""))
-	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	if got != want {
-		t.Errorf("sha256Hex empty: got %s, want %s", got, want)
-	}
-}
 
 func TestCallSTS_Valid(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -49,8 +29,7 @@ func TestCallSTS_Valid(t *testing.T) {
 	defer ts.Close()
 
 	e := &ValidationEnvironment{client: ts.Client()}
-	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", now)
+	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY")
 
 	if result["status"] != int64(200) {
 		t.Fatalf("expected status 200, got %v", result["status"])
@@ -74,8 +53,7 @@ func TestCallSTS_Invalid(t *testing.T) {
 	defer ts.Close()
 
 	e := &ValidationEnvironment{client: ts.Client()}
-	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "badkey", now)
+	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "badkey")
 
 	if result["status"] != int64(403) {
 		t.Fatalf("expected status 403, got %v", result["status"])
@@ -92,8 +70,7 @@ func TestCallSTS_ServerError(t *testing.T) {
 	defer ts.Close()
 
 	e := &ValidationEnvironment{client: ts.Client()}
-	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
-	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "anykey", now)
+	result := callSTS(e, ts.URL, "AKIAIOSFODNN7EXAMPLE", "anykey")
 
 	if result["status"] != int64(500) {
 		t.Fatalf("expected status 500, got %v", result["status"])

--- a/cmd/flag_retrievers.go
+++ b/cmd/flag_retrievers.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/spf13/cobra"
+)
+
+func mustGetBoolFlag(cmd *cobra.Command, name string) bool {
+	value, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}
+
+func mustGetIntFlag(cmd *cobra.Command, name string) int {
+	value, err := cmd.Flags().GetInt(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}
+
+func mustGetUIntFlag(cmd *cobra.Command, name string) uint {
+	value, err := cmd.Flags().GetUint(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}
+
+func mustGetStringFlag(cmd *cobra.Command, name string) string {
+	value, err := cmd.Flags().GetString(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}
+
+func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
+	value, err := cmd.Flags().GetInt64(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -627,11 +627,3 @@ func FormatDuration(d time.Duration) string {
 	}
 	return d.Round(scale / 100).String()
 }
-
-func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
-	value, err := cmd.Flags().GetInt64(name)
-	if err != nil {
-		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
-	}
-	return value
-}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -628,32 +628,8 @@ func FormatDuration(d time.Duration) string {
 	return d.Round(scale / 100).String()
 }
 
-func mustGetBoolFlag(cmd *cobra.Command, name string) bool {
-	value, err := cmd.Flags().GetBool(name)
-	if err != nil {
-		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
-	}
-	return value
-}
-
-func mustGetIntFlag(cmd *cobra.Command, name string) int {
-	value, err := cmd.Flags().GetInt(name)
-	if err != nil {
-		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
-	}
-	return value
-}
-
-func mustGetUIntFlag(cmd *cobra.Command, name string) uint {
-	value, err := cmd.Flags().GetUint(name)
-	if err != nil {
-		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
-	}
-	return value
-}
-
-func mustGetStringFlag(cmd *cobra.Command, name string) string {
-	value, err := cmd.Flags().GetString(name)
+func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
+	value, err := cmd.Flags().GetInt64(name)
 	if err != nil {
 		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
 	}

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/report"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+func init() {
+	rootCmd.AddCommand(s3Cmd)
+	s3Cmd.Flags().String("region", "", "AWS region (required for some non-AWS endpoints; auto-probed for AWS)")
+	s3Cmd.Flags().Bool("anonymous", false, "do not sign requests; ignore AWS_* env vars and --access-key/--secret-key")
+	s3Cmd.Flags().String("access-key", "", "AWS access key (overrides AWS_ACCESS_KEY_ID)")
+	s3Cmd.Flags().String("secret-key", "", "AWS secret key (overrides AWS_SECRET_ACCESS_KEY)")
+	s3Cmd.Flags().String("session-token", "", "AWS session token (overrides AWS_SESSION_TOKEN)")
+	s3Cmd.Flags().Int64("max-object-size", 0, "objects larger than this many bytes are skipped (0 = 250 MiB default)")
+	s3Cmd.Flags().Int("workers", 0, "concurrent object fetches (0 = 16 default)")
+}
+
+var s3Cmd = &cobra.Command{
+	Use:   "s3 <url> [flags]",
+	Short: "scan an S3 (or S3-compatible) bucket for secrets",
+	Example: `  # Scan an AWS bucket
+  betterleaks s3 s3://my-bucket/logs/
+
+  # Enumerate and scan all buckets in the account
+  # (requires s3:ListAllMyBuckets on the credentials)
+  betterleaks s3 's3://*'
+
+  # Enumerate buckets matching a glob, scan a shared prefix in each
+  # (same permission requirement as above)
+  betterleaks s3 's3://prod-*/logs/'
+
+  # Scan a public bucket without credentials
+  betterleaks s3 --anonymous s3://commoncrawl/crawl-data/
+
+  # Scan a single Cloudflare R2 bucket
+  betterleaks s3 https://my-bucket.acct123.r2.cloudflarestorage.com/
+
+  # Enumerate all R2 buckets in an account
+  # (requires an admin-scoped R2 API token, not a bucket-scoped one)
+  betterleaks s3 'https://acct123.r2.cloudflarestorage.com/*'
+
+  # Scan a MinIO bucket
+  betterleaks s3 --region=us-east-1 http://localhost:9000/mybucket`,
+	Args: cobra.ExactArgs(1),
+	Run:  runS3,
+}
+
+func runS3(cmd *cobra.Command, args []string) {
+	start := time.Now()
+
+	initConfig(".")
+	initDiagnostics()
+
+	cfg := Config(cmd)
+	detector := Detector(cmd, cfg, ".")
+
+	src := &sources.S3{
+		URL:             args[0],
+		Region:          mustGetStringFlag(cmd, "region"),
+		Anonymous:       mustGetBoolFlag(cmd, "anonymous"),
+		AccessKey:       mustGetStringFlag(cmd, "access-key"),
+		SecretKey:       mustGetStringFlag(cmd, "secret-key"),
+		SessionToken:    mustGetStringFlag(cmd, "session-token"),
+		MaxObjectSize:   mustGetInt64Flag(cmd, "max-object-size"),
+		Workers:         mustGetIntFlag(cmd, "workers"),
+		ShouldSkip:      detector.SkipFunc(),
+		Sema:            detector.Sema,
+		MaxArchiveDepth: detector.MaxArchiveDepth,
+	}
+
+	if err := src.Validate(); err != nil {
+		logging.Fatal().Err(err).Msg("invalid S3 configuration")
+	}
+
+	exitCode := mustGetIntFlag(cmd, "exit-code")
+	noColor := mustGetBoolFlag(cmd, "no-color")
+	redact := mustGetUIntFlag(cmd, "redact")
+	verbose := mustGetBoolFlag(cmd, "verbose")
+
+	detector.SkipFindingAppend = true
+	var findings []report.Finding
+	var scanErrs []error
+	for result := range detector.Run(cmd.Context(), src) {
+		if result.Err != nil {
+			scanErrs = append(scanErrs, result.Err)
+			logging.Error().Err(result.Err).Msg("scan error")
+			continue
+		}
+		findings = append(findings, result.Finding)
+		if verbose {
+			result.Finding.Print(noColor, redact)
+		}
+	}
+
+	var scanErr error
+	if n := len(scanErrs); n > 0 {
+		scanErr = &multipleErrors{
+			msg:  fmt.Sprintf("%d error(s) during S3 scan", n),
+			errs: scanErrs,
+		}
+	}
+	findingSummaryAndExit(detector, findings, exitCode, start, scanErr)
+}
+
+func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
+	value, err := cmd.Flags().GetInt64(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -75,7 +75,6 @@ func runS3(cmd *cobra.Command, args []string) {
 		MaxObjectSize:   mustGetInt64Flag(cmd, "max-object-size"),
 		Workers:         mustGetIntFlag(cmd, "workers"),
 		ShouldSkip:      detector.SkipFunc(),
-		Sema:            detector.Sema,
 		MaxArchiveDepth: detector.MaxArchiveDepth,
 	}
 

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -26,18 +26,22 @@ var s3Cmd = &cobra.Command{
 	Use:   "s3 <url> [flags]",
 	Short: "scan an S3 (or S3-compatible) bucket for secrets",
 	Example: `  # Scan an AWS bucket
+  betterleaks s3 https://my-bucket.s3.us-east-1.amazonaws.com/logs/
+
+  # AWS shorthand (region auto-probed)
   betterleaks s3 s3://my-bucket/logs/
 
   # Enumerate and scan all buckets in the account
   # (requires s3:ListAllMyBuckets on the credentials)
-  betterleaks s3 's3://*'
+  betterleaks s3 'https://s3.us-east-1.amazonaws.com/*'
 
   # Enumerate buckets matching a glob, scan a shared prefix in each
   # (same permission requirement as above)
-  betterleaks s3 's3://prod-*/logs/'
+  betterleaks s3 'https://s3.us-east-1.amazonaws.com/prod-*/logs/'
 
   # Scan a public bucket without credentials
-  betterleaks s3 --anonymous s3://commoncrawl/crawl-data/
+  # (the bucket policy must grant anonymous s3:ListBucket, not just s3:GetObject)
+  betterleaks s3 --anonymous https://<public-bucket>.s3.<region>.amazonaws.com/
 
   # Scan a single Cloudflare R2 bucket
   betterleaks s3 https://my-bucket.acct123.r2.cloudflarestorage.com/

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -111,11 +111,3 @@ func runS3(cmd *cobra.Command, args []string) {
 	}
 	findingSummaryAndExit(detector, findings, exitCode, start, scanErr)
 }
-
-func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
-	value, err := cmd.Flags().GetInt64(name)
-	if err != nil {
-		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
-	}
-	return value
-}

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -220,24 +220,31 @@ betterleaks github https://github.example.com/platform-team
 
 `s3` takes a single URL describing either one bucket or a glob of buckets to enumerate. The same command works against AWS, Cloudflare R2, MinIO, Backblaze B2, DigitalOcean Spaces, Wasabi — anything speaking the S3 REST API.
 
+### Choosing a URL form
+
+Two URL schemes are supported and the docs below default to `https://`:
+
+- **`https://`** is explicit about the endpoint (host + region). Required for any non-AWS provider — R2, MinIO, B2, DigitalOcean Spaces, Wasabi. Use this in CI and scripts; the region is pinned so there's no extra round-trip and no failure mode if AWS's global endpoint is unreachable.
+- **`s3://`** is an AWS-only shorthand. The endpoint is implied (`s3.amazonaws.com`) and the bucket's region is auto-probed via a `HEAD` request that reads the `x-amz-bucket-region` header. Convenient for one-off scans where you'd rather not look up the region. The probe fails loud if the bucket can't be reached.
+
+If you don't know whether `s3://` or `https://` is right for you, prefer `https://`.
+
 ### URL forms
 
 | URL | What it scans |
 | :--- | :--- |
-| `s3://my-bucket/prefix/` | One AWS bucket, optionally narrowed by key prefix |
-| `https://my-bucket.s3.us-west-2.amazonaws.com/` | One AWS bucket, region pinned in the URL |
+| `https://my-bucket.s3.us-west-2.amazonaws.com/prefix/` | One AWS bucket, optionally narrowed by key prefix |
 | `https://s3.us-east-1.amazonaws.com/my-bucket/` | AWS path-style |
+| `s3://my-bucket/prefix/` | AWS shorthand (region auto-probed) |
 | `https://<bucket>.<account>.r2.cloudflarestorage.com/` | One Cloudflare R2 bucket |
 | `https://<account>.r2.cloudflarestorage.com/<bucket>/` | R2 path-style |
 | `http://localhost:9000/my-bucket/` | MinIO or other generic endpoint (needs `--region`) |
-| `'s3://*'` | Enumerate all buckets in the AWS account |
-| `'s3://prod-*/logs/'` | Enumerate buckets matching `prod-*`, scan only the `logs/` prefix in each |
+| `'https://s3.us-east-1.amazonaws.com/*'` | Enumerate all buckets in the AWS account |
+| `'https://s3.us-east-1.amazonaws.com/prod-*/logs/'` | Enumerate buckets matching `prod-*`, scan only the `logs/` prefix in each |
 | `'https://<account>.r2.cloudflarestorage.com/*'` | Enumerate all R2 buckets in the account |
 | `'http://localhost:9000/*'` | Enumerate all buckets at the MinIO endpoint |
 
 Quote any URL containing `*` so your shell doesn't expand it.
-
-For AWS URLs without an explicit region (`s3://my-bucket`, `https://my-bucket.s3.amazonaws.com`), the region is auto-probed via a `HEAD` request that reads the `x-amz-bucket-region` header. If the probe fails, the scan fails loud — pass `--region` to skip the probe.
 
 ### Authentication
 
@@ -247,16 +254,16 @@ Credentials are resolved in this order: `--anonymous` flag → `--access-key`/`-
 # AWS via environment
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
-betterleaks s3 s3://my-bucket/
+betterleaks s3 https://my-bucket.s3.us-east-1.amazonaws.com/
 
 # AWS via flags
 betterleaks s3 \
 	--access-key=AKIA... \
 	--secret-key=... \
-	s3://my-bucket/
+	https://my-bucket.s3.us-east-1.amazonaws.com/
 
-# Public bucket, no signing
-betterleaks s3 --anonymous s3://commoncrawl/crawl-data/
+# Public bucket, no signing (requires anonymous s3:ListBucket, not just s3:GetObject)
+betterleaks s3 --anonymous https://<public-bucket>.s3.<region>.amazonaws.com/
 
 # Cloudflare R2 (Access Key ID + Secret from the R2 dashboard)
 export AWS_ACCESS_KEY_ID=<r2-access-key-id>
@@ -277,13 +284,13 @@ Globs in the bucket position switch the source into enumeration mode: list every
 
 ```sh
 # every AWS bucket (requires s3:ListAllMyBuckets on the credentials)
-betterleaks s3 's3://*'
+betterleaks s3 'https://s3.us-east-1.amazonaws.com/*'
 
 # AWS buckets matching a prefix
-betterleaks s3 's3://prod-*'
+betterleaks s3 'https://s3.us-east-1.amazonaws.com/prod-*'
 
 # common key prefix across many buckets
-betterleaks s3 's3://prod-*/logs/'
+betterleaks s3 'https://s3.us-east-1.amazonaws.com/prod-*/logs/'
 
 # every R2 bucket in an account (requires an admin-scoped R2 API token)
 betterleaks s3 'https://acct123.r2.cloudflarestorage.com/*'
@@ -297,13 +304,13 @@ Per-bucket failures during enumeration (region probe errors, `AccessDenied`, etc
 
 ```sh
 # raise the per-object size cap (default: 250 MiB)
-betterleaks s3 --max-object-size=1073741824 s3://my-bucket/
+betterleaks s3 --max-object-size=1073741824 https://my-bucket.s3.us-east-1.amazonaws.com/
 
 # scan inside archives (.zip, .tar.gz, ...) in S3 objects
-betterleaks s3 --max-archive-depth=2 s3://my-bucket/
+betterleaks s3 --max-archive-depth=2 https://my-bucket.s3.us-east-1.amazonaws.com/
 
 # fewer concurrent GETs against rate-limited endpoints (default: 16)
-betterleaks s3 --workers=4 s3://my-bucket/
+betterleaks s3 --workers=4 https://my-bucket.s3.us-east-1.amazonaws.com/
 ```
 
 Objects in `GLACIER`, `GLACIER_IR`, and `DEEP_ARCHIVE` storage classes are skipped before fetching, as are empty objects and directory markers (`key/`).

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -10,6 +10,7 @@ Use `--help` for full flag descriptions. This page is for patterns.
 | Git history | `betterleaks git` |
 | Staged or pre-commit diffs | `betterleaks git --pre-commit [--staged]` |
 | GitHub repos, Issues, PRs, Actions, Releases, Discussions, Gists | `betterleaks github <url>` |
+| S3 (and S3-compatible: R2, MinIO, etc.) | `betterleaks s3 <url>` |
 | Piped content | `betterleaks stdin` |
 
 ---
@@ -212,6 +213,100 @@ betterleaks github https://gist.github.com/octocat/aaaaaaaaaaaaaaaaaaaa
 ```sh
 betterleaks github https://github.example.com/platform-team
 ```
+
+---
+
+## `s3`
+
+`s3` takes a single URL describing either one bucket or a glob of buckets to enumerate. The same command works against AWS, Cloudflare R2, MinIO, Backblaze B2, DigitalOcean Spaces, Wasabi — anything speaking the S3 REST API.
+
+### URL forms
+
+| URL | What it scans |
+| :--- | :--- |
+| `s3://my-bucket/prefix/` | One AWS bucket, optionally narrowed by key prefix |
+| `https://my-bucket.s3.us-west-2.amazonaws.com/` | One AWS bucket, region pinned in the URL |
+| `https://s3.us-east-1.amazonaws.com/my-bucket/` | AWS path-style |
+| `https://<bucket>.<account>.r2.cloudflarestorage.com/` | One Cloudflare R2 bucket |
+| `https://<account>.r2.cloudflarestorage.com/<bucket>/` | R2 path-style |
+| `http://localhost:9000/my-bucket/` | MinIO or other generic endpoint (needs `--region`) |
+| `'s3://*'` | Enumerate all buckets in the AWS account |
+| `'s3://prod-*/logs/'` | Enumerate buckets matching `prod-*`, scan only the `logs/` prefix in each |
+| `'https://<account>.r2.cloudflarestorage.com/*'` | Enumerate all R2 buckets in the account |
+| `'http://localhost:9000/*'` | Enumerate all buckets at the MinIO endpoint |
+
+Quote any URL containing `*` so your shell doesn't expand it.
+
+For AWS URLs without an explicit region (`s3://my-bucket`, `https://my-bucket.s3.amazonaws.com`), the region is auto-probed via a `HEAD` request that reads the `x-amz-bucket-region` header. If the probe fails, the scan fails loud — pass `--region` to skip the probe.
+
+### Authentication
+
+Credentials are resolved in this order: `--anonymous` flag → `--access-key`/`--secret-key`/`--session-token` flags → `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` env vars. With none of the three, the scan fails loud — there is no implicit fall-through to `~/.aws/credentials`.
+
+```sh
+# AWS via environment
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+betterleaks s3 s3://my-bucket/
+
+# AWS via flags
+betterleaks s3 \
+	--access-key=AKIA... \
+	--secret-key=... \
+	s3://my-bucket/
+
+# Public bucket, no signing
+betterleaks s3 --anonymous s3://commoncrawl/crawl-data/
+
+# Cloudflare R2 (Access Key ID + Secret from the R2 dashboard)
+export AWS_ACCESS_KEY_ID=<r2-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<r2-secret-access-key>
+betterleaks s3 https://my-bucket.acct123.r2.cloudflarestorage.com/
+
+# MinIO / generic S3-compatible
+betterleaks s3 \
+	--access-key=minioadmin \
+	--secret-key=minioadmin \
+	--region=us-east-1 \
+	http://localhost:9000/my-bucket/
+```
+
+### Enumeration
+
+Globs in the bucket position switch the source into enumeration mode: list every bucket the credentials can see, filter by the pattern, scan each match.
+
+```sh
+# every AWS bucket (requires s3:ListAllMyBuckets on the credentials)
+betterleaks s3 's3://*'
+
+# AWS buckets matching a prefix
+betterleaks s3 's3://prod-*'
+
+# common key prefix across many buckets
+betterleaks s3 's3://prod-*/logs/'
+
+# every R2 bucket in an account (requires an admin-scoped R2 API token)
+betterleaks s3 'https://acct123.r2.cloudflarestorage.com/*'
+```
+
+Anonymous enumeration is not possible — `ListBuckets` is account-scoped and requires authenticated credentials. Bucket-scoped tokens fail loudly on the initial `ListBuckets` call; switch to a single-bucket URL or upgrade the token's scope.
+
+Per-bucket failures during enumeration (region probe errors, `AccessDenied`, etc.) are logged and non-fatal — the scan continues to the next bucket.
+
+### Object filters and limits
+
+```sh
+# raise the per-object size cap (default: 250 MiB)
+betterleaks s3 --max-object-size=1073741824 s3://my-bucket/
+
+# scan inside archives (.zip, .tar.gz, ...) in S3 objects
+betterleaks s3 --max-archive-depth=2 s3://my-bucket/
+
+# fewer concurrent GETs against rate-limited endpoints (default: 16)
+betterleaks s3 --workers=4 s3://my-bucket/
+```
+
+Objects in `GLACIER`, `GLACIER_IR`, and `DEEP_ARCHIVE` storage classes are skipped before fetching, as are empty objects and directory markers (`key/`).
 
 ---
 

--- a/sigv4/sigv4.go
+++ b/sigv4/sigv4.go
@@ -1,0 +1,238 @@
+// Package sigv4 implements AWS Signature Version 4 request signing.
+//
+// SigV4 is the request-signing scheme used by S3, STS, and every S3-compatible
+// object store (R2, MinIO, B2, etc.). The algorithm and credentials are
+// per-service: the signing math is identical, but credentials issued by one
+// provider only authenticate against that provider's endpoints.
+//
+// Spec: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+package sigv4
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	Algorithm = "AWS4-HMAC-SHA256"
+	// EmptyPayloadSHA is the lowercase-hex SHA-256 of the empty string, used
+	// as the canonical payload hash for requests with no body.
+	EmptyPayloadSHA = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// Credentials are static SigV4 credentials. SessionToken is optional and only
+// populated for temporary credentials (STS, IAM Roles Anywhere, etc.).
+type Credentials struct {
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+}
+
+// Sign signs req in place using SigV4 for the given region and service.
+//
+// The host is taken from req.Host (falling back to req.URL.Host). The body
+// parameter is hashed for the canonical-payload component; pass nil for empty
+// bodies. X-Amz-Date, X-Amz-Content-Sha256, and Authorization headers are set
+// on the request; X-Amz-Security-Token is set when creds.SessionToken is
+// non-empty.
+//
+// Headers included in the signed-headers set: host, x-amz-*, content-*. Other
+// headers (Accept-Encoding, User-Agent, etc.) are intentionally excluded so
+// the signature isn't invalidated by middleware that mutates them.
+func Sign(req *http.Request, body []byte, region, service string, creds Credentials) error {
+	return signAt(req, body, region, service, creds, time.Now().UTC())
+}
+
+// signAt is Sign with an injected timestamp (for testing).
+func signAt(req *http.Request, body []byte, region, service string, creds Credentials, now time.Time) error {
+	if creds.AccessKey == "" || creds.SecretKey == "" {
+		return errors.New("sigv4: missing access key or secret")
+	}
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	var payloadHash string
+	if len(body) == 0 {
+		payloadHash = EmptyPayloadSHA
+	} else {
+		payloadHash = SHA256Hex(body)
+	}
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+
+	canonicalHeaders, signedHeaders := canonicalHeaders(req)
+	canonicalQuery := canonicalQuery(req.URL.Query())
+	canonicalURI := canonicalURI(req.URL.Path)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, service)
+	stringToSign := strings.Join([]string{
+		Algorithm,
+		amzDate,
+		scope,
+		SHA256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := DeriveSigningKey(creds.SecretKey, dateStamp, region, service)
+	signature := hex.EncodeToString(HMACSHA256(signingKey, []byte(stringToSign)))
+
+	req.Header.Set("Authorization", fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		Algorithm, creds.AccessKey, scope, signedHeaders, signature,
+	))
+	return nil
+}
+
+// DeriveSigningKey returns the SigV4 signing key for the given secret, date
+// (YYYYMMDD), region, and service.
+func DeriveSigningKey(secret, dateStamp, region, service string) []byte {
+	kDate := HMACSHA256([]byte("AWS4"+secret), []byte(dateStamp))
+	kRegion := HMACSHA256(kDate, []byte(region))
+	kService := HMACSHA256(kRegion, []byte(service))
+	return HMACSHA256(kService, []byte("aws4_request"))
+}
+
+// HMACSHA256 returns HMAC-SHA256(data) keyed with key.
+func HMACSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+// SHA256Hex returns the lowercase-hex SHA-256 hash of data.
+func SHA256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func canonicalHeaders(req *http.Request) (canonical, signed string) {
+	type kv struct{ k, v string }
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	headers := []kv{{"host", host}}
+	for name, values := range req.Header {
+		lower := strings.ToLower(name)
+		if lower == "host" || lower == "authorization" {
+			continue
+		}
+		// Sign only the headers SigV4 callers tend to set deliberately. Skipping
+		// Accept-Encoding/User-Agent etc. avoids signature invalidation when
+		// the http.Client populates them later.
+		if !strings.HasPrefix(lower, "x-amz-") && !strings.HasPrefix(lower, "content-") {
+			continue
+		}
+		headers = append(headers, kv{lower, strings.Join(values, ",")})
+	}
+	sort.Slice(headers, func(i, j int) bool { return headers[i].k < headers[j].k })
+
+	var cb, sb strings.Builder
+	for i, h := range headers {
+		cb.WriteString(h.k)
+		cb.WriteByte(':')
+		cb.WriteString(strings.TrimSpace(collapseWhitespace(h.v)))
+		cb.WriteByte('\n')
+		if i > 0 {
+			sb.WriteByte(';')
+		}
+		sb.WriteString(h.k)
+	}
+	return cb.String(), sb.String()
+}
+
+// collapseWhitespace converts runs of spaces/tabs in a header value into a
+// single space, as required by the SigV4 canonicalization rules.
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	var prevSpace bool
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		prevSpace = false
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func canonicalQuery(values map[string][]string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		vs := values[k]
+		sort.Strings(vs)
+		for j, v := range vs {
+			if i > 0 || j > 0 {
+				b.WriteByte('&')
+			}
+			b.WriteString(URIEncode(k, true))
+			b.WriteByte('=')
+			b.WriteString(URIEncode(v, true))
+		}
+	}
+	return b.String()
+}
+
+// canonicalURI URI-encodes the path once (S3-style; "/" preserved between
+// segments). AWS services other than S3 encode twice; S3 is the practical
+// caller here and the discrepancy hasn't yet caused issues for STS.
+func canonicalURI(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return URIEncode(path, false)
+}
+
+// URIEncode applies the AWS-spec URI encoding: unreserved chars
+// (A-Z, a-z, 0-9, '-', '_', '.', '~') pass through; everything else is
+// percent-encoded. With encodeSlash=false (used for path components), '/' is
+// preserved.
+func URIEncode(s string, encodeSlash bool) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'),
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		case c == '/' && !encodeSlash:
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}

--- a/sigv4/sigv4_test.go
+++ b/sigv4/sigv4_test.go
@@ -1,0 +1,88 @@
+package sigv4
+
+import (
+	"encoding/hex"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeriveSigningKey is the canonical AWS test vector from
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/signature-v4-examples.html.
+func TestDeriveSigningKey(t *testing.T) {
+	got := DeriveSigningKey(
+		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		"20150830", "us-east-1", "iam",
+	)
+	const want = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+	assert.Equal(t, want, hex.EncodeToString(got))
+}
+
+func TestURIEncode(t *testing.T) {
+	cases := []struct {
+		in          string
+		encodeSlash bool
+		want        string
+	}{
+		{"foo/bar.txt", false, "foo/bar.txt"},
+		{"foo/bar.txt", true, "foo%2Fbar.txt"},
+		{"hello world", false, "hello%20world"},
+		{"a+b=c", false, "a%2Bb%3Dc"},
+		{"unicode-café", false, "unicode-caf%C3%A9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, URIEncode(tc.in, tc.encodeSlash))
+		})
+	}
+}
+
+func TestSign_setsRequiredHeaders(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://mybucket.s3.us-east-1.amazonaws.com/?list-type=2", nil)
+	require.NoError(t, err)
+	creds := Credentials{AccessKey: "AKIAIOSFODNN7EXAMPLE", SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"}
+	require.NoError(t, Sign(req, nil, "us-east-1", "s3", creds))
+
+	auth := req.Header.Get("Authorization")
+	assert.Contains(t, auth, Algorithm+" ")
+	assert.Contains(t, auth, "Credential=AKIAIOSFODNN7EXAMPLE/")
+	assert.Contains(t, auth, "/us-east-1/s3/aws4_request")
+	assert.Contains(t, auth, "SignedHeaders=host;x-amz-content-sha256;x-amz-date")
+	assert.Equal(t, EmptyPayloadSHA, req.Header.Get("X-Amz-Content-Sha256"))
+	assert.NotEmpty(t, req.Header.Get("X-Amz-Date"))
+}
+
+func TestSign_includesSessionTokenWhenSet(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://example.s3.us-east-1.amazonaws.com/", nil)
+	require.NoError(t, err)
+	creds := Credentials{AccessKey: "ak", SecretKey: "sk", SessionToken: "tok"}
+	require.NoError(t, Sign(req, nil, "us-east-1", "s3", creds))
+	assert.Equal(t, "tok", req.Header.Get("X-Amz-Security-Token"))
+	assert.Contains(t, req.Header.Get("Authorization"), "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token")
+}
+
+func TestSign_missingCredsErrors(t *testing.T) {
+	req, _ := http.NewRequest(http.MethodGet, "https://example.s3.us-east-1.amazonaws.com/", nil)
+	require.Error(t, Sign(req, nil, "us-east-1", "s3", Credentials{}))
+}
+
+// TestSign_deterministic verifies that signing the same request at the same
+// time produces the same Authorization header — a regression guard for any
+// future canonicalization changes.
+func TestSign_deterministic(t *testing.T) {
+	ts := time.Date(2025, 1, 2, 3, 4, 5, 0, time.UTC)
+	mk := func() *http.Request {
+		r, _ := http.NewRequest(http.MethodPost, "https://sts.amazonaws.com/", nil)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return r
+	}
+	creds := Credentials{AccessKey: "AKIDEXAMPLE", SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"}
+	r1, r2 := mk(), mk()
+	require.NoError(t, signAt(r1, []byte("Action=GetCallerIdentity&Version=2011-06-15"), "us-east-1", "sts", creds, ts))
+	require.NoError(t, signAt(r2, []byte("Action=GetCallerIdentity&Version=2011-06-15"), "us-east-1", "sts", creds, ts))
+	assert.Equal(t, r1.Header.Get("Authorization"), r2.Header.Get("Authorization"))
+	assert.Contains(t, r1.Header.Get("Authorization"), "SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date")
+}

--- a/sources/attribute.go
+++ b/sources/attribute.go
@@ -56,4 +56,16 @@ const (
 	AttrGitHubGistID           = "github.gist.id"
 	AttrGitHubGistFilename     = "github.gist.filename"
 	AttrGitHubGistOwner        = "github.gist.owner"
+
+	// S3 (and S3-compatible object stores)
+	AttrS3Bucket       = "s3.bucket"
+	AttrS3Key          = "s3.key"
+	AttrS3Region       = "s3.region"
+	AttrS3Endpoint     = "s3.endpoint"
+	AttrS3LastModified = "s3.last_modified"
+	AttrS3ETag         = "s3.etag"
+	AttrS3Size         = "s3.size"
+	AttrS3StorageClass = "s3.storage_class"
+
+	ResourceS3Object = "s3.object"
 )

--- a/sources/s3.go
+++ b/sources/s3.go
@@ -1,0 +1,869 @@
+package sources
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fatih/semgroup"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/betterleaks/betterleaks/logging"
+)
+
+const (
+	s3DefaultMaxObjectSize int64 = 250 * 1024 * 1024 // 250 MiB
+	s3DefaultWorkers             = 16
+	s3GetObjectTimeout           = 30 * time.Second
+	s3ListPageSize               = 1000
+	s3Service                    = "s3"
+	s3SignAlgorithm              = "AWS4-HMAC-SHA256"
+	s3EmptyPayloadSHA256         = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	s3StorageClassGlacier        = "GLACIER"
+	s3StorageClassGlacierIR      = "GLACIER_IR"
+	s3StorageClassDeepArchive    = "DEEP_ARCHIVE"
+)
+
+// S3 enumerates objects in an S3 (or S3-compatible) bucket and yields a
+// fragment for each object's content. The target is described by a single URL
+// passed via S3.URL.
+type S3 struct {
+	// URL is the target bucket (and optional prefix). Required. Supported forms:
+	//
+	//   s3://bucket/prefix
+	//   https://bucket.s3.amazonaws.com/prefix
+	//   https://bucket.s3.<region>.amazonaws.com/prefix
+	//   https://s3.<region>.amazonaws.com/bucket/prefix
+	//   https://<bucket>.<account>.r2.cloudflarestorage.com/prefix
+	//   https://<endpoint>[:port]/bucket/prefix      (MinIO, generic S3-compat)
+	URL string
+
+	// Region overrides whatever the URL implies. Required when the URL is a
+	// path-style endpoint with no inferable region (e.g. MinIO at a custom host).
+	Region string
+
+	// Credentials. Explicit fields win over environment variables. If both are
+	// empty and Anonymous is false, the source fails Validate.
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+	Anonymous    bool
+
+	// Scan config
+	MaxObjectSize   int64
+	Workers         int
+	ShouldSkip      SkipFunc
+	Sema            *semgroup.Group
+	MaxArchiveDepth int
+
+	parsed s3Target
+	creds  s3Creds
+}
+
+// s3Target captures everything the request builder needs after URL parsing.
+type s3Target struct {
+	Scheme        string // "https" or "http"
+	Host          string // request host (with bucket subdomain for virtual-hosted)
+	Bucket        string
+	Prefix        string
+	Region        string // may be "" pre-probe for AWS forms missing region
+	PathStyle     bool
+	IsAWS         bool   // true for *.amazonaws.com and s3:// scheme
+	RequiresProbe bool   // AWS hosts where region was not in the URL
+	Endpoint      string // descriptive endpoint label for logging / attrs
+}
+
+// s3Creds holds resolved request-signing credentials.
+type s3Creds struct {
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+	Anonymous    bool
+}
+
+// Validate parses the URL, resolves credentials, and (for AWS targets without
+// an explicit region) probes the bucket region.
+func (s *S3) Validate() error {
+	if s.URL == "" {
+		return errors.New("target URL is required")
+	}
+	target, err := s3ParseURL(s.URL)
+	if err != nil {
+		return fmt.Errorf("invalid S3 URL: %w", err)
+	}
+	if s.Region != "" {
+		target.Region = s.Region
+		target.RequiresProbe = false
+	}
+	if target.Region == "" && target.RequiresProbe && target.IsAWS {
+		region, err := s3ProbeAWSRegion(context.Background(), target.Bucket)
+		if err != nil {
+			return fmt.Errorf("could not determine bucket region (pass --region): %w", err)
+		}
+		target.Region = region
+		// AWS virtual-hosted host with the resolved region.
+		target.Host = fmt.Sprintf("%s.s3.%s.amazonaws.com", target.Bucket, region)
+		target.RequiresProbe = false
+	}
+	if target.Region == "" {
+		return errors.New("region could not be inferred from URL; pass --region")
+	}
+	s.parsed = target
+
+	creds, err := s.resolveCreds()
+	if err != nil {
+		return err
+	}
+	s.creds = creds
+	return nil
+}
+
+// resolveCreds applies the auth waterfall:
+//
+//	Anonymous flag         → anonymous
+//	Explicit fields        → static
+//	AWS_* env vars         → static
+//	None of the above      → error (fail loud)
+func (s *S3) resolveCreds() (s3Creds, error) {
+	if s.Anonymous {
+		return s3Creds{Anonymous: true}, nil
+	}
+	if s.AccessKey != "" && s.SecretKey != "" {
+		return s3Creds{
+			AccessKey:    s.AccessKey,
+			SecretKey:    s.SecretKey,
+			SessionToken: s.SessionToken,
+		}, nil
+	}
+	envAK := os.Getenv("AWS_ACCESS_KEY_ID")
+	envSK := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	if envAK != "" && envSK != "" {
+		return s3Creds{
+			AccessKey:    envAK,
+			SecretKey:    envSK,
+			SessionToken: os.Getenv("AWS_SESSION_TOKEN"),
+		}, nil
+	}
+	return s3Creds{}, errors.New("no credentials: set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, pass --access-key/--secret-key, or pass --anonymous")
+}
+
+// Fragments enumerates objects under the configured prefix and yields content
+// fragments for each one.
+func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
+	if s.parsed.Bucket == "" {
+		if err := s.Validate(); err != nil {
+			return err
+		}
+	}
+	maxSize := s.MaxObjectSize
+	if maxSize <= 0 {
+		maxSize = s3DefaultMaxObjectSize
+	}
+	workers := s.Workers
+	if workers <= 0 {
+		workers = s3DefaultWorkers
+	}
+
+	bucketAttrs := map[string]string{
+		AttrS3Bucket: s.parsed.Bucket,
+		AttrS3Region: s.parsed.Region,
+		AttrResource: ResourceS3Object,
+	}
+	if s.parsed.Endpoint != "" {
+		bucketAttrs[AttrS3Endpoint] = s.parsed.Endpoint
+	}
+	if s.ShouldSkip != nil && s.ShouldSkip(bucketAttrs) {
+		logging.Info().Str("bucket", s.parsed.Bucket).Msg("skipping bucket: filtered by prefilter")
+		return nil
+	}
+
+	logging.Info().
+		Str("bucket", s.parsed.Bucket).
+		Str("region", s.parsed.Region).
+		Str("prefix", s.parsed.Prefix).
+		Str("endpoint", s.parsed.Endpoint).
+		Msg("starting S3 scan")
+
+	httpClient := &http.Client{}
+	start := time.Now()
+	var (
+		objectCount  int
+		scannedCount int
+		mu           sync.Mutex
+	)
+
+	var continuationToken string
+	for {
+		page, err := s3ListPage(ctx, httpClient, s.parsed, s.creds, s.parsed.Prefix, continuationToken)
+		if err != nil {
+			return fmt.Errorf("list objects: %w", err)
+		}
+
+		g, gctx := errgroup.WithContext(ctx)
+		g.SetLimit(workers)
+		for _, obj := range page.Contents {
+			if skipReason := s.skipReason(obj, maxSize); skipReason != "" {
+				logging.Trace().Str("key", obj.Key).Str("reason", skipReason).Msg("skipping object")
+				continue
+			}
+			attrs := s.objectAttributes(obj)
+			if s.ShouldSkip != nil && s.ShouldSkip(attrs) {
+				logging.Trace().Str("key", obj.Key).Msg("skipping object: filtered by prefilter")
+				continue
+			}
+			objectCount++
+			g.Go(func() error {
+				if err := s.scanObject(gctx, httpClient, obj, attrs, yield); err != nil {
+					logging.Error().Err(err).Str("key", obj.Key).Msg("could not scan S3 object")
+					return nil
+				}
+				mu.Lock()
+				scannedCount++
+				mu.Unlock()
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return err
+		}
+		if !page.IsTruncated || page.NextContinuationToken == "" {
+			break
+		}
+		continuationToken = page.NextContinuationToken
+	}
+
+	logging.Info().
+		Int("objects_listed", objectCount).
+		Int("objects_scanned", scannedCount).
+		Str("duration", time.Since(start).Round(time.Millisecond).String()).
+		Msg("S3 scan complete")
+	return nil
+}
+
+// skipReason returns a non-empty reason if the object should be skipped before
+// attempting to fetch it. The empty string means "scan it".
+func (s *S3) skipReason(obj s3Object, maxSize int64) string {
+	switch obj.StorageClass {
+	case s3StorageClassGlacier, s3StorageClassGlacierIR, s3StorageClassDeepArchive:
+		return "storage_class:" + obj.StorageClass
+	}
+	if obj.Size > maxSize {
+		return "size_limit"
+	}
+	if obj.Size == 0 {
+		return "empty"
+	}
+	if strings.HasSuffix(obj.Key, "/") {
+		return "directory"
+	}
+	return ""
+}
+
+// objectAttributes builds the attr map stamped on every fragment for this object.
+func (s *S3) objectAttributes(obj s3Object) map[string]string {
+	attrs := map[string]string{
+		AttrPath:           obj.Key,
+		AttrURL:            s3ObjectURL(s.parsed, obj.Key),
+		AttrResource:       ResourceS3Object,
+		AttrS3Bucket:       s.parsed.Bucket,
+		AttrS3Key:          obj.Key,
+		AttrS3Region:       s.parsed.Region,
+		AttrS3Size:         strconv.FormatInt(obj.Size, 10),
+		AttrS3ETag:         strings.Trim(obj.ETag, `"`),
+		AttrS3LastModified: obj.LastModified,
+		AttrS3StorageClass: obj.StorageClass,
+	}
+	if s.parsed.Endpoint != "" {
+		attrs[AttrS3Endpoint] = s.parsed.Endpoint
+	}
+	return attrs
+}
+
+// scanObject GETs an object and pipes its body through File.Fragments, which
+// already handles archives, mime sniffing, and chunk boundaries.
+func (s *S3) scanObject(ctx context.Context, client *http.Client, obj s3Object, attrs map[string]string, yield FragmentsFunc) error {
+	objCtx, cancel := context.WithTimeout(ctx, s3GetObjectTimeout)
+	defer cancel()
+
+	body, err := s3GetObject(objCtx, client, s.parsed, s.creds, obj.Key)
+	if err != nil {
+		return err
+	}
+	defer body.Close()
+
+	stampedYield := s.wrapYieldWithAttrs(attrs, yield)
+	file := &File{
+		Content:         body,
+		Path:            obj.Key,
+		MaxArchiveDepth: s.MaxArchiveDepth,
+		ShouldSkip:      s.ShouldSkip,
+	}
+	return file.Fragments(ctx, stampedYield)
+}
+
+// wrapYieldWithAttrs returns a yield that stamps the given attrs on every
+// fragment, re-applies ShouldSkip with the merged attrs, and serializes calls
+// through a mutex. Mirrors the GitHub source.
+func (s *S3) wrapYieldWithAttrs(attrs map[string]string, yield FragmentsFunc) FragmentsFunc {
+	var mu sync.Mutex
+	return func(fragment Fragment, err error) error {
+		if err == nil {
+			for k, v := range attrs {
+				if v == "" {
+					continue
+				}
+				// Always override AttrResource so the fragment reflects the S3
+				// source rather than the File source's default "fs.content".
+				if k == AttrResource || fragment.Attr(k) == "" {
+					fragment.SetAttr(k, v)
+				}
+			}
+			if s.ShouldSkip != nil && s.ShouldSkip(fragment.Attributes) {
+				return nil
+			}
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return yield(fragment, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// URL parsing
+// ---------------------------------------------------------------------------
+
+// s3ParseURL accepts the documented URL forms and returns a populated s3Target.
+func s3ParseURL(raw string) (s3Target, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return s3Target{}, err
+	}
+	switch u.Scheme {
+	case "s3":
+		if u.Host == "" {
+			return s3Target{}, errors.New("s3:// URL is missing bucket")
+		}
+		return s3Target{
+			Scheme:        "https",
+			Host:          fmt.Sprintf("%s.s3.amazonaws.com", u.Host),
+			Bucket:        u.Host,
+			Prefix:        strings.TrimPrefix(u.Path, "/"),
+			IsAWS:         true,
+			RequiresProbe: true,
+			Endpoint:      "s3.amazonaws.com",
+		}, nil
+	case "http", "https":
+		// fall through
+	default:
+		return s3Target{}, fmt.Errorf("unsupported scheme %q", u.Scheme)
+	}
+
+	host := u.Host
+	hostOnly := host
+	if i := strings.IndexByte(hostOnly, ':'); i >= 0 {
+		hostOnly = hostOnly[:i]
+	}
+	path := strings.TrimPrefix(u.Path, "/")
+
+	switch {
+	case strings.HasSuffix(hostOnly, ".amazonaws.com") || hostOnly == "amazonaws.com":
+		return parseAWSHostURL(u, hostOnly, path)
+	case strings.HasSuffix(hostOnly, ".r2.cloudflarestorage.com"):
+		return parseR2HostURL(u, hostOnly, path)
+	default:
+		// Generic S3-compatible: assume path-style; first path segment is bucket.
+		bucket, prefix := splitBucketAndPrefix(path)
+		if bucket == "" {
+			return s3Target{}, errors.New("path-style URL is missing bucket segment")
+		}
+		return s3Target{
+			Scheme:    u.Scheme,
+			Host:      host,
+			Bucket:    bucket,
+			Prefix:    prefix,
+			PathStyle: true,
+			Endpoint:  host,
+		}, nil
+	}
+}
+
+// parseAWSHostURL handles the AWS-hosted forms:
+//
+//	<bucket>.s3.amazonaws.com              (region probe required)
+//	<bucket>.s3.<region>.amazonaws.com
+//	s3.amazonaws.com / <bucket>            (legacy path-style, probe required)
+//	s3.<region>.amazonaws.com / <bucket>
+func parseAWSHostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
+	labels := strings.Split(hostOnly, ".")
+	// suffix is always [..., "amazonaws", "com"]; strip it.
+	if len(labels) < 3 {
+		return s3Target{}, fmt.Errorf("unrecognized amazonaws.com host %q", hostOnly)
+	}
+	prefix := labels[:len(labels)-2]
+
+	// Virtual-hosted: bucket.s3[.region].amazonaws.com
+	for i := 1; i < len(prefix); i++ {
+		if prefix[i] == "s3" {
+			bucket := strings.Join(prefix[:i], ".")
+			rest := prefix[i+1:]
+			region := ""
+			if len(rest) >= 1 {
+				region = rest[0]
+			}
+			bPrefix := path
+			return s3Target{
+				Scheme:        u.Scheme,
+				Host:          u.Host,
+				Bucket:        bucket,
+				Prefix:        bPrefix,
+				Region:        region,
+				IsAWS:         true,
+				RequiresProbe: region == "",
+				Endpoint:      hostOnly,
+			}, nil
+		}
+	}
+
+	// Path-style: s3[.region].amazonaws.com / bucket
+	if prefix[0] == "s3" {
+		region := ""
+		if len(prefix) >= 2 {
+			region = prefix[1]
+		}
+		bucket, bPrefix := splitBucketAndPrefix(path)
+		if bucket == "" {
+			return s3Target{}, errors.New("path-style amazonaws.com URL is missing bucket segment")
+		}
+		return s3Target{
+			Scheme:        u.Scheme,
+			Host:          u.Host,
+			Bucket:        bucket,
+			Prefix:        bPrefix,
+			Region:        region,
+			PathStyle:     true,
+			IsAWS:         true,
+			RequiresProbe: region == "",
+			Endpoint:      hostOnly,
+		}, nil
+	}
+
+	return s3Target{}, fmt.Errorf("unrecognized amazonaws.com host %q", hostOnly)
+}
+
+// parseR2HostURL handles Cloudflare R2's `*.r2.cloudflarestorage.com` host.
+// R2 ignores region but SigV4 requires one; the canonical value is "auto".
+func parseR2HostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
+	labels := strings.Split(hostOnly, ".")
+	// Expect at least <account>.r2.cloudflarestorage.com, optionally with a
+	// leading <bucket> label for virtual-hosted form.
+	if len(labels) < 4 {
+		return s3Target{}, fmt.Errorf("unrecognized r2 host %q", hostOnly)
+	}
+	// Virtual-hosted: <bucket>.<account>.r2.cloudflarestorage.com
+	if len(labels) >= 5 {
+		bucket := labels[0]
+		return s3Target{
+			Scheme:   u.Scheme,
+			Host:     u.Host,
+			Bucket:   bucket,
+			Prefix:   path,
+			Region:   "auto",
+			IsAWS:    false,
+			Endpoint: hostOnly,
+		}, nil
+	}
+	// Path-style: <account>.r2.cloudflarestorage.com/<bucket>/<prefix>
+	bucket, bPrefix := splitBucketAndPrefix(path)
+	if bucket == "" {
+		return s3Target{}, errors.New("r2 URL is missing bucket segment")
+	}
+	return s3Target{
+		Scheme:    u.Scheme,
+		Host:      u.Host,
+		Bucket:    bucket,
+		Prefix:    bPrefix,
+		Region:    "auto",
+		PathStyle: true,
+		IsAWS:     false,
+		Endpoint:  hostOnly,
+	}, nil
+}
+
+// splitBucketAndPrefix splits a path of the form "bucket/prefix..." into its parts.
+// Both pieces are returned without leading or trailing slashes (prefix keeps internal "/").
+func splitBucketAndPrefix(path string) (bucket, prefix string) {
+	path = strings.TrimPrefix(path, "/")
+	if path == "" {
+		return "", ""
+	}
+	b, p, _ := strings.Cut(path, "/")
+	return b, p
+}
+
+// ---------------------------------------------------------------------------
+// Region probe (AWS only)
+// ---------------------------------------------------------------------------
+
+// s3ProbeAWSRegion issues a HEAD against the bucket's global endpoint and reads
+// the x-amz-bucket-region header. AWS sets this header on success and on the
+// `301 PermanentRedirect` it returns when the bucket lives elsewhere.
+func s3ProbeAWSRegion(ctx context.Context, bucket string) (string, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodHead, fmt.Sprintf("https://%s.s3.amazonaws.com", bucket), nil)
+	if err != nil {
+		return "", err
+	}
+	client := &http.Client{
+		// Don't follow the 301 redirect; we just want the header.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	region := resp.Header.Get("x-amz-bucket-region")
+	if region == "" {
+		return "", fmt.Errorf("HEAD %s returned %s with no x-amz-bucket-region header", req.URL, resp.Status)
+	}
+	return region, nil
+}
+
+// ---------------------------------------------------------------------------
+// List + Get
+// ---------------------------------------------------------------------------
+
+type s3Object struct {
+	Key          string `xml:"Key"`
+	LastModified string `xml:"LastModified"`
+	ETag         string `xml:"ETag"`
+	Size         int64  `xml:"Size"`
+	StorageClass string `xml:"StorageClass"`
+}
+
+type s3ListBucketResult struct {
+	XMLName               xml.Name   `xml:"ListBucketResult"`
+	Name                  string     `xml:"Name"`
+	Prefix                string     `xml:"Prefix"`
+	KeyCount              int        `xml:"KeyCount"`
+	MaxKeys               int        `xml:"MaxKeys"`
+	IsTruncated           bool       `xml:"IsTruncated"`
+	NextContinuationToken string     `xml:"NextContinuationToken"`
+	Contents              []s3Object `xml:"Contents"`
+}
+
+// s3ListPage requests one page of ListObjectsV2.
+func s3ListPage(ctx context.Context, client *http.Client, target s3Target, creds s3Creds, prefix, continuationToken string) (*s3ListBucketResult, error) {
+	query := url.Values{}
+	query.Set("list-type", "2")
+	query.Set("max-keys", strconv.Itoa(s3ListPageSize))
+	if prefix != "" {
+		query.Set("prefix", prefix)
+	}
+	if continuationToken != "" {
+		query.Set("continuation-token", continuationToken)
+	}
+
+	req, err := s3NewRequest(ctx, http.MethodGet, target, "", query)
+	if err != nil {
+		return nil, err
+	}
+	if err := s3Sign(req, nil, target.Region, creds); err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("list returned %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	var result s3ListBucketResult
+	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode list response: %w", err)
+	}
+	return &result, nil
+}
+
+// s3GetObject signs and issues GET /<key>. The caller closes the returned body.
+func s3GetObject(ctx context.Context, client *http.Client, target s3Target, creds s3Creds, key string) (io.ReadCloser, error) {
+	req, err := s3NewRequest(ctx, http.MethodGet, target, key, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := s3Sign(req, nil, target.Region, creds); err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		resp.Body.Close()
+		return nil, fmt.Errorf("get returned %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	return resp.Body, nil
+}
+
+// s3NewRequest builds an http.Request targeting the given key, taking
+// virtual-hosted vs path-style into account.
+func s3NewRequest(ctx context.Context, method string, target s3Target, key string, query url.Values) (*http.Request, error) {
+	path := "/"
+	if target.PathStyle {
+		path = "/" + target.Bucket
+	}
+	if key != "" {
+		// Each key segment URI-encoded; "/" preserved between segments.
+		path = strings.TrimSuffix(path, "/") + "/" + s3EncodeKey(key)
+	}
+	u := url.URL{
+		Scheme: target.Scheme,
+		Host:   target.Host,
+		Path:   path,
+	}
+	if query != nil {
+		u.RawQuery = query.Encode()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	// Replace stdlib's RawPath/Path normalization; we want raw bytes to match
+	// what we sign.
+	req.URL.Opaque = ""
+	req.URL.RawPath = path
+	return req, nil
+}
+
+// s3ObjectURL builds a virtual-hosted-style public URL for the given key.
+// Used as AttrURL on findings.
+func s3ObjectURL(target s3Target, key string) string {
+	path := s3EncodeKey(key)
+	if target.PathStyle {
+		return fmt.Sprintf("%s://%s/%s/%s", target.Scheme, target.Host, target.Bucket, path)
+	}
+	return fmt.Sprintf("%s://%s/%s", target.Scheme, target.Host, path)
+}
+
+// ---------------------------------------------------------------------------
+// SigV4
+// ---------------------------------------------------------------------------
+
+// s3Sign signs the request in place using AWS Signature Version 4.
+// Anonymous requests skip signing entirely.
+//
+// Spec: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+func s3Sign(req *http.Request, body []byte, region string, creds s3Creds) error {
+	if creds.Anonymous {
+		return nil
+	}
+	if creds.AccessKey == "" || creds.SecretKey == "" {
+		return errors.New("missing credentials for signed request")
+	}
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	var payloadHash string
+	if len(body) == 0 {
+		// All our requests (list, get-object) have empty request bodies.
+		payloadHash = s3EmptyPayloadSHA256
+	} else {
+		sum := sha256.Sum256(body)
+		payloadHash = hex.EncodeToString(sum[:])
+	}
+
+	req.Header.Set("Host", req.Host)
+	if req.Header.Get("Host") == "" {
+		req.Header.Set("Host", req.URL.Host)
+	}
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+
+	canonicalHeaders, signedHeaders := s3CanonicalHeaders(req)
+	canonicalQuery := s3CanonicalQuery(req.URL.Query())
+	canonicalURI := s3CanonicalURI(req.URL.Path)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI,
+		canonicalQuery,
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, s3Service)
+	hashedCanonical := sha256.Sum256([]byte(canonicalRequest))
+	stringToSign := strings.Join([]string{
+		s3SignAlgorithm,
+		amzDate,
+		scope,
+		hex.EncodeToString(hashedCanonical[:]),
+	}, "\n")
+
+	signingKey := s3DeriveSigningKey(creds.SecretKey, dateStamp, region, s3Service)
+	signature := hex.EncodeToString(s3HMAC(signingKey, []byte(stringToSign)))
+
+	auth := fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		s3SignAlgorithm,
+		creds.AccessKey,
+		scope,
+		signedHeaders,
+		signature,
+	)
+	req.Header.Set("Authorization", auth)
+	return nil
+}
+
+func s3CanonicalHeaders(req *http.Request) (canonical, signed string) {
+	type kv struct{ k, v string }
+	var headers []kv
+	headers = append(headers, kv{"host", req.Host})
+	if req.Host == "" {
+		headers[0].v = req.URL.Host
+	}
+	for name, values := range req.Header {
+		lower := strings.ToLower(name)
+		if lower == "host" || lower == "authorization" {
+			continue
+		}
+		// Only sign x-amz-* and Content-* headers; this matches what the SDK does
+		// for typical S3 requests and avoids accidentally signing headers added by
+		// http.Client (Accept-Encoding, User-Agent).
+		if !strings.HasPrefix(lower, "x-amz-") && !strings.HasPrefix(lower, "content-") {
+			continue
+		}
+		headers = append(headers, kv{lower, strings.Join(values, ",")})
+	}
+	sort.Slice(headers, func(i, j int) bool { return headers[i].k < headers[j].k })
+
+	var cb, sb strings.Builder
+	for i, h := range headers {
+		cb.WriteString(h.k)
+		cb.WriteByte(':')
+		cb.WriteString(strings.TrimSpace(collapseWhitespace(h.v)))
+		cb.WriteByte('\n')
+		if i > 0 {
+			sb.WriteByte(';')
+		}
+		sb.WriteString(h.k)
+	}
+	return cb.String(), sb.String()
+}
+
+func collapseWhitespace(s string) string {
+	// AWS spec: convert sequential whitespace into a single space inside header values.
+	var b strings.Builder
+	var prevSpace bool
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\t' {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		prevSpace = false
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+func s3CanonicalQuery(values url.Values) string {
+	if len(values) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		vs := values[k]
+		sort.Strings(vs)
+		for j, v := range vs {
+			if i > 0 || j > 0 {
+				b.WriteByte('&')
+			}
+			b.WriteString(s3URIEncode(k, true))
+			b.WriteByte('=')
+			b.WriteString(s3URIEncode(v, true))
+		}
+	}
+	return b.String()
+}
+
+// s3CanonicalURI URI-encodes the path once (S3-style); "/" is preserved.
+func s3CanonicalURI(path string) string {
+	if path == "" {
+		return "/"
+	}
+	return s3URIEncode(path, false)
+}
+
+// s3EncodeKey URI-encodes a key, preserving "/" between segments. Used when
+// constructing request URLs (not for signing — signing uses s3CanonicalURI on
+// the full path).
+func s3EncodeKey(key string) string {
+	return s3URIEncode(key, false)
+}
+
+// s3URIEncode applies the AWS-spec URI encoding: unreserved chars (A-Z, a-z,
+// 0-9, '-', '_', '.', '~') pass through; everything else is percent-encoded.
+// When encodeSlash is false, '/' is preserved (used for path segments).
+func s3URIEncode(s string, encodeSlash bool) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'),
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		case c == '/' && !encodeSlash:
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+func s3DeriveSigningKey(secret, dateStamp, region, service string) []byte {
+	kDate := s3HMAC([]byte("AWS4"+secret), []byte(dateStamp))
+	kRegion := s3HMAC(kDate, []byte(region))
+	kService := s3HMAC(kRegion, []byte(service))
+	return s3HMAC(kService, []byte("aws4_request"))
+}
+
+func s3HMAC(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}

--- a/sources/s3.go
+++ b/sources/s3.go
@@ -424,12 +424,7 @@ func (s *S3) wrapYieldWithAttrs(attrs map[string]string, yield FragmentsFunc) Fr
 	}
 }
 
-// ---------------------------------------------------------------------------
-// URL parsing
-// ---------------------------------------------------------------------------
-
 // s3ParseURL accepts the documented URL forms and returns a populated s3Target.
-//
 // Globs are allowed in the bucket position only ("s3://<here>" or the first
 // path segment of path-style URLs). Globs in DNS hostnames (virtual-hosted AWS
 // or R2 forms) are rejected so users go through the explicit s3:// or
@@ -684,10 +679,6 @@ func s3ProbeAWSRegion(ctx context.Context, bucket string) (string, error) {
 	}
 	return region, nil
 }
-
-// ---------------------------------------------------------------------------
-// List + Get
-// ---------------------------------------------------------------------------
 
 // s3BucketEntry mirrors the <Bucket> element inside a ListAllMyBucketsResult.
 type s3BucketEntry struct {

--- a/sources/s3.go
+++ b/sources/s3.go
@@ -2,9 +2,6 @@ package sources
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -13,29 +10,29 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/fatih/semgroup"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/sigv4"
 )
 
 const (
 	s3DefaultMaxObjectSize int64 = 250 * 1024 * 1024 // 250 MiB
 	s3DefaultWorkers             = 16
-	s3GetObjectTimeout           = 30 * time.Second
-	s3ListPageSize               = 1000
-	s3Service                    = "s3"
-	s3SignAlgorithm              = "AWS4-HMAC-SHA256"
-	s3EmptyPayloadSHA256         = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	s3StorageClassGlacier        = "GLACIER"
-	s3StorageClassGlacierIR      = "GLACIER_IR"
-	s3StorageClassDeepArchive    = "DEEP_ARCHIVE"
+	// s3PerObjectTimeout covers the full per-object scan (HTTP GET + body
+	// read + content scanning). Sized for the default 250 MiB cap at modest
+	// bandwidth, with room for archive extraction.
+	s3PerObjectTimeout        = 5 * time.Minute
+	s3ListPageSize            = 1000
+	s3Service                 = "s3"
+	s3StorageClassGlacier     = "GLACIER"
+	s3StorageClassGlacierIR   = "GLACIER_IR"
+	s3StorageClassDeepArchive = "DEEP_ARCHIVE"
 )
 
 // S3 enumerates objects in an S3 (or S3-compatible) bucket and yields a
@@ -67,7 +64,6 @@ type S3 struct {
 	MaxObjectSize   int64
 	Workers         int
 	ShouldSkip      SkipFunc
-	Sema            *semgroup.Group
 	MaxArchiveDepth int
 
 	parsed s3Target
@@ -286,8 +282,8 @@ func (s *S3) scanBucket(ctx context.Context, client *http.Client, target s3Targe
 
 	start := time.Now()
 	var (
-		objectCount  int
-		scannedCount int
+		listedCount  int // every object returned by ListObjectsV2
+		scannedCount int // objects fully fetched + processed without error
 		mu           sync.Mutex
 	)
 
@@ -297,6 +293,7 @@ func (s *S3) scanBucket(ctx context.Context, client *http.Client, target s3Targe
 		if err != nil {
 			return fmt.Errorf("list objects: %w", err)
 		}
+		listedCount += len(page.Contents)
 
 		g, gctx := errgroup.WithContext(ctx)
 		g.SetLimit(workers)
@@ -310,7 +307,6 @@ func (s *S3) scanBucket(ctx context.Context, client *http.Client, target s3Targe
 				logging.Trace().Str("key", obj.Key).Msg("skipping object: filtered by prefilter")
 				continue
 			}
-			objectCount++
 			g.Go(func() error {
 				if err := s.scanObject(gctx, client, target, obj, attrs, yield); err != nil {
 					logging.Error().Err(err).Str("key", obj.Key).Msg("could not scan S3 object")
@@ -333,7 +329,7 @@ func (s *S3) scanBucket(ctx context.Context, client *http.Client, target s3Targe
 
 	logging.Info().
 		Str("bucket", target.Bucket).
-		Int("objects_listed", objectCount).
+		Int("objects_listed", listedCount).
 		Int("objects_scanned", scannedCount).
 		Str("duration", time.Since(start).Round(time.Millisecond).String()).
 		Msg("S3 scan complete")
@@ -382,7 +378,7 @@ func (s *S3) objectAttributes(target s3Target, obj s3Object) map[string]string {
 // scanObject GETs an object and pipes its body through File.Fragments, which
 // already handles archives, mime sniffing, and chunk boundaries.
 func (s *S3) scanObject(ctx context.Context, client *http.Client, target s3Target, obj s3Object, attrs map[string]string, yield FragmentsFunc) error {
-	objCtx, cancel := context.WithTimeout(ctx, s3GetObjectTimeout)
+	objCtx, cancel := context.WithTimeout(ctx, s3PerObjectTimeout)
 	defer cancel()
 
 	body, err := s3GetObject(objCtx, client, target, s.creds, obj.Key)
@@ -398,7 +394,7 @@ func (s *S3) scanObject(ctx context.Context, client *http.Client, target s3Targe
 		MaxArchiveDepth: s.MaxArchiveDepth,
 		ShouldSkip:      s.ShouldSkip,
 	}
-	return file.Fragments(ctx, stampedYield)
+	return file.Fragments(objCtx, stampedYield)
 }
 
 // wrapYieldWithAttrs returns a yield that stamps the given attrs on every
@@ -527,11 +523,28 @@ func parseAWSHostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
 	}
 	prefix := labels[:len(labels)-2]
 
-	// Virtual-hosted: bucket.s3[.region].amazonaws.com
+	// Reject accelerate / fips variants explicitly so users get a clear error
+	// rather than a hard-to-debug auth failure. The regional virtual-hosted
+	// form works for the same buckets.
+	for _, label := range prefix {
+		switch {
+		case label == "s3-accelerate", label == "s3-accelerate-fips":
+			return s3Target{}, fmt.Errorf("S3 Transfer Acceleration endpoint %q is not supported; use the regional form like bucket.s3.<region>.amazonaws.com", hostOnly)
+		case strings.HasPrefix(label, "s3-fips"):
+			return s3Target{}, fmt.Errorf("S3 FIPS endpoint %q is not supported; use the regional form like bucket.s3.<region>.amazonaws.com", hostOnly)
+		}
+	}
+
+	// Virtual-hosted: bucket.s3[.dualstack][.region].amazonaws.com
 	for i := 1; i < len(prefix); i++ {
 		if prefix[i] == "s3" {
 			bucket := strings.Join(prefix[:i], ".")
 			rest := prefix[i+1:]
+			// "dualstack" is an IPv6-capable qualifier that appears between
+			// "s3" and the region. Skip it; signing region is the one after.
+			if len(rest) >= 1 && rest[0] == "dualstack" {
+				rest = rest[1:]
+			}
 			region := ""
 			if len(rest) >= 1 {
 				region = rest[0]
@@ -550,11 +563,15 @@ func parseAWSHostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
 		}
 	}
 
-	// Path-style: s3[.region].amazonaws.com / bucket
+	// Path-style: s3[.dualstack][.region].amazonaws.com / bucket
 	if prefix[0] == "s3" {
+		rest := prefix[1:]
+		if len(rest) >= 1 && rest[0] == "dualstack" {
+			rest = rest[1:]
+		}
 		region := ""
-		if len(prefix) >= 2 {
-			region = prefix[1]
+		if len(rest) >= 1 {
+			region = rest[0]
 		}
 		bucket, bPrefix := splitBucketAndPrefix(path)
 		if bucket == "" {
@@ -808,23 +825,15 @@ func s3NewRequest(ctx context.Context, method string, target s3Target, key strin
 		// Each key segment URI-encoded; "/" preserved between segments.
 		path = strings.TrimSuffix(path, "/") + "/" + s3EncodeKey(key)
 	}
-	u := url.URL{
-		Scheme: target.Scheme,
-		Host:   target.Host,
-		Path:   path,
+	// Build the URL string directly so the percent-encoded path we computed is
+	// what hits the wire. Going through url.URL{Path: path}.String() would
+	// re-escape '%' into '%25' (double-encoding), invalidating the signature
+	// and routing for any key containing a non-unreserved character.
+	urlStr := target.Scheme + "://" + target.Host + path
+	if len(query) > 0 {
+		urlStr += "?" + query.Encode()
 	}
-	if query != nil {
-		u.RawQuery = query.Encode()
-	}
-	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-	// Replace stdlib's RawPath/Path normalization; we want raw bytes to match
-	// what we sign.
-	req.URL.Opaque = ""
-	req.URL.RawPath = path
-	return req, nil
+	return http.NewRequestWithContext(ctx, method, urlStr, nil)
 }
 
 // s3ObjectURL builds a virtual-hosted-style public URL for the given key.
@@ -837,206 +846,21 @@ func s3ObjectURL(target s3Target, key string) string {
 	return fmt.Sprintf("%s://%s/%s", target.Scheme, target.Host, path)
 }
 
-// ---------------------------------------------------------------------------
-// SigV4
-// ---------------------------------------------------------------------------
-
-// s3Sign signs the request in place using AWS Signature Version 4.
-// Anonymous requests skip signing entirely.
-//
-// Spec: https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+// s3Sign signs req using SigV4 (s3 service) unless creds are anonymous, in
+// which case it leaves the request unsigned for buckets with public read.
 func s3Sign(req *http.Request, body []byte, region string, creds s3Creds) error {
 	if creds.Anonymous {
 		return nil
 	}
-	if creds.AccessKey == "" || creds.SecretKey == "" {
-		return errors.New("missing credentials for signed request")
-	}
-	now := time.Now().UTC()
-	amzDate := now.Format("20060102T150405Z")
-	dateStamp := now.Format("20060102")
-
-	var payloadHash string
-	if len(body) == 0 {
-		// All our requests (list, get-object) have empty request bodies.
-		payloadHash = s3EmptyPayloadSHA256
-	} else {
-		sum := sha256.Sum256(body)
-		payloadHash = hex.EncodeToString(sum[:])
-	}
-
-	req.Header.Set("Host", req.Host)
-	if req.Header.Get("Host") == "" {
-		req.Header.Set("Host", req.URL.Host)
-	}
-	req.Header.Set("X-Amz-Date", amzDate)
-	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
-	if creds.SessionToken != "" {
-		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
-	}
-
-	canonicalHeaders, signedHeaders := s3CanonicalHeaders(req)
-	canonicalQuery := s3CanonicalQuery(req.URL.Query())
-	canonicalURI := s3CanonicalURI(req.URL.Path)
-
-	canonicalRequest := strings.Join([]string{
-		req.Method,
-		canonicalURI,
-		canonicalQuery,
-		canonicalHeaders,
-		signedHeaders,
-		payloadHash,
-	}, "\n")
-
-	scope := fmt.Sprintf("%s/%s/%s/aws4_request", dateStamp, region, s3Service)
-	hashedCanonical := sha256.Sum256([]byte(canonicalRequest))
-	stringToSign := strings.Join([]string{
-		s3SignAlgorithm,
-		amzDate,
-		scope,
-		hex.EncodeToString(hashedCanonical[:]),
-	}, "\n")
-
-	signingKey := s3DeriveSigningKey(creds.SecretKey, dateStamp, region, s3Service)
-	signature := hex.EncodeToString(s3HMAC(signingKey, []byte(stringToSign)))
-
-	auth := fmt.Sprintf(
-		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
-		s3SignAlgorithm,
-		creds.AccessKey,
-		scope,
-		signedHeaders,
-		signature,
-	)
-	req.Header.Set("Authorization", auth)
-	return nil
-}
-
-func s3CanonicalHeaders(req *http.Request) (canonical, signed string) {
-	type kv struct{ k, v string }
-	var headers []kv
-	headers = append(headers, kv{"host", req.Host})
-	if req.Host == "" {
-		headers[0].v = req.URL.Host
-	}
-	for name, values := range req.Header {
-		lower := strings.ToLower(name)
-		if lower == "host" || lower == "authorization" {
-			continue
-		}
-		// Only sign x-amz-* and Content-* headers; this matches what the SDK does
-		// for typical S3 requests and avoids accidentally signing headers added by
-		// http.Client (Accept-Encoding, User-Agent).
-		if !strings.HasPrefix(lower, "x-amz-") && !strings.HasPrefix(lower, "content-") {
-			continue
-		}
-		headers = append(headers, kv{lower, strings.Join(values, ",")})
-	}
-	sort.Slice(headers, func(i, j int) bool { return headers[i].k < headers[j].k })
-
-	var cb, sb strings.Builder
-	for i, h := range headers {
-		cb.WriteString(h.k)
-		cb.WriteByte(':')
-		cb.WriteString(strings.TrimSpace(collapseWhitespace(h.v)))
-		cb.WriteByte('\n')
-		if i > 0 {
-			sb.WriteByte(';')
-		}
-		sb.WriteString(h.k)
-	}
-	return cb.String(), sb.String()
-}
-
-func collapseWhitespace(s string) string {
-	// AWS spec: convert sequential whitespace into a single space inside header values.
-	var b strings.Builder
-	var prevSpace bool
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c == ' ' || c == '\t' {
-			if !prevSpace {
-				b.WriteByte(' ')
-				prevSpace = true
-			}
-			continue
-		}
-		prevSpace = false
-		b.WriteByte(c)
-	}
-	return b.String()
-}
-
-func s3CanonicalQuery(values url.Values) string {
-	if len(values) == 0 {
-		return ""
-	}
-	keys := make([]string, 0, len(values))
-	for k := range values {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	var b strings.Builder
-	for i, k := range keys {
-		vs := values[k]
-		sort.Strings(vs)
-		for j, v := range vs {
-			if i > 0 || j > 0 {
-				b.WriteByte('&')
-			}
-			b.WriteString(s3URIEncode(k, true))
-			b.WriteByte('=')
-			b.WriteString(s3URIEncode(v, true))
-		}
-	}
-	return b.String()
-}
-
-// s3CanonicalURI URI-encodes the path once (S3-style); "/" is preserved.
-func s3CanonicalURI(path string) string {
-	if path == "" {
-		return "/"
-	}
-	return s3URIEncode(path, false)
+	return sigv4.Sign(req, body, region, s3Service, sigv4.Credentials{
+		AccessKey:    creds.AccessKey,
+		SecretKey:    creds.SecretKey,
+		SessionToken: creds.SessionToken,
+	})
 }
 
 // s3EncodeKey URI-encodes a key, preserving "/" between segments. Used when
-// constructing request URLs (not for signing — signing uses s3CanonicalURI on
-// the full path).
+// constructing request URLs.
 func s3EncodeKey(key string) string {
-	return s3URIEncode(key, false)
-}
-
-// s3URIEncode applies the AWS-spec URI encoding: unreserved chars (A-Z, a-z,
-// 0-9, '-', '_', '.', '~') pass through; everything else is percent-encoded.
-// When encodeSlash is false, '/' is preserved (used for path segments).
-func s3URIEncode(s string, encodeSlash bool) string {
-	var b strings.Builder
-	b.Grow(len(s))
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'),
-			c == '-', c == '_', c == '.', c == '~':
-			b.WriteByte(c)
-		case c == '/' && !encodeSlash:
-			b.WriteByte(c)
-		default:
-			fmt.Fprintf(&b, "%%%02X", c)
-		}
-	}
-	return b.String()
-}
-
-func s3DeriveSigningKey(secret, dateStamp, region, service string) []byte {
-	kDate := s3HMAC([]byte("AWS4"+secret), []byte(dateStamp))
-	kRegion := s3HMAC(kDate, []byte(region))
-	kService := s3HMAC(kRegion, []byte(service))
-	return s3HMAC(kService, []byte("aws4_request"))
-}
-
-func s3HMAC(key, data []byte) []byte {
-	h := hmac.New(sha256.New, key)
-	h.Write(data)
-	return h.Sum(nil)
+	return sigv4.URIEncode(key, false)
 }

--- a/sources/s3.go
+++ b/sources/s3.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -76,15 +77,20 @@ type S3 struct {
 // s3Target captures everything the request builder needs after URL parsing.
 type s3Target struct {
 	Scheme        string // "https" or "http"
-	Host          string // request host (with bucket subdomain for virtual-hosted)
-	Bucket        string
+	Host          string // request host. For virtual-hosted single-bucket, includes the bucket subdomain. In enumerate mode, this is the endpoint without any bucket prefix.
+	Bucket        string // exact bucket name (single-bucket mode)
+	BucketGlob    string // glob pattern in enumerate mode (e.g. "*", "prod-*")
 	Prefix        string
 	Region        string // may be "" pre-probe for AWS forms missing region
 	PathStyle     bool
-	IsAWS         bool   // true for *.amazonaws.com and s3:// scheme
-	RequiresProbe bool   // AWS hosts where region was not in the URL
-	Endpoint      string // descriptive endpoint label for logging / attrs
+	IsAWS         bool // true for *.amazonaws.com and s3:// scheme
+	RequiresProbe bool // AWS hosts where region was not in the URL
+	Endpoint      string
 }
+
+// IsEnumerate reports whether the target is a bucket-enumeration target rather
+// than a single-bucket target.
+func (t s3Target) IsEnumerate() bool { return t.BucketGlob != "" }
 
 // s3Creds holds resolved request-signing credentials.
 type s3Creds struct {
@@ -94,8 +100,9 @@ type s3Creds struct {
 	Anonymous    bool
 }
 
-// Validate parses the URL, resolves credentials, and (for AWS targets without
-// an explicit region) probes the bucket region.
+// Validate parses the URL, resolves credentials, and (for AWS single-bucket
+// targets without an explicit region) probes the bucket region. In enumerate
+// mode, region resolution is deferred to scan time on a per-bucket basis.
 func (s *S3) Validate() error {
 	if s.URL == "" {
 		return errors.New("target URL is required")
@@ -108,14 +115,21 @@ func (s *S3) Validate() error {
 		target.Region = s.Region
 		target.RequiresProbe = false
 	}
-	if target.Region == "" && target.RequiresProbe && target.IsAWS {
+	switch {
+	case target.IsEnumerate() && target.IsAWS && target.Region == "":
+		// ListBuckets is account-scoped; us-east-1 is the conventional default
+		// for SigV4 scope. Per-bucket region is resolved later.
+		target.Region = "us-east-1"
+		target.RequiresProbe = false
+	case target.RequiresProbe && target.IsAWS && target.Region == "":
 		region, err := s3ProbeAWSRegion(context.Background(), target.Bucket)
 		if err != nil {
 			return fmt.Errorf("could not determine bucket region (pass --region): %w", err)
 		}
 		target.Region = region
-		// AWS virtual-hosted host with the resolved region.
-		target.Host = fmt.Sprintf("%s.s3.%s.amazonaws.com", target.Bucket, region)
+		if !target.PathStyle {
+			target.Host = fmt.Sprintf("%s.s3.%s.amazonaws.com", target.Bucket, region)
+		}
 		target.RequiresProbe = false
 	}
 	if target.Region == "" {
@@ -160,14 +174,87 @@ func (s *S3) resolveCreds() (s3Creds, error) {
 	return s3Creds{}, errors.New("no credentials: set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY, pass --access-key/--secret-key, or pass --anonymous")
 }
 
-// Fragments enumerates objects under the configured prefix and yields content
-// fragments for each one.
+// Fragments dispatches to single-bucket or enumerate-mode scanning based on
+// the parsed URL.
 func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
-	if s.parsed.Bucket == "" {
+	if s.parsed.Bucket == "" && s.parsed.BucketGlob == "" {
 		if err := s.Validate(); err != nil {
 			return err
 		}
 	}
+	httpClient := &http.Client{}
+	if s.parsed.IsEnumerate() {
+		return s.scanEnumerated(ctx, httpClient, yield)
+	}
+	return s.scanBucket(ctx, httpClient, s.parsed, yield)
+}
+
+// scanEnumerated lists buckets at the endpoint, filters by glob, and scans
+// each matched bucket. Per-bucket failures (e.g. AccessDenied, region probe
+// errors) are logged and non-fatal.
+func (s *S3) scanEnumerated(ctx context.Context, client *http.Client, yield FragmentsFunc) error {
+	logging.Info().
+		Str("endpoint", s.parsed.Endpoint).
+		Str("bucket_glob", s.parsed.BucketGlob).
+		Str("region", s.parsed.Region).
+		Msg("enumerating buckets")
+
+	buckets, err := s3ListAllBuckets(ctx, client, s.parsed, s.creds)
+	if err != nil {
+		return fmt.Errorf("list buckets: %w", err)
+	}
+
+	var matched []string
+	for _, b := range buckets {
+		ok, err := path.Match(s.parsed.BucketGlob, b)
+		if err != nil {
+			return fmt.Errorf("invalid bucket glob %q: %w", s.parsed.BucketGlob, err)
+		}
+		if ok {
+			matched = append(matched, b)
+		}
+	}
+	logging.Info().Int("total", len(buckets)).Int("matched", len(matched)).Msg("bucket enumeration complete")
+
+	for _, b := range matched {
+		sub, err := s.bucketSubTarget(ctx, b)
+		if err != nil {
+			logging.Error().Err(err).Str("bucket", b).Msg("could not resolve bucket; skipping")
+			continue
+		}
+		if err := s.scanBucket(ctx, client, sub, yield); err != nil {
+			logging.Error().Err(err).Str("bucket", b).Msg("bucket scan failed; continuing")
+		}
+	}
+	return nil
+}
+
+// bucketSubTarget builds a single-bucket target derived from the enumerate
+// target. For AWS, this probes the bucket's region (which may differ from the
+// account's default).
+func (s *S3) bucketSubTarget(ctx context.Context, bucket string) (s3Target, error) {
+	sub := s.parsed
+	sub.Bucket = bucket
+	sub.BucketGlob = ""
+
+	if sub.IsAWS {
+		region, err := s3ProbeAWSRegion(ctx, bucket)
+		if err != nil {
+			return s3Target{}, fmt.Errorf("probe region: %w", err)
+		}
+		sub.Region = region
+		if sub.PathStyle {
+			sub.Host = fmt.Sprintf("s3.%s.amazonaws.com", region)
+		} else {
+			sub.Host = fmt.Sprintf("%s.s3.%s.amazonaws.com", bucket, region)
+		}
+	}
+	return sub, nil
+}
+
+// scanBucket runs the list-then-fetch loop for a single bucket described by
+// target.
+func (s *S3) scanBucket(ctx context.Context, client *http.Client, target s3Target, yield FragmentsFunc) error {
 	maxSize := s.MaxObjectSize
 	if maxSize <= 0 {
 		maxSize = s3DefaultMaxObjectSize
@@ -178,26 +265,25 @@ func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	}
 
 	bucketAttrs := map[string]string{
-		AttrS3Bucket: s.parsed.Bucket,
-		AttrS3Region: s.parsed.Region,
+		AttrS3Bucket: target.Bucket,
+		AttrS3Region: target.Region,
 		AttrResource: ResourceS3Object,
 	}
-	if s.parsed.Endpoint != "" {
-		bucketAttrs[AttrS3Endpoint] = s.parsed.Endpoint
+	if target.Endpoint != "" {
+		bucketAttrs[AttrS3Endpoint] = target.Endpoint
 	}
 	if s.ShouldSkip != nil && s.ShouldSkip(bucketAttrs) {
-		logging.Info().Str("bucket", s.parsed.Bucket).Msg("skipping bucket: filtered by prefilter")
+		logging.Info().Str("bucket", target.Bucket).Msg("skipping bucket: filtered by prefilter")
 		return nil
 	}
 
 	logging.Info().
-		Str("bucket", s.parsed.Bucket).
-		Str("region", s.parsed.Region).
-		Str("prefix", s.parsed.Prefix).
-		Str("endpoint", s.parsed.Endpoint).
+		Str("bucket", target.Bucket).
+		Str("region", target.Region).
+		Str("prefix", target.Prefix).
+		Str("endpoint", target.Endpoint).
 		Msg("starting S3 scan")
 
-	httpClient := &http.Client{}
 	start := time.Now()
 	var (
 		objectCount  int
@@ -207,7 +293,7 @@ func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
 
 	var continuationToken string
 	for {
-		page, err := s3ListPage(ctx, httpClient, s.parsed, s.creds, s.parsed.Prefix, continuationToken)
+		page, err := s3ListPage(ctx, client, target, s.creds, target.Prefix, continuationToken)
 		if err != nil {
 			return fmt.Errorf("list objects: %w", err)
 		}
@@ -219,14 +305,14 @@ func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
 				logging.Trace().Str("key", obj.Key).Str("reason", skipReason).Msg("skipping object")
 				continue
 			}
-			attrs := s.objectAttributes(obj)
+			attrs := s.objectAttributes(target, obj)
 			if s.ShouldSkip != nil && s.ShouldSkip(attrs) {
 				logging.Trace().Str("key", obj.Key).Msg("skipping object: filtered by prefilter")
 				continue
 			}
 			objectCount++
 			g.Go(func() error {
-				if err := s.scanObject(gctx, httpClient, obj, attrs, yield); err != nil {
+				if err := s.scanObject(gctx, client, target, obj, attrs, yield); err != nil {
 					logging.Error().Err(err).Str("key", obj.Key).Msg("could not scan S3 object")
 					return nil
 				}
@@ -246,6 +332,7 @@ func (s *S3) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	}
 
 	logging.Info().
+		Str("bucket", target.Bucket).
 		Int("objects_listed", objectCount).
 		Int("objects_scanned", scannedCount).
 		Str("duration", time.Since(start).Round(time.Millisecond).String()).
@@ -273,32 +360,32 @@ func (s *S3) skipReason(obj s3Object, maxSize int64) string {
 }
 
 // objectAttributes builds the attr map stamped on every fragment for this object.
-func (s *S3) objectAttributes(obj s3Object) map[string]string {
+func (s *S3) objectAttributes(target s3Target, obj s3Object) map[string]string {
 	attrs := map[string]string{
 		AttrPath:           obj.Key,
-		AttrURL:            s3ObjectURL(s.parsed, obj.Key),
+		AttrURL:            s3ObjectURL(target, obj.Key),
 		AttrResource:       ResourceS3Object,
-		AttrS3Bucket:       s.parsed.Bucket,
+		AttrS3Bucket:       target.Bucket,
 		AttrS3Key:          obj.Key,
-		AttrS3Region:       s.parsed.Region,
+		AttrS3Region:       target.Region,
 		AttrS3Size:         strconv.FormatInt(obj.Size, 10),
 		AttrS3ETag:         strings.Trim(obj.ETag, `"`),
 		AttrS3LastModified: obj.LastModified,
 		AttrS3StorageClass: obj.StorageClass,
 	}
-	if s.parsed.Endpoint != "" {
-		attrs[AttrS3Endpoint] = s.parsed.Endpoint
+	if target.Endpoint != "" {
+		attrs[AttrS3Endpoint] = target.Endpoint
 	}
 	return attrs
 }
 
 // scanObject GETs an object and pipes its body through File.Fragments, which
 // already handles archives, mime sniffing, and chunk boundaries.
-func (s *S3) scanObject(ctx context.Context, client *http.Client, obj s3Object, attrs map[string]string, yield FragmentsFunc) error {
+func (s *S3) scanObject(ctx context.Context, client *http.Client, target s3Target, obj s3Object, attrs map[string]string, yield FragmentsFunc) error {
 	objCtx, cancel := context.WithTimeout(ctx, s3GetObjectTimeout)
 	defer cancel()
 
-	body, err := s3GetObject(objCtx, client, s.parsed, s.creds, obj.Key)
+	body, err := s3GetObject(objCtx, client, target, s.creds, obj.Key)
 	if err != nil {
 		return err
 	}
@@ -346,6 +433,11 @@ func (s *S3) wrapYieldWithAttrs(attrs map[string]string, yield FragmentsFunc) Fr
 // ---------------------------------------------------------------------------
 
 // s3ParseURL accepts the documented URL forms and returns a populated s3Target.
+//
+// Globs are allowed in the bucket position only ("s3://<here>" or the first
+// path segment of path-style URLs). Globs in DNS hostnames (virtual-hosted AWS
+// or R2 forms) are rejected so users go through the explicit s3:// or
+// path-style forms for enumeration.
 func s3ParseURL(raw string) (s3Target, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -356,15 +448,21 @@ func s3ParseURL(raw string) (s3Target, error) {
 		if u.Host == "" {
 			return s3Target{}, errors.New("s3:// URL is missing bucket")
 		}
-		return s3Target{
+		t := s3Target{
 			Scheme:        "https",
-			Host:          fmt.Sprintf("%s.s3.amazonaws.com", u.Host),
-			Bucket:        u.Host,
 			Prefix:        strings.TrimPrefix(u.Path, "/"),
 			IsAWS:         true,
 			RequiresProbe: true,
 			Endpoint:      "s3.amazonaws.com",
-		}, nil
+		}
+		if s3IsGlob(u.Host) {
+			t.BucketGlob = u.Host
+			t.Host = "s3.amazonaws.com"
+		} else {
+			t.Bucket = u.Host
+			t.Host = fmt.Sprintf("%s.s3.amazonaws.com", u.Host)
+		}
+		return t, nil
 	case "http", "https":
 		// fall through
 	default:
@@ -375,6 +473,9 @@ func s3ParseURL(raw string) (s3Target, error) {
 	hostOnly := host
 	if i := strings.IndexByte(hostOnly, ':'); i >= 0 {
 		hostOnly = hostOnly[:i]
+	}
+	if s3IsGlob(hostOnly) {
+		return s3Target{}, errors.New("glob is not allowed in the hostname; use s3://<glob> or path-style https://endpoint/<glob>")
 	}
 	path := strings.TrimPrefix(u.Path, "/")
 
@@ -389,15 +490,27 @@ func s3ParseURL(raw string) (s3Target, error) {
 		if bucket == "" {
 			return s3Target{}, errors.New("path-style URL is missing bucket segment")
 		}
-		return s3Target{
+		t := s3Target{
 			Scheme:    u.Scheme,
 			Host:      host,
-			Bucket:    bucket,
 			Prefix:    prefix,
 			PathStyle: true,
 			Endpoint:  host,
-		}, nil
+		}
+		if s3IsGlob(bucket) {
+			t.BucketGlob = bucket
+		} else {
+			t.Bucket = bucket
+		}
+		return t, nil
 	}
+}
+
+// s3IsGlob reports whether s contains glob metacharacters. Real S3 bucket names
+// cannot contain '*', '?', or '[', so any of these unambiguously signals
+// enumeration mode.
+func s3IsGlob(s string) bool {
+	return strings.ContainsAny(s, "*?[")
 }
 
 // parseAWSHostURL handles the AWS-hosted forms:
@@ -447,17 +560,22 @@ func parseAWSHostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
 		if bucket == "" {
 			return s3Target{}, errors.New("path-style amazonaws.com URL is missing bucket segment")
 		}
-		return s3Target{
+		t := s3Target{
 			Scheme:        u.Scheme,
 			Host:          u.Host,
-			Bucket:        bucket,
 			Prefix:        bPrefix,
 			Region:        region,
 			PathStyle:     true,
 			IsAWS:         true,
 			RequiresProbe: region == "",
 			Endpoint:      hostOnly,
-		}, nil
+		}
+		if s3IsGlob(bucket) {
+			t.BucketGlob = bucket
+		} else {
+			t.Bucket = bucket
+		}
+		return t, nil
 	}
 
 	return s3Target{}, fmt.Errorf("unrecognized amazonaws.com host %q", hostOnly)
@@ -490,16 +608,21 @@ func parseR2HostURL(u *url.URL, hostOnly, path string) (s3Target, error) {
 	if bucket == "" {
 		return s3Target{}, errors.New("r2 URL is missing bucket segment")
 	}
-	return s3Target{
+	t := s3Target{
 		Scheme:    u.Scheme,
 		Host:      u.Host,
-		Bucket:    bucket,
 		Prefix:    bPrefix,
 		Region:    "auto",
 		PathStyle: true,
 		IsAWS:     false,
 		Endpoint:  hostOnly,
-	}, nil
+	}
+	if s3IsGlob(bucket) {
+		t.BucketGlob = bucket
+	} else {
+		t.Bucket = bucket
+	}
+	return t, nil
 }
 
 // splitBucketAndPrefix splits a path of the form "bucket/prefix..." into its parts.
@@ -548,6 +671,56 @@ func s3ProbeAWSRegion(ctx context.Context, bucket string) (string, error) {
 // ---------------------------------------------------------------------------
 // List + Get
 // ---------------------------------------------------------------------------
+
+// s3BucketEntry mirrors the <Bucket> element inside a ListAllMyBucketsResult.
+type s3BucketEntry struct {
+	Name         string `xml:"Name"`
+	CreationDate string `xml:"CreationDate"`
+}
+
+type s3ListAllMyBucketsResult struct {
+	XMLName xml.Name        `xml:"ListAllMyBucketsResult"`
+	Buckets []s3BucketEntry `xml:"Buckets>Bucket"`
+}
+
+// s3ListAllBuckets issues GET / against the endpoint host (no bucket subdomain
+// or path segment) and returns the bucket names. Requires the
+// s3:ListAllMyBuckets permission on AWS; non-AWS providers have equivalent
+// account-level credentials.
+func s3ListAllBuckets(ctx context.Context, client *http.Client, target s3Target, creds s3Creds) ([]string, error) {
+	// Build a target that addresses the endpoint root: same host as the
+	// enumerate target, no bucket path segment.
+	endpointTarget := target
+	endpointTarget.Bucket = ""
+	endpointTarget.BucketGlob = ""
+	endpointTarget.PathStyle = false // request path stays "/" with no bucket prefix
+
+	req, err := s3NewRequest(ctx, http.MethodGet, endpointTarget, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := s3Sign(req, nil, target.Region, creds); err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("list-buckets returned %s: %s", resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	var result s3ListAllMyBucketsResult
+	if err := xml.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode list-buckets response: %w", err)
+	}
+	names := make([]string, 0, len(result.Buckets))
+	for _, b := range result.Buckets {
+		names = append(names, b.Name)
+	}
+	return names, nil
+}
 
 type s3Object struct {
 	Key          string `xml:"Key"`

--- a/sources/s3_test.go
+++ b/sources/s3_test.go
@@ -1,0 +1,385 @@
+package sources
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3ParseURL(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		want      s3Target
+		expectErr bool
+	}{
+		{
+			name: "s3 scheme bucket only",
+			raw:  "s3://my-bucket",
+			want: s3Target{
+				Scheme: "https", Host: "my-bucket.s3.amazonaws.com",
+				Bucket: "my-bucket", Prefix: "",
+				IsAWS: true, RequiresProbe: true,
+				Endpoint: "s3.amazonaws.com",
+			},
+		},
+		{
+			name: "s3 scheme bucket with prefix",
+			raw:  "s3://my-bucket/logs/2024",
+			want: s3Target{
+				Scheme: "https", Host: "my-bucket.s3.amazonaws.com",
+				Bucket: "my-bucket", Prefix: "logs/2024",
+				IsAWS: true, RequiresProbe: true,
+				Endpoint: "s3.amazonaws.com",
+			},
+		},
+		{
+			name: "virtual-hosted no region",
+			raw:  "https://my-bucket.s3.amazonaws.com/foo/",
+			want: s3Target{
+				Scheme: "https", Host: "my-bucket.s3.amazonaws.com",
+				Bucket: "my-bucket", Prefix: "foo/",
+				IsAWS: true, RequiresProbe: true,
+				Endpoint: "my-bucket.s3.amazonaws.com",
+			},
+		},
+		{
+			name: "virtual-hosted with region",
+			raw:  "https://my-bucket.s3.us-west-2.amazonaws.com/foo",
+			want: s3Target{
+				Scheme: "https", Host: "my-bucket.s3.us-west-2.amazonaws.com",
+				Bucket: "my-bucket", Prefix: "foo",
+				Region: "us-west-2", IsAWS: true,
+				Endpoint: "my-bucket.s3.us-west-2.amazonaws.com",
+			},
+		},
+		{
+			name: "path-style with region",
+			raw:  "https://s3.us-east-1.amazonaws.com/mybucket/x/y",
+			want: s3Target{
+				Scheme: "https", Host: "s3.us-east-1.amazonaws.com",
+				Bucket: "mybucket", Prefix: "x/y",
+				Region: "us-east-1", PathStyle: true, IsAWS: true,
+				Endpoint: "s3.us-east-1.amazonaws.com",
+			},
+		},
+		{
+			name: "path-style legacy global endpoint",
+			raw:  "https://s3.amazonaws.com/mybucket/x",
+			want: s3Target{
+				Scheme: "https", Host: "s3.amazonaws.com",
+				Bucket: "mybucket", Prefix: "x",
+				PathStyle: true, IsAWS: true, RequiresProbe: true,
+				Endpoint: "s3.amazonaws.com",
+			},
+		},
+		{
+			name: "r2 virtual-hosted",
+			raw:  "https://mybucket.acct123.r2.cloudflarestorage.com/some/prefix",
+			want: s3Target{
+				Scheme: "https", Host: "mybucket.acct123.r2.cloudflarestorage.com",
+				Bucket: "mybucket", Prefix: "some/prefix",
+				Region: "auto", Endpoint: "mybucket.acct123.r2.cloudflarestorage.com",
+			},
+		},
+		{
+			name: "r2 path-style",
+			raw:  "https://acct123.r2.cloudflarestorage.com/mybucket/x",
+			want: s3Target{
+				Scheme: "https", Host: "acct123.r2.cloudflarestorage.com",
+				Bucket: "mybucket", Prefix: "x",
+				Region: "auto", PathStyle: true,
+				Endpoint: "acct123.r2.cloudflarestorage.com",
+			},
+		},
+		{
+			name: "generic minio with port",
+			raw:  "http://localhost:9000/mybucket/prefix",
+			want: s3Target{
+				Scheme: "http", Host: "localhost:9000",
+				Bucket: "mybucket", Prefix: "prefix",
+				PathStyle: true, Endpoint: "localhost:9000",
+			},
+		},
+		{
+			name: "bucket with dots virtual-hosted",
+			raw:  "https://bucket.with.dots.s3.amazonaws.com/",
+			want: s3Target{
+				Scheme: "https", Host: "bucket.with.dots.s3.amazonaws.com",
+				Bucket: "bucket.with.dots", Prefix: "",
+				IsAWS: true, RequiresProbe: true,
+				Endpoint: "bucket.with.dots.s3.amazonaws.com",
+			},
+		},
+		{name: "empty s3 host", raw: "s3:///foo", expectErr: true},
+		{name: "path-style no bucket", raw: "https://s3.us-west-2.amazonaws.com/", expectErr: true},
+		{name: "generic no bucket", raw: "https://example.com/", expectErr: true},
+		{name: "bad scheme", raw: "ftp://host/bucket", expectErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := s3ParseURL(tc.raw)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestS3DeriveSigningKey checks the SigV4 key derivation against AWS's published
+// example (https://docs.aws.amazon.com/IAM/latest/UserGuide/signature-v4-examples.html).
+func TestS3DeriveSigningKey(t *testing.T) {
+	got := s3DeriveSigningKey(
+		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+		"20150830", "us-east-1", "iam",
+	)
+	const want = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
+	assert.Equal(t, want, hex.EncodeToString(got))
+}
+
+func TestS3URIEncode(t *testing.T) {
+	cases := []struct {
+		in          string
+		encodeSlash bool
+		want        string
+	}{
+		{"foo/bar.txt", false, "foo/bar.txt"},
+		{"foo/bar.txt", true, "foo%2Fbar.txt"},
+		{"hello world", false, "hello%20world"},
+		{"a+b=c", false, "a%2Bb%3Dc"},
+		{"unicode-café", false, "unicode-caf%C3%A9"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			assert.Equal(t, tc.want, s3URIEncode(tc.in, tc.encodeSlash))
+		})
+	}
+}
+
+func TestS3Sign_producesExpectedAuthorizationStructure(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://mybucket.s3.us-east-1.amazonaws.com/?list-type=2", nil)
+	require.NoError(t, err)
+	creds := s3Creds{AccessKey: "AKIAIOSFODNN7EXAMPLE", SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"}
+	require.NoError(t, s3Sign(req, nil, "us-east-1", creds))
+
+	auth := req.Header.Get("Authorization")
+	require.True(t, strings.HasPrefix(auth, s3SignAlgorithm+" "), "auth prefix: %q", auth)
+	require.Contains(t, auth, "Credential=AKIAIOSFODNN7EXAMPLE/")
+	require.Contains(t, auth, "/us-east-1/s3/aws4_request")
+	require.Contains(t, auth, "SignedHeaders=")
+	require.Contains(t, auth, "Signature=")
+	require.Equal(t, s3EmptyPayloadSHA256, req.Header.Get("X-Amz-Content-Sha256"))
+	require.NotEmpty(t, req.Header.Get("X-Amz-Date"))
+}
+
+func TestS3Sign_anonymousSkipsSigning(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "https://b.s3.amazonaws.com/", nil)
+	require.NoError(t, err)
+	require.NoError(t, s3Sign(req, nil, "us-east-1", s3Creds{Anonymous: true}))
+	assert.Empty(t, req.Header.Get("Authorization"))
+	assert.Empty(t, req.Header.Get("X-Amz-Date"))
+}
+
+func TestS3_resolveCreds(t *testing.T) {
+	t.Run("anonymous", func(t *testing.T) {
+		s := &S3{Anonymous: true}
+		c, err := s.resolveCreds()
+		require.NoError(t, err)
+		assert.True(t, c.Anonymous)
+	})
+	t.Run("explicit", func(t *testing.T) {
+		s := &S3{AccessKey: "ak", SecretKey: "sk", SessionToken: "tok"}
+		c, err := s.resolveCreds()
+		require.NoError(t, err)
+		assert.Equal(t, s3Creds{AccessKey: "ak", SecretKey: "sk", SessionToken: "tok"}, c)
+	})
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "envak")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "envsk")
+		t.Setenv("AWS_SESSION_TOKEN", "envtok")
+		s := &S3{}
+		c, err := s.resolveCreds()
+		require.NoError(t, err)
+		assert.Equal(t, s3Creds{AccessKey: "envak", SecretKey: "envsk", SessionToken: "envtok"}, c)
+	})
+	t.Run("none fails loud", func(t *testing.T) {
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+		s := &S3{}
+		_, err := s.resolveCreds()
+		require.Error(t, err)
+	})
+}
+
+func TestS3_skipReason(t *testing.T) {
+	s := &S3{}
+	const max = 100
+	cases := []struct {
+		name string
+		obj  s3Object
+		want string
+	}{
+		{"glacier", s3Object{Key: "k", Size: 10, StorageClass: s3StorageClassGlacier}, "storage_class:GLACIER"},
+		{"deep archive", s3Object{Key: "k", Size: 10, StorageClass: s3StorageClassDeepArchive}, "storage_class:DEEP_ARCHIVE"},
+		{"over max", s3Object{Key: "k", Size: 200}, "size_limit"},
+		{"empty", s3Object{Key: "k", Size: 0}, "empty"},
+		{"directory marker", s3Object{Key: "logs/", Size: 10}, "directory"},
+		{"normal object", s3Object{Key: "logs/x.txt", Size: 10, StorageClass: "STANDARD"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, s.skipReason(tc.obj, max))
+		})
+	}
+}
+
+// TestS3_listsAndScans_endToEnd points the source at an httptest server that
+// behaves like a minimal S3-compatible endpoint with two list pages and two
+// scannable objects.
+func TestS3_listsAndScans_endToEnd(t *testing.T) {
+	objects := map[string]string{
+		"a.txt": "alpha-content",
+		"b.txt": "AKIAIOSFODNN7EXAMPLE bravo-content", // contains an AWS-key-shaped string
+	}
+
+	page1 := s3ListBucketResult{
+		Name: "mybucket", KeyCount: 1, MaxKeys: 1, IsTruncated: true,
+		NextContinuationToken: "tok1",
+		Contents: []s3Object{
+			{Key: "a.txt", Size: int64(len(objects["a.txt"])), ETag: `"etag-a"`, LastModified: "2024-01-01T00:00:00Z", StorageClass: "STANDARD"},
+		},
+	}
+	page2 := s3ListBucketResult{
+		Name: "mybucket", KeyCount: 1, MaxKeys: 1, IsTruncated: false,
+		Contents: []s3Object{
+			{Key: "b.txt", Size: int64(len(objects["b.txt"])), ETag: `"etag-b"`, LastModified: "2024-01-02T00:00:00Z", StorageClass: "STANDARD"},
+		},
+	}
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Every request must be signed.
+		require.NotEmpty(t, r.Header.Get("Authorization"), "missing auth on %s %s", r.Method, r.URL)
+
+		if r.URL.Query().Get("list-type") == "2" {
+			w.Header().Set("Content-Type", "application/xml")
+			if r.URL.Query().Get("continuation-token") == "tok1" {
+				require.NoError(t, xml.NewEncoder(w).Encode(page2))
+				return
+			}
+			require.NoError(t, xml.NewEncoder(w).Encode(page1))
+			return
+		}
+		// GET object: path is "/<bucket>/<key>" for path-style.
+		// strip "/mybucket/"
+		key := strings.TrimPrefix(r.URL.Path, "/mybucket/")
+		body, ok := objects[key]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	s := &S3{
+		URL:       fmt.Sprintf("%s/mybucket/", srv.URL),
+		Region:    "us-east-1",
+		AccessKey: "AKIAIOSFODNN7EXAMPLE",
+		SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+	}
+	require.NoError(t, s.Validate())
+	assert.Equal(t, "mybucket", s.parsed.Bucket)
+	assert.True(t, s.parsed.PathStyle)
+	assert.Equal(t, u.Host, s.parsed.Host)
+
+	var mu sync.Mutex
+	var keys []string
+	attrsByKey := map[string]map[string]string{}
+	err := s.Fragments(context.Background(), func(f Fragment, err error) error {
+		require.NoError(t, err)
+		mu.Lock()
+		defer mu.Unlock()
+		key := f.Attr(AttrS3Key)
+		keys = append(keys, key)
+		attrsByKey[key] = f.Attributes
+		return nil
+	})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"a.txt", "b.txt"}, keys)
+
+	for _, k := range []string{"a.txt", "b.txt"} {
+		a := attrsByKey[k]
+		assert.Equal(t, "mybucket", a[AttrS3Bucket])
+		assert.Equal(t, "us-east-1", a[AttrS3Region])
+		assert.Equal(t, "s3.object", a[AttrResource])
+		assert.Equal(t, k, a[AttrPath])
+		assert.NotEmpty(t, a[AttrURL])
+	}
+}
+
+func TestS3_prefilterSkipsBucket(t *testing.T) {
+	// httptest server that fails the test if it is ever hit; the prefilter must
+	// short-circuit before any S3 request is made.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request %s %s", r.Method, r.URL)
+	}))
+	defer srv.Close()
+	s := &S3{
+		URL:       fmt.Sprintf("%s/mybucket/", srv.URL),
+		Region:    "us-east-1",
+		AccessKey: "ak", SecretKey: "sk",
+		ShouldSkip: func(attrs map[string]string) bool {
+			return attrs[AttrS3Bucket] == "mybucket"
+		},
+	}
+	require.NoError(t, s.Validate())
+	require.NoError(t, s.Fragments(context.Background(), func(Fragment, error) error {
+		t.Fatal("yield called for skipped bucket")
+		return nil
+	}))
+}
+
+func TestS3_skipsBeforeFetch(t *testing.T) {
+	listResp := s3ListBucketResult{
+		Name: "mybucket",
+		Contents: []s3Object{
+			{Key: "glacier.txt", Size: 100, StorageClass: s3StorageClassGlacier},
+			{Key: "huge.bin", Size: 10_000_000_000, StorageClass: "STANDARD"},
+			{Key: "empty.txt", Size: 0, StorageClass: "STANDARD"},
+			{Key: "dir/", Size: 0, StorageClass: "STANDARD"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("list-type") == "2" {
+			require.NoError(t, xml.NewEncoder(w).Encode(listResp))
+			return
+		}
+		t.Fatalf("unexpected GET for %s", r.URL)
+	}))
+	defer srv.Close()
+	s := &S3{
+		URL:       fmt.Sprintf("%s/mybucket/", srv.URL),
+		Region:    "us-east-1",
+		AccessKey: "ak", SecretKey: "sk",
+	}
+	require.NoError(t, s.Validate())
+	require.NoError(t, s.Fragments(context.Background(), func(Fragment, error) error {
+		t.Fatal("no objects should be yielded")
+		return nil
+	}))
+}

--- a/sources/s3_test.go
+++ b/sources/s3_test.go
@@ -2,7 +2,6 @@ package sources
 
 import (
 	"context"
-	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -121,10 +120,32 @@ func TestS3ParseURL(t *testing.T) {
 				Endpoint: "bucket.with.dots.s3.amazonaws.com",
 			},
 		},
+		{
+			name: "aws dualstack virtual-hosted",
+			raw:  "https://my-bucket.s3.dualstack.us-west-2.amazonaws.com/foo",
+			want: s3Target{
+				Scheme: "https", Host: "my-bucket.s3.dualstack.us-west-2.amazonaws.com",
+				Bucket: "my-bucket", Prefix: "foo",
+				Region: "us-west-2", IsAWS: true,
+				Endpoint: "my-bucket.s3.dualstack.us-west-2.amazonaws.com",
+			},
+		},
+		{
+			name: "aws dualstack path-style",
+			raw:  "https://s3.dualstack.us-east-1.amazonaws.com/mybucket/x",
+			want: s3Target{
+				Scheme: "https", Host: "s3.dualstack.us-east-1.amazonaws.com",
+				Bucket: "mybucket", Prefix: "x",
+				Region: "us-east-1", PathStyle: true, IsAWS: true,
+				Endpoint: "s3.dualstack.us-east-1.amazonaws.com",
+			},
+		},
 		{name: "empty s3 host", raw: "s3:///foo", expectErr: true},
 		{name: "path-style no bucket", raw: "https://s3.us-west-2.amazonaws.com/", expectErr: true},
 		{name: "generic no bucket", raw: "https://example.com/", expectErr: true},
 		{name: "bad scheme", raw: "ftp://host/bucket", expectErr: true},
+		{name: "accelerate rejected", raw: "https://bucket.s3-accelerate.amazonaws.com/", expectErr: true},
+		{name: "fips rejected", raw: "https://bucket.s3-fips.us-east-1.amazonaws.com/", expectErr: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -139,50 +160,19 @@ func TestS3ParseURL(t *testing.T) {
 	}
 }
 
-// TestS3DeriveSigningKey checks the SigV4 key derivation against AWS's published
-// example (https://docs.aws.amazon.com/IAM/latest/UserGuide/signature-v4-examples.html).
-func TestS3DeriveSigningKey(t *testing.T) {
-	got := s3DeriveSigningKey(
-		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
-		"20150830", "us-east-1", "iam",
-	)
-	const want = "c4afb1cc5771d871763a393e44b703571b55cc28424d1a5e86da6ed3c154a4b9"
-	assert.Equal(t, want, hex.EncodeToString(got))
-}
-
-func TestS3URIEncode(t *testing.T) {
-	cases := []struct {
-		in          string
-		encodeSlash bool
-		want        string
-	}{
-		{"foo/bar.txt", false, "foo/bar.txt"},
-		{"foo/bar.txt", true, "foo%2Fbar.txt"},
-		{"hello world", false, "hello%20world"},
-		{"a+b=c", false, "a%2Bb%3Dc"},
-		{"unicode-café", false, "unicode-caf%C3%A9"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.in, func(t *testing.T) {
-			assert.Equal(t, tc.want, s3URIEncode(tc.in, tc.encodeSlash))
-		})
-	}
-}
-
-func TestS3Sign_producesExpectedAuthorizationStructure(t *testing.T) {
+// TestS3Sign_passesThroughToSigv4 verifies the thin wrapper delegates to the
+// shared sigv4 package and produces a /s3/ scope.
+func TestS3Sign_passesThroughToSigv4(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://mybucket.s3.us-east-1.amazonaws.com/?list-type=2", nil)
 	require.NoError(t, err)
 	creds := s3Creds{AccessKey: "AKIAIOSFODNN7EXAMPLE", SecretKey: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"}
 	require.NoError(t, s3Sign(req, nil, "us-east-1", creds))
 
 	auth := req.Header.Get("Authorization")
-	require.True(t, strings.HasPrefix(auth, s3SignAlgorithm+" "), "auth prefix: %q", auth)
-	require.Contains(t, auth, "Credential=AKIAIOSFODNN7EXAMPLE/")
+	require.Contains(t, auth, "AWS4-HMAC-SHA256 ")
 	require.Contains(t, auth, "/us-east-1/s3/aws4_request")
-	require.Contains(t, auth, "SignedHeaders=")
-	require.Contains(t, auth, "Signature=")
-	require.Equal(t, s3EmptyPayloadSHA256, req.Header.Get("X-Amz-Content-Sha256"))
 	require.NotEmpty(t, req.Header.Get("X-Amz-Date"))
+	require.NotEmpty(t, req.Header.Get("X-Amz-Content-Sha256"))
 }
 
 func TestS3Sign_anonymousSkipsSigning(t *testing.T) {

--- a/sources/s3_test.go
+++ b/sources/s3_test.go
@@ -354,6 +354,173 @@ func TestS3_prefilterSkipsBucket(t *testing.T) {
 	}))
 }
 
+func TestS3ParseURL_globs(t *testing.T) {
+	cases := []struct {
+		name      string
+		raw       string
+		want      s3Target
+		expectErr bool
+	}{
+		{
+			name: "s3 scheme star",
+			raw:  "s3://*",
+			want: s3Target{
+				Scheme: "https", Host: "s3.amazonaws.com",
+				BucketGlob: "*",
+				IsAWS:      true, RequiresProbe: true,
+				Endpoint: "s3.amazonaws.com",
+			},
+		},
+		{
+			name: "s3 scheme glob with prefix",
+			raw:  "s3://prod-*/logs/",
+			want: s3Target{
+				Scheme: "https", Host: "s3.amazonaws.com",
+				BucketGlob: "prod-*", Prefix: "logs/",
+				IsAWS: true, RequiresProbe: true,
+				Endpoint: "s3.amazonaws.com",
+			},
+		},
+		{
+			name: "aws path-style glob",
+			raw:  "https://s3.us-west-2.amazonaws.com/*/foo",
+			want: s3Target{
+				Scheme: "https", Host: "s3.us-west-2.amazonaws.com",
+				BucketGlob: "*", Prefix: "foo",
+				Region: "us-west-2", PathStyle: true, IsAWS: true,
+				Endpoint: "s3.us-west-2.amazonaws.com",
+			},
+		},
+		{
+			name: "minio path-style glob",
+			raw:  "http://localhost:9000/prod-*/logs/",
+			want: s3Target{
+				Scheme: "http", Host: "localhost:9000",
+				BucketGlob: "prod-*", Prefix: "logs/",
+				PathStyle: true, Endpoint: "localhost:9000",
+			},
+		},
+		{
+			name: "r2 path-style glob",
+			raw:  "https://acct.r2.cloudflarestorage.com/*",
+			want: s3Target{
+				Scheme: "https", Host: "acct.r2.cloudflarestorage.com",
+				BucketGlob: "*", Region: "auto",
+				PathStyle: true, Endpoint: "acct.r2.cloudflarestorage.com",
+			},
+		},
+		{name: "glob in dns hostname rejected", raw: "https://*.s3.amazonaws.com/", expectErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := s3ParseURL(tc.raw)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			assert.True(t, got.IsEnumerate(), "expected enumerate mode")
+		})
+	}
+}
+
+// TestS3_enumerateMatchesGlob points the source at an httptest server that
+// serves a ListBuckets response followed by per-bucket ListObjectsV2 + GetObject.
+// Only the two buckets matching "prod-*" should be scanned.
+func TestS3_enumerateMatchesGlob(t *testing.T) {
+	const (
+		bucketProdA = "prod-a"
+		bucketProdB = "prod-b"
+		bucketDev   = "dev-one"
+	)
+	objects := map[string]map[string]string{
+		bucketProdA: {"x.txt": "x-content"},
+		bucketProdB: {"y.txt": "y-content"},
+	}
+
+	listAll := s3ListAllMyBucketsResult{
+		Buckets: []s3BucketEntry{
+			{Name: bucketProdA, CreationDate: "2024-01-01T00:00:00Z"},
+			{Name: bucketProdB, CreationDate: "2024-01-02T00:00:00Z"},
+			{Name: bucketDev, CreationDate: "2024-01-03T00:00:00Z"},
+		},
+	}
+
+	var listBucketsHits int
+	var devHits int
+	var hitMu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NotEmpty(t, r.Header.Get("Authorization"))
+
+		// Account-level ListBuckets: GET / (no path-style bucket prefix).
+		if r.URL.Path == "/" && r.URL.RawQuery == "" {
+			hitMu.Lock()
+			listBucketsHits++
+			hitMu.Unlock()
+			require.NoError(t, xml.NewEncoder(w).Encode(listAll))
+			return
+		}
+
+		// Path-style: /<bucket>/...
+		segments := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/"), "/", 2)
+		bucket := segments[0]
+		hitMu.Lock()
+		if bucket == bucketDev {
+			devHits++
+		}
+		hitMu.Unlock()
+
+		if r.URL.Query().Get("list-type") == "2" {
+			objs := objects[bucket]
+			result := s3ListBucketResult{Name: bucket}
+			for k, v := range objs {
+				result.Contents = append(result.Contents, s3Object{
+					Key: k, Size: int64(len(v)), StorageClass: "STANDARD",
+					LastModified: "2024-01-01T00:00:00Z", ETag: `"e"`,
+				})
+			}
+			require.NoError(t, xml.NewEncoder(w).Encode(result))
+			return
+		}
+		// GetObject
+		var key string
+		if len(segments) == 2 {
+			key = segments[1]
+		}
+		body, ok := objects[bucket][key]
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	s := &S3{
+		URL:       fmt.Sprintf("%s/prod-*", srv.URL),
+		Region:    "us-east-1",
+		AccessKey: "ak", SecretKey: "sk",
+	}
+	require.NoError(t, s.Validate())
+	require.True(t, s.parsed.IsEnumerate())
+	require.Equal(t, "prod-*", s.parsed.BucketGlob)
+
+	var seenKeys []string
+	var mu sync.Mutex
+	require.NoError(t, s.Fragments(context.Background(), func(f Fragment, err error) error {
+		require.NoError(t, err)
+		mu.Lock()
+		defer mu.Unlock()
+		seenKeys = append(seenKeys, f.Attr(AttrS3Bucket)+":"+f.Attr(AttrS3Key))
+		return nil
+	}))
+
+	assert.Equal(t, 1, listBucketsHits)
+	assert.Zero(t, devHits, "dev-one bucket should not have been scanned")
+	assert.ElementsMatch(t, []string{"prod-a:x.txt", "prod-b:y.txt"}, seenKeys)
+}
+
 func TestS3_skipsBeforeFetch(t *testing.T) {
 	listResp := s3ListBucketResult{
 		Name: "mybucket",


### PR DESCRIPTION
This pull request adds support for scanning S3 buckets (and S3-compatible object stores like Cloudflare R2, MinIO, etc.) for secrets. It introduces a new `s3` command, updates documentation to describe its usage and options, and adds new resource attributes for S3 objects.

Ex:
```
./betterleaks s3 https://commoncrawl.s3.amazonaws.com/crawl-data/CC-MAIN-2017-04/warc.paths.gz --max-archive-depth=5
```