### PR TITLE
bump min bl config version

### DIFF
--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -17,7 +17,7 @@ title = "{{.Title}}"
 # betterleaksMinVersion indicates the minimum betterleaks version required.
 # If the running version is older, a warning will be logged.
 minVersion = "v8.25.0"
-betterleaksMinVersion = "v1.2.0"
+betterleaksMinVersion = "v1.3.0"
 
 {{ with .Prefilter }}
 prefilter = {{ tomlCEL . }}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -17,7 +17,7 @@ title = "betterleaks config"
 # betterleaksMinVersion indicates the minimum betterleaks version required.
 # If the running version is older, a warning will be logged.
 minVersion = "v8.25.0"
-betterleaksMinVersion = "v1.2.0"
+betterleaksMinVersion = "v1.3.0"
 
 
 prefilter = '''


### PR DESCRIPTION
`finding` map in CEL requires v1.3.0