### PR TITLE
fix: Remove stray comma from nytimes identifier

### DIFF
--- a/cmd/generate/config/rules/nytimes.go
+++ b/cmd/generate/config/rules/nytimes.go
@@ -12,7 +12,7 @@ func NytimesAccessToken() *config.Rule {
 		RuleID:      "nytimes-access-token",
 		Description: "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services.",
 		Regex: utils.GenerateSemiGenericRegex([]string{
-			"nytimes", "new-york-times,", "newyorktimes"},
+			"nytimes", "new-york-times", "newyorktimes"},
 			utils.AlphaNumericExtended("32"), true),
 
 		Keywords: []string{

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4056,7 +4056,7 @@ entropy(finding["secret"]) <= 3.5
 [[rules]]
 id = "nytimes-access-token"
 description = "Detected a Nytimes Access Token, risking unauthorized access to New York Times APIs and content services."
-regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times,|newyorktimes)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{32})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+regex = '''(?i)[\w.-]{0,50}?(?:nytimes|new-york-times|newyorktimes)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9=_\-]{32})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = [
     "nytimes",
     "new-york-times",


### PR DESCRIPTION
The 'new-york-times,' identifier in the 'GenerateSemiGenericRegex' call
had a trailing comma inside the string literal, causing the regex to
match 'new-york-times,' (with comma) instead of 'new-york-times'.
The 'Keywords' slice was correct - only the regex identifier was affected.