### PR TITLE
Add ValidateCEL for Stripe and Datadog rules

### DIFF
--- a/cmd/generate/config/rules/datadog.go
+++ b/cmd/generate/config/rules/datadog.go
@@ -16,6 +16,17 @@ func DatadogtokenAccessToken() *config.Rule {
 		Keywords: []string{
 			"datadog",
 		},
+		ValidateCEL: `cel.bind(r,
+  http.get("https://api.datadoghq.com/api/v1/validate", {
+    "DD-API-KEY": finding["secret"]
+  }),
+  r.status == 200 && r.json.?valid.orValue(false) == true ? {
+    "result": "valid"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : unknown(r)
+)`,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -21,6 +21,17 @@ func StripeAccessToken() *config.Rule {
 			"rk_live",
 			"rk_prod",
 		},
+		ValidateCEL: `cel.bind(r,
+  http.get("https://api.stripe.com/v1/account", {
+    "Authorization": "Bearer " + finding["secret"]
+  }),
+  r.status == 200 && r.json.?object.orValue("") == "account" ? {
+    "result": "valid"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : unknown(r)
+)`,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/stripe.go
+++ b/cmd/generate/config/rules/stripe.go
@@ -22,12 +22,15 @@ func StripeAccessToken() *config.Rule {
 			"rk_prod",
 		},
 		ValidateCEL: `cel.bind(r,
-  http.get("https://api.stripe.com/v1/account", {
+  http.get("https://api.stripe.com/v1/balance", {
     "Authorization": "Bearer " + finding["secret"]
   }),
-  r.status == 200 && r.json.?object.orValue("") == "account" ? {
+  r.status == 200 && r.json.?object.orValue("") == "balance" ? {
     "result": "valid"
-  } : r.status in [401, 403] ? {
+  } : r.status == 403 ? {
+    "result": "valid",
+    "reason": "Restricted key"
+  } : r.status == 401 ? {
     "result": "invalid",
     "reason": "Unauthorized"
   } : unknown(r)

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -729,6 +729,19 @@ id = "datadog-access-token"
 description = "Detected a Datadog Access Token, potentially risking monitoring and analytics data exposure and manipulation."
 regex = '''(?i)[\w.-]{0,50}?(?:datadog)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([a-z0-9]{40})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["datadog"]
+validate = '''
+cel.bind(r,
+  http.get("https://api.datadoghq.com/api/v1/validate", {
+    "DD-API-KEY": finding["secret"]
+  }),
+  r.status == 200 && r.json.?valid.orValue(false) == true ? {
+    "result": "valid"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : unknown(r)
+)
+'''
 
 # ──────────────────────────────────────────────────────────────────────────────
 # deepgram-api-key
@@ -5034,6 +5047,19 @@ keywords = [
     "rk_live",
     "rk_prod",
 ]
+validate = '''
+cel.bind(r,
+  http.get("https://api.stripe.com/v1/account", {
+    "Authorization": "Bearer " + finding["secret"]
+  }),
+  r.status == 200 && r.json.?object.orValue("") == "account" ? {
+    "result": "valid"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : unknown(r)
+)
+'''
 filter = '''
 entropy(finding["secret"]) <= 2.0
 '''

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -5049,12 +5049,15 @@ keywords = [
 ]
 validate = '''
 cel.bind(r,
-  http.get("https://api.stripe.com/v1/account", {
+  http.get("https://api.stripe.com/v1/balance", {
     "Authorization": "Bearer " + finding["secret"]
   }),
-  r.status == 200 && r.json.?object.orValue("") == "account" ? {
+  r.status == 200 && r.json.?object.orValue("") == "balance" ? {
     "result": "valid"
-  } : r.status in [401, 403] ? {
+  } : r.status == 403 ? {
+    "result": "valid",
+    "reason": "Restricted key"
+  } : r.status == 401 ? {
     "result": "invalid",
     "reason": "Unauthorized"
   } : unknown(r)


### PR DESCRIPTION
**Stripe** ('stripe-access-token')
- Endpoint: 'GET https://api.stripe.com/v1/account'
- Auth: 'Authorization: Bearer {token}'
- Valid when: status 200 and 'object == "account"'

**Datadog** ('datadog-access-token')
- Endpoint: 'GET https://api.datadoghq.com/api/v1/validate'
- Auth: 'DD-API-KEY: {token}' header
- Valid when: status 200 and 'valid == true'

Both expressions follow the existing 'cel.bind' pattern used by other rules (OpenAI, Anthropic, etc.) and use 'finding["secret"]' per the 'celenv/validation.go' convention.

'config/betterleaks.toml' regenerated via 'go generate ./...'.