### PR TITLE
expose some context for filtering/validation

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -787,6 +787,14 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 
 		finding.SetFingerprint()
 
+		finding.CELContext = extractContext(fragment.Raw, matchIndex, MatchContextSpec{
+			Mode:        ContextModeBox,
+			LinesBefore: 100,
+			LinesAfter:  100,
+			ColsBefore:  350,
+			ColsAfter:   350,
+		})
+
 		// Build finding map once, only when at least one filter program is compiled.
 		var findingMap map[string]string
 		if d.Config.FilterProgram() != nil || r.FilterProgram() != nil {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -789,8 +789,8 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 
 		finding.CELContext = extractContext(fragment.Raw, matchIndex, MatchContextSpec{
 			Mode:        ContextModeBox,
-			LinesBefore: 100,
-			LinesAfter:  100,
+			LinesBefore: 20,
+			LinesAfter:  20,
 			ColsBefore:  350,
 			ColsAfter:   350,
 		})

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -789,13 +789,13 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 
 		// before setting CELContext, check if we have a validate or filter (TODO rename CelProgram to ValidateProgram)
 		if r.CelProgram() != nil || d.Config.FilterProgram() != nil || r.FilterProgram() != nil {
-			finding.CELContext = extractContext(fragment.Raw, matchIndex, MatchContextSpec{
+			finding.SetCELContext(extractContext(fragment.Raw, matchIndex, MatchContextSpec{
 				Mode:        ContextModeBox,
 				LinesBefore: 20,
 				LinesAfter:  20,
 				ColsBefore:  350,
 				ColsAfter:   350,
-			})
+			}))
 		}
 
 		// Build finding map once, only when at least one filter program is compiled.

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -787,13 +787,16 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 
 		finding.SetFingerprint()
 
-		finding.CELContext = extractContext(fragment.Raw, matchIndex, MatchContextSpec{
-			Mode:        ContextModeBox,
-			LinesBefore: 20,
-			LinesAfter:  20,
-			ColsBefore:  350,
-			ColsAfter:   350,
-		})
+		// before setting CELContext, check if we have a validate or filter (TODO rename CelProgram to ValidateProgram)
+		if r.CelProgram() != nil || d.Config.FilterProgram() != nil || r.FilterProgram() != nil {
+			finding.CELContext = extractContext(fragment.Raw, matchIndex, MatchContextSpec{
+				Mode:        ContextModeBox,
+				LinesBefore: 20,
+				LinesAfter:  20,
+				ColsBefore:  350,
+				ColsAfter:   350,
+			})
+		}
 
 		// Build finding map once, only when at least one filter program is compiled.
 		var findingMap map[string]string

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -99,6 +99,8 @@ username = "admin"
 
 func compare(t *testing.T, got, want []report.Finding) {
 	t.Helper()
+	got = stripFindingAttributes(append([]report.Finding(nil), got...))
+	want = stripFindingAttributes(append([]report.Finding(nil), want...))
 	if diff := cmp.Diff(want, got,
 		cmpopts.SortSlices(func(a, b report.Finding) bool {
 			if a.File != b.File {
@@ -125,6 +127,7 @@ func compare(t *testing.T, got, want []report.Finding) {
 			"Fingerprint", "Author", "Email", "Date", "Message", "Commit",
 			"File", "SymlinkFile", "Attributes",
 			"RequiredSets"),
+		cmpopts.IgnoreUnexported(report.Finding{}),
 		cmpopts.EquateApprox(0.0001, 0), // For floating point Entropy comparison
 	); diff != "" {
 		t.Errorf("findings mismatch (-want +got):\n%s", diff)
@@ -138,6 +141,7 @@ func stripFindingAttributes(findings []report.Finding) []report.Finding {
 	for i := range findings {
 		findings[i].Attributes = nil
 		findings[i].Link = ""
+		findings[i].SetCELContext("")
 	}
 	return findings
 }
@@ -1383,6 +1387,7 @@ func TestFromGit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(strings.Join([]string{tt.cfgName, tt.source, tt.logOpts}, "/"), func(t *testing.T) {
+			viper.Reset()
 			viper.AddConfigPath(configPath)
 			viper.SetConfigName("simple")
 			viper.SetConfigType("toml")
@@ -1476,6 +1481,7 @@ func TestFromGitStaged(t *testing.T) {
 	moveDotGit(t, "dotGit", ".git")
 	defer moveDotGit(t, ".git", "dotGit")
 	for _, tt := range tests {
+		viper.Reset()
 
 		viper.AddConfigPath(configPath)
 		viper.SetConfigName("simple")
@@ -1594,6 +1600,7 @@ func TestFromFiles(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.cfgName+" - "+tt.source, func(t *testing.T) {
+			viper.Reset()
 			viper.AddConfigPath(configPath)
 			viper.SetConfigName(tt.cfgName)
 			viper.SetConfigType("toml")
@@ -2195,6 +2202,7 @@ func TestDetectWithArchives(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.cfgName+" - "+tt.source, func(t *testing.T) {
+			viper.Reset()
 			viper.AddConfigPath(configPath)
 			viper.SetConfigName(tt.cfgName)
 			viper.SetConfigType("toml")
@@ -2206,6 +2214,7 @@ func TestDetectWithArchives(t *testing.T) {
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
 			if tt.expireContext {
 				cancel()
 			}
@@ -2286,6 +2295,7 @@ func TestDetectWithSymlinks(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		viper.Reset()
 		viper.AddConfigPath(configPath)
 		viper.SetConfigName("simple")
 		viper.SetConfigType("toml")

--- a/report/finding.go
+++ b/report/finding.go
@@ -32,8 +32,6 @@ type Finding struct {
 	// MatchContext contains surrounding lines around the match
 	MatchContext string `json:",omitempty"`
 
-	CELContext string `json:"-"`
-
 	Line string `json:"-"`
 
 	// CaptureGroups holds named regex capture groups from the match.
@@ -61,6 +59,9 @@ type Finding struct {
 
 	// unique identifier
 	Fingerprint string
+
+	// Hidden field to hold the context for CEL evaluation without bloating the report output.
+	celContext string
 
 	// Deprecated
 	// File is the name of the file containing the finding
@@ -203,6 +204,10 @@ func MaskSecret(secret string, percent uint) string {
 	lth := int64(math.RoundToEven(len * prc / float64(100)))
 
 	return secret[:lth] + "..."
+}
+
+func (f *Finding) SetCELContext(context string) {
+	f.celContext = context
 }
 
 func (f *Finding) PrintRequiredFindings(noColor bool, redact uint) {
@@ -608,6 +613,6 @@ func (f *Finding) ToCELMap() map[string]string {
 		"line":        f.Line,
 		"rule_id":     f.RuleID,
 		"description": f.Description,
-		"context":     f.CELContext,
+		"context":     f.celContext,
 	}
 }

--- a/report/finding.go
+++ b/report/finding.go
@@ -32,6 +32,8 @@ type Finding struct {
 	// MatchContext contains surrounding lines around the match
 	MatchContext string `json:",omitempty"`
 
+	CELContext string `json:"-"`
+
 	Line string `json:"-"`
 
 	// CaptureGroups holds named regex capture groups from the match.
@@ -606,5 +608,6 @@ func (f *Finding) ToCELMap() map[string]string {
 		"line":        f.Line,
 		"rule_id":     f.RuleID,
 		"description": f.Description,
+		"context":     f.CELContext,
 	}
 }


### PR DESCRIPTION
This PR exposes a little more context around the match for users to operate on in a filter or validate CEL environment