### PR TITLE
Feat/needs validation status

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,7 @@ func init() {
 
 	// Validation flags
 	rootCmd.PersistentFlags().Bool("validation", false, "enable validation of findings against live APIs")
-	rootCmd.PersistentFlags().String("validation-status", "", "comma-separated list of validation statuses to include: valid, invalid, revoked, error, unknown, none (none = rules without validation)")
+	rootCmd.PersistentFlags().String("validation-status", "", "comma-separated list of validation statuses to include: valid, needs_validation, invalid, revoked, error, unknown, none (none = rules without validation)")
 	rootCmd.PersistentFlags().Duration("validation-timeout", 10*time.Second, "per-request timeout for validation")
 	rootCmd.PersistentFlags().Bool("validation-debug", false, "include raw HTTP response in validation output")
 	rootCmd.PersistentFlags().Int("validation-workers", 10, "number of concurrent validation workers")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -543,6 +543,7 @@ func findingSummaryAndExit(detector *detect.Detector, findings []report.Finding,
 	if detector.ValidationPool != nil {
 		logging.Info().
 			Int("valid", detector.ValidationCounts["valid"]).
+			Int("needs_validation", detector.ValidationCounts["needs_validation"]).
 			Int("invalid", detector.ValidationCounts["invalid"]).
 			Int("revoked", detector.ValidationCounts["revoked"]).
 			Int("unknown", detector.ValidationCounts["unknown"]).

--- a/docs/config.md
+++ b/docs/config.md
@@ -122,3 +122,82 @@ cel.bind(r,
 '''
 ```
 This reads as "set r as the response to an http GET call from api.github.com/app, then if status is 200 and `slug` is in the return json, *then* return 'result' valid otherwise if status is 401 or 403, return 'invalid', and finally if none of the conditions are met, return 'unknown'".
+
+
+### "Validating" with an LLM
+
+For generic high-entropy matches that no live API can adjudicate, you can ask an LLM whether the candidate looks like a real secret. Put the system and user prompts directly in the multi-line `validate` TOML string (CEL string literals and concatenation). Use `json.string(...)` when you need quoted, escaped fragments inside a hand-built JSON body. Use `env(...)` plus `--validation-env-vars` so provider API keys stay out of config files. Optionally use `obfuscate(secret)` to send a same-length shape-preserving stand-in instead of the raw candidate when talking to a third-party API. Interpret a positive model signal as `"needs_validation"` when you are not verifying liveness authoritatively; reserve `"valid"` for credentials confirmed live through a definitive check.
+
+Example generic rule w/ llm "validation":
+
+```
+[[rules]]
+id = "generic-secret-llm-filtered"
+description = "Generic secret filtered by an LLM"
+regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+keywords = [
+    "access",
+    "api",
+    "auth",
+    "key",
+    "credential",
+    "creds",
+    "passwd",
+    "password",
+    "secret",
+    "token",
+]
+
+filter = '''
+entropy(finding["secret"]) <= 4.0 ||
+failsTokenEfficiency(finding["secret"])
+'''
+
+validate = '''
+cel.bind(obf_secret, obfuscate(finding["secret"]),
+  cel.bind(obf_context, finding["context"].replace(finding["secret"], obf_secret),
+    cel.bind(r,
+      http.post(
+        "https://api.openai.com/v1/chat/completions",
+        {
+          "Authorization": "Bearer " + env("OPENAI_API_KEY"),
+          "Content-Type": "application/json"
+        },
+        "{" +
+          "\"model\":\"gpt-5.4-mini\"," +
+          "\"temperature\":0," +
+          "\"max_completion_tokens\":256," +
+          "\"messages\":[" +
+            "{\"role\":\"system\",\"content\":" +
+              json.string(
+                "Classify whether the candidate is a real usable credential or a benign match using only the surrounding source context. " +
+                "Respond with exactly three lines: VERDICT_SECRET or VERDICT_NOT, confidence in that verdict as a decimal from 0.0 to 1.0, and a one-sentence justification under 25 words."
+              ) +
+            "}," +
+            "{\"role\":\"user\",\"content\":" +
+              json.string(
+                "Candidate: " + obf_secret + "\n\n" +
+                "Surrounding code:\n" + obf_context
+              ) +
+            "}" +
+          "]" +
+        "}"
+      ),
+      cel.bind(content, r.json.?choices[?0].?message.?content.orValue(""),
+        r.status == 200 && r.body.contains("VERDICT_SECRET") ? {
+          "result": "needs_validation",
+          "justification": content.split("\n")[?2].orValue(content),
+          "confidence": content.split("\n")[?1].orValue("0").trim()
+        } : r.status == 200 && r.body.contains("VERDICT_NOT") ? {
+          "result": "invalid",
+          "confidence": content.split("\n")[?1].orValue("0").trim(),
+          "justification": content.split("\n")[?2].orValue(content)
+        } : unknown(r)
+      )
+    )
+  )
+)
+'''
+```
+
+It's a little messy but it gets the job done. The system prompt is trash but hey it demonstrates what you can do!

--- a/report/finding.go
+++ b/report/finding.go
@@ -288,6 +288,10 @@ func formatSetStatus(status string, noColor bool) string {
 	switch status {
 	case "valid":
 		style = color.New().Foreground("#00d26a")
+	case "needs_validation":
+		// Deliberately distinct from "valid" (green): the candidate looked plausible
+		// to a non-authoritative check (e.g. an LLM) but liveness wasn't confirmed.
+		style = color.New().Foreground("#60a5fa")
 	case "invalid":
 		style = color.New().Foreground("#888888")
 	case "revoked":
@@ -449,6 +453,8 @@ func validationStyle(status string, noColor bool) color.Style {
 	switch status {
 	case "valid":
 		return color.New().Bold().Foreground("#00d26a")
+	case "needs_validation":
+		return color.New().Bold().Foreground("#60a5fa")
 	case "invalid":
 		return color.New().Foreground("#888888")
 	case "revoked":

--- a/validate/result.go
+++ b/validate/result.go
@@ -61,7 +61,7 @@ var statusPriority = map[string]int{
 }
 
 // BetterStatus returns whichever of a or b has higher priority.
-// Priority order: valid > revoked > unknown > invalid > error > "".
+// Priority order: valid > needs_validation > revoked > unknown > invalid > error > "".
 // This is used for rolling up per-component validation results into an
 // overall finding-level status for composite rules.
 func BetterStatus(a, b string) string {

--- a/validate/result.go
+++ b/validate/result.go
@@ -12,11 +12,12 @@ var mapAnyType = reflect.TypeFor[map[string]any]()
 
 // validStatuses is the set of recognised validation statuses.
 var validStatuses = map[string]bool{
-	"valid":   true,
-	"invalid": true,
-	"revoked": true,
-	"unknown": true,
-	"error":   true,
+	"valid":            true,
+	"needs_validation": true,
+	"invalid":          true,
+	"revoked":          true,
+	"unknown":          true,
+	"error":            true,
 }
 
 // Result holds the outcome of a CEL validation evaluation.
@@ -50,12 +51,13 @@ func ParseResult(val ref.Val) *Result {
 // statusPriority defines precedence for status rollup.
 // Higher value = higher priority. "valid" wins over everything; "" loses to everything.
 var statusPriority = map[string]int{
-	"":        0,
-	"error":   1,
-	"invalid": 2,
-	"unknown": 3,
-	"revoked": 4,
-	"valid":   5,
+	"":                 0,
+	"error":            1,
+	"invalid":          2,
+	"unknown":          3,
+	"revoked":          4,
+	"needs_validation": 6,
+	"valid":            6,
 }
 
 // BetterStatus returns whichever of a or b has higher priority.

--- a/validate/result.go
+++ b/validate/result.go
@@ -56,7 +56,7 @@ var statusPriority = map[string]int{
 	"invalid":          2,
 	"unknown":          3,
 	"revoked":          4,
-	"needs_validation": 6,
+	"needs_validation": 5,
 	"valid":            6,
 }
 


### PR DESCRIPTION
This pull request introduces support for a new validation status, "needs_validation", throughout the codebase. This status is intended for cases where a candidate secret looks plausible to a non-authoritative check (such as an LLM), but liveness has not been definitively confirmed. The changes update CLI flags, documentation, reporting, and validation logic to incorporate this new status and clarify its intended use.
