### PR TITLE
fix: Inject safe.directory in git isolation env

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -50,6 +50,12 @@ func gitConfigIsolationEnv() []string {
 		"GIT_CONFIG_SYSTEM":      nullDevice,
 		"GIT_NO_REPLACE_OBJECTS": "1",
 		"GIT_TERMINAL_PROMPT":    "0",
+		// Inject safe.directory=* so betterleaks can scan repositories owned by a
+		// different user (common in Docker/CI). Global and system configs are
+		// suppressed above, making this the only way to pass the setting through.
+		"GIT_CONFIG_COUNT":   "1",
+		"GIT_CONFIG_KEY_0":   "safe.directory",
+		"GIT_CONFIG_VALUE_0": "*",
 	}
 
 	env := os.Environ()

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -1,5 +1,27 @@
 package sources
 
+import (
+	"strings"
+	"testing"
+)
+
+func TestGitConfigIsolationEnv(t *testing.T) {
+	env := gitConfigIsolationEnv()
+	joined := strings.Join(env, "\n")
+
+	for _, want := range []string{
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_CONFIG_COUNT=1",
+		"GIT_CONFIG_KEY_0=safe.directory",
+		"GIT_CONFIG_VALUE_0=*",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("gitConfigIsolationEnv() missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
 // TODO: commenting out this test for now because it's flaky. Alternatives to consider to get this working:
 // -- use `git stash` instead of `restore()`
 

--- a/sources/scm/clone.go
+++ b/sources/scm/clone.go
@@ -163,12 +163,14 @@ func gitCloneEnv(configs []GitConfig) []string {
 		"GIT_TERMINAL_PROMPT":    "0",
 	}
 
-	if len(configs) > 0 {
-		overrides["GIT_CONFIG_COUNT"] = fmt.Sprintf("%d", len(configs))
-		for i, cfg := range configs {
-			overrides[fmt.Sprintf("GIT_CONFIG_KEY_%d", i)] = cfg.Key
-			overrides[fmt.Sprintf("GIT_CONFIG_VALUE_%d", i)] = cfg.Value
-		}
+	// Always inject safe.directory=* so git can access repositories owned by a
+	// different user (common in Docker/CI). Prepend it so caller-provided configs
+	// (e.g. auth headers) take higher indices and are unaffected.
+	allConfigs := append([]GitConfig{{Key: "safe.directory", Value: "*"}}, configs...)
+	overrides["GIT_CONFIG_COUNT"] = fmt.Sprintf("%d", len(allConfigs))
+	for i, cfg := range allConfigs {
+		overrides[fmt.Sprintf("GIT_CONFIG_KEY_%d", i)] = cfg.Key
+		overrides[fmt.Sprintf("GIT_CONFIG_VALUE_%d", i)] = cfg.Value
 	}
 
 	env := os.Environ()

--- a/sources/scm/clone_test.go
+++ b/sources/scm/clone_test.go
@@ -86,20 +86,41 @@ func TestAuthCloneConfigs(t *testing.T) {
 }
 
 func TestGitCloneEnv(t *testing.T) {
-	env := gitCloneEnv([]GitConfig{{Key: "http.extraheader", Value: "Authorization: basic abc"}})
-	joined := strings.Join(env, "\n")
+	t.Run("with auth config", func(t *testing.T) {
+		env := gitCloneEnv([]GitConfig{{Key: "http.extraheader", Value: "Authorization: basic abc"}})
+		joined := strings.Join(env, "\n")
 
-	for _, want := range []string{
-		"GIT_CONFIG_COUNT=1",
-		"GIT_CONFIG_KEY_0=http.extraheader",
-		"GIT_CONFIG_VALUE_0=Authorization: basic abc",
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_CONFIG_NOSYSTEM=1",
-	} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("gitCloneEnv() missing %q in %q", want, joined)
+		for _, want := range []string{
+			"GIT_CONFIG_COUNT=2",
+			"GIT_CONFIG_KEY_0=safe.directory",
+			"GIT_CONFIG_VALUE_0=*",
+			"GIT_CONFIG_KEY_1=http.extraheader",
+			"GIT_CONFIG_VALUE_1=Authorization: basic abc",
+			"GIT_TERMINAL_PROMPT=0",
+			"GIT_CONFIG_NOSYSTEM=1",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Fatalf("gitCloneEnv() missing %q in:\n%s", want, joined)
+			}
 		}
-	}
+	})
+
+	t.Run("no auth config", func(t *testing.T) {
+		env := gitCloneEnv(nil)
+		joined := strings.Join(env, "\n")
+
+		for _, want := range []string{
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=safe.directory",
+			"GIT_CONFIG_VALUE_0=*",
+			"GIT_TERMINAL_PROMPT=0",
+			"GIT_CONFIG_NOSYSTEM=1",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Fatalf("gitCloneEnv() missing %q in:\n%s", want, joined)
+			}
+		}
+	})
 }
 
 func TestSanitizeOutput(t *testing.T) {


### PR DESCRIPTION
'gitConfigIsolationEnv()' suppresses all user/system git config files via
'GIT_CONFIG_GLOBAL=/dev/null' and 'GIT_CONFIG_NOSYSTEM=1'. This means any
'safe.directory' setting configured in a Dockerfile or CI environment is
silently ignored, causing a fatal "dubious ownership" error when scanning
repositories owned by a different user.

The same issue exists in 'gitCloneEnv()' in 'sources/scm/clone.go'.

Fix: inject 'safe.directory=*' via 'GIT_CONFIG_COUNT/KEY/VALUE' in both
functions. Since global and system configs are already suppressed, this is
the only way to pass the setting through the isolation boundary.

Closes #120