### PR TITLE
fix: update github-app-token regex for new ~520-char JWT format (#107)

### DIFF
--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -114,7 +114,7 @@ func GitHubApp() *config.Rule {
 	r := config.Rule{
 		RuleID:      "github-app-token",
 		Description: "Identified a GitHub App Token, which may compromise GitHub application integrations and source code security.",
-		Regex:       regexp.MustCompile(`(?:ghu|ghs)_[0-9a-zA-Z]{36}`),
+		Regex:       regexp.MustCompile(`(?:ghu|ghs)_[0-9a-zA-Z._-]{36,519}`),
 		Entropy:     3,
 		Keywords:    []string{"ghu_", "ghs_"},
 		Allowlists:  githubAllowlist,

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2774,7 +2774,7 @@ entropy(finding["secret"]) <= 3.0
 [[rules]]
 id = "github-app-token"
 description = "Identified a GitHub App Token, which may compromise GitHub application integrations and source code security."
-regex = '''(?:ghu|ghs)_[0-9a-zA-Z]{36}'''
+regex = '''(?:ghu|ghs)_[0-9a-zA-Z._-]{36,519}'''
 keywords = [
     "ghu_",
     "ghs_",

--- a/testdata/github_app_token_test.txt
+++ b/testdata/github_app_token_test.txt
@@ -1,0 +1,5 @@
+# Formato antigo (36 chars) - deve ser detectado
+export GITHUB_TOKEN=ghs_16C7e42F292c6912E7710c838347Ae178B4a
+
+# Novo formato (JWT longo ~520 chars) - deve ser detectado
+export GITHUB_TOKEN=ghs_12345_eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTY5OTIwMDAsImV4cCI6MTcxNjk5MjM2MCwiaXNzIjoiZ2l0aHViIiwic3ViIjoiZ2l0aHViYXBwfDEyMzQ1NiIsInJlcG9zaXRvcnlfaWQiOiI5ODc2NTQiLCJyZXBvc2l0b3J5X293bmVyX2lkIjoiMTExMTExIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c

--- a/testdata/github_app_token_test.txt
+++ b/testdata/github_app_token_test.txt
@@ -1,5 +1,5 @@
-# Formato antigo (36 chars) - deve ser detectado
+# Old format (36 chars) - should be detected
 export GITHUB_TOKEN=ghs_16C7e42F292c6912E7710c838347Ae178B4a
 
-# Novo formato (JWT longo ~520 chars) - deve ser detectado
+# New format (JWT ~520 chars) - should be detected
 export GITHUB_TOKEN=ghs_12345_eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE3MTY5OTIwMDAsImV4cCI6MTcxNjk5MjM2MCwiaXNzIjoiZ2l0aHViIiwic3ViIjoiZ2l0aHViYXBwfDEyMzQ1NiIsInJlcG9zaXRvcnlfaWQiOiI5ODc2NTQiLCJyZXBvc2l0b3J5X293bmVyX2lkIjoiMTExMTExIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c


### PR DESCRIPTION
## Summary

Fixes #107

GitHub [announced on April 24, 2026](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/) that App installation tokens are changing format:

- **Old format**: `ghs_[A-Za-z0-9]{36}` (fixed 40 chars total)
- **New format**: `ghs_APPID_JWT` (~520 chars, variable length)

The rollout for all GitHub Apps is happening now (mid-May → late June 2026), meaning **leaked tokens in the new format are currently invisible to betterleaks**.

## Change

```diff
- regex = 'ghs_[A-Za-z0-9]{36}'
+ regex = 'ghs_[A-Za-z0-9._-]{36,519}'
```

The new range `{36,519}` covers:
- ✅ Old 36-char tokens (backwards compatible)
- ✅ New JWT tokens up to ~520 chars total (`ghs_` prefix = 4 chars, so 519 remaining)
- ✅ JWT base64url charset (`A-Za-z0-9._-`)

## Testing

Added testdata with both old and new format examples.