### PR TITLE
obfuscate secret

### DIFF
--- a/celenv/bindings_obfuscate.go
+++ b/celenv/bindings_obfuscate.go
@@ -66,19 +66,20 @@ func obfuscate(secret string) string {
 // splitPrefix returns the identifying prefix and the body to perturb.
 // Short secrets have no preserved prefix.
 func splitPrefix(secret string) (prefix, body string) {
-	if len(secret) <= prefixMinLen {
+	runes := []rune(secret)
+	if len(runes) <= prefixMinLen {
 		return "", secret
 	}
 	scan := prefixScanLen
-	if scan > len(secret) {
-		scan = len(secret)
+	if scan > len(runes) {
+		scan = len(runes)
 	}
 	for i := 0; i < scan; i++ {
-		if strings.ContainsRune(prefixSeparators, rune(secret[i])) {
-			return secret[:i+1], secret[i+1:]
+		if strings.ContainsRune(prefixSeparators, runes[i]) {
+			return string(runes[:i+1]), string(runes[i+1:])
 		}
 	}
-	return secret[:prefixFallbackLen], secret[prefixFallbackLen:]
+	return string(runes[:prefixFallbackLen]), string(runes[prefixFallbackLen:])
 }
 
 // hexPool returns the hex alphabet to use for secret, or "" if secret isn't
@@ -99,10 +100,12 @@ func hexPool(secret string) string {
 	switch {
 	case hasLower && hasUpper:
 		return ""
+	case hasLower:
+		return classHexLower
 	case hasUpper:
 		return classHexUpper
 	default:
-		return classHexLower
+		return ""
 	}
 }
 

--- a/celenv/bindings_obfuscate.go
+++ b/celenv/bindings_obfuscate.go
@@ -1,0 +1,177 @@
+package celenv
+
+import (
+	"crypto/rand"
+	"io"
+	"math/big"
+	"strings"
+
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const (
+	obfuscateRate     = 0.7
+	prefixMinLen      = 20
+	prefixFallbackLen = 6
+	prefixScanLen     = 8
+	prefixSeparators  = "_-."
+	classLower        = "abcdefghijklmnopqrstuvwxyz"
+	classUpper        = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	classDigit        = "0123456789"
+	classHexLower     = "0123456789abcdef"
+	classHexUpper     = "0123456789ABCDEF"
+)
+
+// obfuscateRand is the randomness source. Tests swap in a deterministic stream.
+var obfuscateRand io.Reader = rand.Reader
+
+func obfuscateBinding() functions.UnaryOp {
+	return func(val ref.Val) ref.Val {
+		s, ok := val.(types.String)
+		if !ok {
+			return types.NewErr("obfuscate: secret must be a string, got %T", val)
+		}
+		return types.String(obfuscate(string(s)))
+	}
+}
+
+// obfuscate returns a same-length, class-preserving perturbation of secret.
+// Each rune is replaced with probability obfuscateRate by a different rune
+// from the same class (lower, upper, digit, hex, or symbols present in
+// secret). Non-ASCII runes pass through. For secrets longer than
+// prefixMinLen, an identifying prefix is preserved verbatim — either up to
+// the first separator within prefixScanLen, or prefixFallbackLen chars.
+func obfuscate(secret string) string {
+	if secret == "" {
+		return ""
+	}
+	prefix, body := splitPrefix(secret)
+	if body == "" {
+		return secret
+	}
+	symbols := collectSymbols(body)
+	hex := hexPool(body)
+	runes := []rune(body)
+	for i, r := range runes {
+		if !shouldPerturb() {
+			continue
+		}
+		runes[i] = perturbRune(r, symbols, hex)
+	}
+	return prefix + string(runes)
+}
+
+// splitPrefix returns the identifying prefix and the body to perturb.
+// Short secrets have no preserved prefix.
+func splitPrefix(secret string) (prefix, body string) {
+	if len(secret) <= prefixMinLen {
+		return "", secret
+	}
+	scan := prefixScanLen
+	if scan > len(secret) {
+		scan = len(secret)
+	}
+	for i := 0; i < scan; i++ {
+		if strings.ContainsRune(prefixSeparators, rune(secret[i])) {
+			return secret[:i+1], secret[i+1:]
+		}
+	}
+	return secret[:prefixFallbackLen], secret[prefixFallbackLen:]
+}
+
+// hexPool returns the hex alphabet to use for secret, or "" if secret isn't
+// single-case hex. Mixed-case hex falls through to generic alphanumeric.
+func hexPool(secret string) string {
+	var hasLower, hasUpper bool
+	for _, r := range secret {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+			hasLower = true
+		case r >= 'A' && r <= 'F':
+			hasUpper = true
+		default:
+			return ""
+		}
+	}
+	switch {
+	case hasLower && hasUpper:
+		return ""
+	case hasUpper:
+		return classHexUpper
+	default:
+		return classHexLower
+	}
+}
+
+func collectSymbols(secret string) []rune {
+	seen := make(map[rune]struct{})
+	var out []rune
+	for _, r := range secret {
+		if !isSymbol(r) {
+			continue
+		}
+		if _, dup := seen[r]; dup {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	return out
+}
+
+func perturbRune(r rune, symbols []rune, hex string) rune {
+	switch {
+	case hex != "" && ((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')):
+		return pickDifferent(hex, r)
+	case r >= 'a' && r <= 'z':
+		return pickDifferent(classLower, r)
+	case r >= 'A' && r <= 'Z':
+		return pickDifferent(classUpper, r)
+	case r >= '0' && r <= '9':
+		return pickDifferent(classDigit, r)
+	case isSymbol(r):
+		if len(symbols) <= 1 {
+			return r
+		}
+		return pickDifferent(string(symbols), r)
+	default:
+		return r
+	}
+}
+
+func isSymbol(r rune) bool {
+	return r >= 0x21 && r <= 0x7e &&
+		!(r >= 'a' && r <= 'z') &&
+		!(r >= 'A' && r <= 'Z') &&
+		!(r >= '0' && r <= '9')
+}
+
+func pickDifferent(pool string, current rune) rune {
+	runes := []rune(pool)
+	for {
+		c := runes[randIndex(len(runes))]
+		if c != current {
+			return c
+		}
+	}
+}
+
+func shouldPerturb() bool {
+	const denom = 1 << 53
+	v, err := rand.Int(obfuscateRand, big.NewInt(denom))
+	if err != nil {
+		return true
+	}
+	return float64(v.Int64())/float64(denom) < obfuscateRate
+}
+
+func randIndex(n int) int {
+	v, err := rand.Int(obfuscateRand, big.NewInt(int64(n)))
+	if err != nil {
+		return 0
+	}
+	return int(v.Int64())
+}

--- a/celenv/bindings_obfuscate_test.go
+++ b/celenv/bindings_obfuscate_test.go
@@ -1,0 +1,162 @@
+package celenv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObfuscate_emptyStringPassesThrough(t *testing.T) {
+	require.Equal(t, "", obfuscate(""))
+}
+
+func TestObfuscate_preservesLength(t *testing.T) {
+	cases := []string{
+		"abc",
+		"AKIAIOSFODNN7EXAMPLE",
+		"sk_live_4eC39HqLyjWDarjtT1zdp7dc",
+		"a1B2c3D4e5F6g7H8",
+		"xx-yy_zz.ww=qq",
+	}
+	for _, in := range cases {
+		got := obfuscate(in)
+		require.Len(t, got, len(in), "length mismatch for %q -> %q", in, got)
+	}
+}
+
+func TestObfuscate_preservesGenericAlphabetClass(t *testing.T) {
+	const in = "aA1!bB2_cC3-dD4=eE5.fF6+gG7/hH8?"
+	got := obfuscate(in)
+	require.Len(t, got, len(in))
+
+	prefix, _ := splitPrefix(in)
+	for i := range in {
+		if i < len(prefix) {
+			require.Equal(t, in[i], got[i], "prefix byte %d changed", i)
+			continue
+		}
+
+		r := rune(in[i])
+		o := rune(got[i])
+		require.Equalf(t, classOf(r), classOf(o),
+			"position %d: input %q class %s, output %q class %s",
+			i, string(r), classOf(r), string(o), classOf(o))
+	}
+}
+
+func TestObfuscate_preservesSeparatorPrefix(t *testing.T) {
+	const in = "sk_live_4eC39HqLyjWDarjtT1zdp7dc"
+	got := obfuscate(in)
+	require.True(t, strings.HasPrefix(got, "sk_"))
+	require.Len(t, got, len(in))
+}
+
+func TestObfuscate_preservesFallbackPrefix(t *testing.T) {
+	const in = "abcdef1234567890abcdef1234567890"
+	got := obfuscate(in)
+	require.True(t, strings.HasPrefix(got, "abcdef"))
+	require.Len(t, got, len(in))
+}
+
+func TestObfuscate_shortSecretHasNoPrefix(t *testing.T) {
+	prefix, body := splitPrefix("abc-def")
+	require.Empty(t, prefix)
+	require.Equal(t, "abc-def", body)
+}
+
+func TestObfuscate_lowerHexBodyStaysHex(t *testing.T) {
+	const in = "sha256_abcdef0123456789abcdef0123456789"
+	got := obfuscate(in)
+	require.True(t, strings.HasPrefix(got, "sha256_"))
+	for _, r := range strings.TrimPrefix(got, "sha256_") {
+		require.Truef(t, (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f'),
+			"output rune %q is not lower hex", string(r))
+	}
+}
+
+func TestObfuscate_upperHexBodyStaysHex(t *testing.T) {
+	const in = "TOKEN.ABCDEF0123456789ABCDEF0123456789"
+	got := obfuscate(in)
+	require.True(t, strings.HasPrefix(got, "TOKEN."))
+	for _, r := range strings.TrimPrefix(got, "TOKEN.") {
+		require.Truef(t, (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F'),
+			"output rune %q is not upper hex", string(r))
+	}
+}
+
+func TestObfuscate_symbolsStayInBodySymbolSet(t *testing.T) {
+	const in = "secret.key-with_dots.and=equals"
+	got := obfuscate(in)
+	prefix, body := splitPrefix(in)
+	gotBody := strings.TrimPrefix(got, prefix)
+
+	allowed := map[rune]bool{}
+	for _, r := range body {
+		if isSymbol(r) {
+			allowed[r] = true
+		}
+	}
+	require.GreaterOrEqual(t, len(allowed), 2,
+		"test fixture must contain at least 2 distinct body symbols")
+
+	for _, r := range gotBody {
+		if isSymbol(r) {
+			require.Truef(t, allowed[r],
+				"output symbol %q not in body symbol set", string(r))
+		}
+	}
+}
+
+func TestObfuscate_singleSymbolStaysPut(t *testing.T) {
+	const in = "abcdefg-hijklmn"
+	got := obfuscate(in)
+	require.Equal(t, "-", string(got[7]))
+}
+
+func TestObfuscate_nonAsciiPassesThrough(t *testing.T) {
+	const in = "café-résumé"
+	got := obfuscate(in)
+	require.Equal(t, len([]rune(in)), len([]rune(got)))
+	require.Contains(t, got, "é")
+}
+
+func TestObfuscate_celBindingUnary(t *testing.T) {
+	env, err := NewEnvironment(nil)
+	require.NoError(t, err)
+
+	prg, err := env.Compile(`obfuscate(finding["secret"])`)
+	require.NoError(t, err)
+
+	const secret = "sk_live_4eC39HqLyjWDarjtT1zdp7dc"
+	got, err := env.Eval(prg, map[string]string{"secret": secret}, nil)
+	require.NoError(t, err)
+
+	out, ok := got.Value().(string)
+	require.True(t, ok)
+	require.Len(t, out, len(secret))
+	require.True(t, strings.HasPrefix(out, "sk_"))
+}
+
+func TestObfuscate_celBindingRejectsBinaryForm(t *testing.T) {
+	env, err := NewEnvironment(nil)
+	require.NoError(t, err)
+
+	_, err = env.Compile(`obfuscate(finding["secret"], 0.0)`)
+	require.Error(t, err)
+}
+
+func classOf(r rune) string {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return "lower"
+	case r >= 'A' && r <= 'Z':
+		return "upper"
+	case r >= '0' && r <= '9':
+		return "digit"
+	case isSymbol(r):
+		return "symbol"
+	default:
+		return "other"
+	}
+}

--- a/celenv/bindings_obfuscate_test.go
+++ b/celenv/bindings_obfuscate_test.go
@@ -3,6 +3,7 @@ package celenv
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +66,19 @@ func TestObfuscate_shortSecretHasNoPrefix(t *testing.T) {
 	require.Equal(t, "abc-def", body)
 }
 
+func TestObfuscate_splitPrefixPreservesUTF8(t *testing.T) {
+	const in = "éééééééééééé3456789012345"
+
+	prefix, body := splitPrefix(in)
+	require.Equal(t, "éééééé", prefix)
+	require.True(t, utf8.ValidString(prefix))
+	require.True(t, utf8.ValidString(body))
+
+	got := obfuscate(in)
+	require.True(t, utf8.ValidString(got))
+	require.Len(t, []rune(got), len([]rune(in)))
+}
+
 func TestObfuscate_lowerHexBodyStaysHex(t *testing.T) {
 	const in = "sha256_abcdef0123456789abcdef0123456789"
 	got := obfuscate(in)
@@ -82,6 +96,18 @@ func TestObfuscate_upperHexBodyStaysHex(t *testing.T) {
 	for _, r := range strings.TrimPrefix(got, "TOKEN.") {
 		require.Truef(t, (r >= '0' && r <= '9') || (r >= 'A' && r <= 'F'),
 			"output rune %q is not upper hex", string(r))
+	}
+}
+
+func TestObfuscate_allDigitBodyIsNotHex(t *testing.T) {
+	require.Empty(t, hexPool("1234567890"))
+
+	const in = "token_12345678901234567890"
+	got := obfuscate(in)
+	require.True(t, strings.HasPrefix(got, "token_"))
+	for _, r := range strings.TrimPrefix(got, "token_") {
+		require.Truef(t, r >= '0' && r <= '9',
+			"output rune %q is not a digit", string(r))
 	}
 }
 

--- a/celenv/validation.go
+++ b/celenv/validation.go
@@ -104,6 +104,16 @@ func NewEnvironment(httpClient *http.Client) (*ValidationEnvironment, error) {
 			),
 		),
 
+		// obfuscate(secret) returns a same-length, class-preserving
+		// perturbation of secret with a stable identifying prefix.
+		cel.Function("obfuscate",
+			cel.Overload("obfuscate_string",
+				[]*cel.Type{cel.StringType},
+				cel.StringType,
+				cel.UnaryBinding(obfuscateBinding()),
+			),
+		),
+
 		// unknown(response) returns {"result": "unknown", "reason": "HTTP <status>"}
 		// for use as a fallback when the HTTP status is unexpected.
 		cel.Function("unknown",


### PR DESCRIPTION
This pull request adds a new function for obfuscating secret strings ensuring that secrets are masked in a class-preserving and length-preserving way, while retaining a recognizable prefix or at least trying to