### PR TITLE
cmd: fail when --experiments has unknown values

### DIFF
--- a/cmd/experiments.go
+++ b/cmd/experiments.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// validExperiments is the set of values --experiments will accept.
+// Add new entries here as experimental features land.
+var validExperiments = map[string]struct{}{}
+
+// validateExperiments returns an error if s contains any comma-separated
+// tokens that aren't in validExperiments. Empty entries (e.g. from trailing
+// or doubled commas) are ignored so users can build the list incrementally.
+func validateExperiments(s string) error {
+	if s == "" {
+		return nil
+	}
+	var unknown []string
+	for _, e := range strings.Split(s, ",") {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		if _, ok := validExperiments[e]; !ok {
+			unknown = append(unknown, e)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("unknown --experiments value(s): %s", strings.Join(unknown, ", "))
+}

--- a/cmd/experiments_test.go
+++ b/cmd/experiments_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateExperiments(t *testing.T) {
+	cases := []struct {
+		name      string
+		in        string
+		wantErr   bool
+		wantInErr string
+	}{
+		{"empty", "", false, ""},
+		{"only commas and whitespace", " , , ", false, ""},
+		{"single unknown", "fake", true, "fake"},
+		{"multiple unknown sorted", "zebra,apple", true, "apple, zebra"},
+		{"trims whitespace", "  fake  ", true, "fake"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateExperiments(tc.in)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validateExperiments(%q): expected error, got nil", tc.in)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validateExperiments(%q): unexpected error %v", tc.in, err)
+			}
+			if err != nil && tc.wantInErr != "" && !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Errorf("validateExperiments(%q): error %q missing %q", tc.in, err.Error(), tc.wantInErr)
+			}
+		})
+	}
+}
+
+func TestValidateExperimentsKnownEntry(t *testing.T) {
+	validExperiments["test-only-flag"] = struct{}{}
+	t.Cleanup(func() { delete(validExperiments, "test-only-flag") })
+
+	if err := validateExperiments("test-only-flag"); err != nil {
+		t.Errorf("validateExperiments rejected a registered value: %v", err)
+	}
+	if err := validateExperiments("test-only-flag,nope"); err == nil {
+		t.Error("validateExperiments accepted unknown value when mixed with known")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,11 @@ var (
 				cmd.SetContext(ctx)
 				cobra.OnFinalize(cancel)
 			}
-			return nil
+			exp, err := cmd.Flags().GetString("experiments")
+			if err != nil {
+				return err
+			}
+			return validateExperiments(exp)
 		},
 	}
 


### PR DESCRIPTION
`--experiments` was silently accepting anything, so a typo just no-ops the feature you wanted. Tagged v1.

There aren't any registered experiments yet, so the valid set starts empty and any non-empty token errors out:

```
$ betterleaks dir /tmp --experiments=fake
FTL unknown --experiments value(s): fake
```

Empty strings (trailing commas etc.) are skipped and unknowns are sorted for deterministic output. As experiments land, they get added to `validExperiments` in `cmd/experiments.go`.

Closes #54