### PR TITLE
feat(dir): include/exclude globs and path patterns in ignore files

### DIFF
--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -16,6 +16,8 @@ import (
 func init() {
 	rootCmd.AddCommand(directoryCmd)
 	directoryCmd.Flags().Bool("follow-symlinks", false, "scan files that are symlinks to other files")
+	directoryCmd.Flags().StringSlice("include", []string{}, "only scan files matching these path globs")
+	directoryCmd.Flags().StringSlice("exclude", []string{}, "skip files and directories matching these path globs")
 }
 
 var directoryCmd = &cobra.Command{
@@ -37,6 +39,8 @@ func runDirectory(cmd *cobra.Command, args []string) {
 	// start timer
 	start := time.Now()
 	followSymlinks := mustGetBoolFlag(cmd, "follow-symlinks")
+	includeGlobs, _ := cmd.Flags().GetStringSlice("include")
+	excludeGlobs, _ := cmd.Flags().GetStringSlice("exclude")
 	maxArchiveDepth := mustGetIntFlag(cmd, "max-archive-depth")
 	maxTargetMegaBytes := mustGetIntFlag(cmd, "max-target-megabytes")
 	noColor := mustGetBoolFlag(cmd, "no-color")
@@ -59,8 +63,12 @@ func runDirectory(cmd *cobra.Command, args []string) {
 		detector.SkipFindingAppend = true
 		lastDetector = detector
 
+		exclude := append(excludeGlobs, detector.PathExcludeGlobs()...)
+
 		s := &sources.Files{
 			ShouldSkip:      detector.SkipFunc(),
+			IncludeGlobs:    includeGlobs,
+			ExcludeGlobs:    exclude,
 			FollowSymlinks:  followSymlinks,
 			MaxFileSize:     maxTargetMegaBytes * 1_000_000,
 			Path:            source,

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -109,6 +110,10 @@ type Detector struct {
 
 	// gitleaksIgnore
 	gitleaksIgnore map[string]struct{}
+
+	// pathExcludeGlobs lists path patterns from .betterleaksignore / .gitleaksignore
+	// that skip files and directories during directory scans.
+	pathExcludeGlobs []string
 
 	TotalBytes atomic.Uint64
 
@@ -531,6 +536,11 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 			continue
 		}
 
+		if !isIgnoreFingerprintLine(line) {
+			d.pathExcludeGlobs = append(d.pathExcludeGlobs, replacer.Replace(line))
+			continue
+		}
+
 		// Normalize the path.
 		// TODO: Make this a breaking change in v9.
 		s := strings.Split(line, ":")
@@ -545,10 +555,33 @@ func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
 			s[1] = replacer.Replace(s[1])
 		default:
 			logging.Warn().Str("fingerprint", line).Msg("Invalid .gitleaksignore entry")
+			continue
 		}
 		d.gitleaksIgnore[strings.Join(s, ":")] = struct{}{}
 	}
-	return nil
+	return scanner.Err()
+}
+
+// PathExcludeGlobs returns path patterns loaded from ignore files.
+func (d *Detector) PathExcludeGlobs() []string {
+	if d == nil || len(d.pathExcludeGlobs) == 0 {
+		return nil
+	}
+	return append([]string(nil), d.pathExcludeGlobs...)
+}
+
+func isIgnoreFingerprintLine(line string) bool {
+	parts := strings.Split(line, ":")
+	switch len(parts) {
+	case 3:
+		_, err := strconv.Atoi(strings.TrimSpace(parts[2]))
+		return err == nil
+	case 4:
+		_, err := strconv.Atoi(strings.TrimSpace(parts[3]))
+		return err == nil
+	default:
+		return false
+	}
 }
 
 // DetectString scans the given string and returns a list of findings

--- a/detect/detect_ignore_test.go
+++ b/detect/detect_ignore_test.go
@@ -1,0 +1,28 @@
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddGitleaksIgnore_pathGlobs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	ignorePath := filepath.Join(dir, ".betterleaksignore")
+	content := `# fixtures
+fixtures/test-keys/**
+api/api.go:aws-access-key:7
+`
+	require.NoError(t, os.WriteFile(ignorePath, []byte(content), 0o600))
+
+	d := NewDetector(nil)
+	require.NoError(t, d.AddGitleaksIgnore(ignorePath))
+
+	require.Equal(t, []string{"fixtures/test-keys/**"}, d.PathExcludeGlobs())
+	_, ok := d.gitleaksIgnore["api/api.go:aws-access-key:7"]
+	require.True(t, ok)
+}

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -51,7 +51,7 @@ betterleaks dir . --include 'src/**' --include 'pkg/**'
 betterleaks dir . --exclude 'fixtures/**' --exclude 'testdata/**'
 ```
 
-Path globs use `filepath.Match` syntax. Patterns ending in `/` or `/**` skip entire directory trees.
+Path globs use `filepath.Match` syntax against the full file path. Patterns ending in `/` or `/**` skip entire directory trees. Use `**/*.go` (not `*.go`) to match by file extension in any directory.
 
 `.betterleaksignore` (and `.gitleaksignore`) accept finding fingerprints and path globs:
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -43,6 +43,24 @@ betterleaks dir . --report-path findings.json --report-format json
 
 # SARIF for code scanning platforms
 betterleaks dir . --report-path findings.sarif --report-format sarif
+
+# only scan selected paths
+betterleaks dir . --include 'src/**' --include 'pkg/**'
+
+# skip fixture directories (also supported in .betterleaksignore)
+betterleaks dir . --exclude 'fixtures/**' --exclude 'testdata/**'
+```
+
+Path globs use `filepath.Match` syntax. Patterns ending in `/` or `/**` skip entire directory trees.
+
+`.betterleaksignore` (and `.gitleaksignore`) accept finding fingerprints and path globs:
+
+```gitignore
+# skip a directory of test keys
+fixtures/test-keys/**
+
+# ignore a specific prior finding
+api/api.go:aws-access-key:7
 ```
 
 ---

--- a/sources/files.go
+++ b/sources/files.go
@@ -46,11 +46,12 @@ func (s *Files) scanTargets(ctx context.Context, yield func(ScanTarget, error) e
 			return nil
 		}
 
-		if !ShouldScanPath(path, s.IncludeGlobs, s.ExcludeGlobs) {
-			if d.IsDir() {
+		if d.IsDir() {
+			if !ShouldWalkDir(path, s.IncludeGlobs, s.ExcludeGlobs) {
 				logger.Debug().Msg("skipping directory: include/exclude glob")
 				return filepath.SkipDir
 			}
+		} else if !ShouldScanPath(path, s.IncludeGlobs, s.ExcludeGlobs) {
 			logger.Debug().Msg("skipping file: include/exclude glob")
 			return nil
 		}

--- a/sources/files.go
+++ b/sources/files.go
@@ -21,6 +21,8 @@ type ScanTarget struct {
 // Files is a source for yielding fragments from a collection of files
 type Files struct {
 	ShouldSkip      SkipFunc
+	IncludeGlobs    []string
+	ExcludeGlobs    []string
 	FollowSymlinks  bool
 	MaxFileSize     int
 	Path            string
@@ -41,6 +43,15 @@ func (s *Files) scanTargets(ctx context.Context, yield func(ScanTarget, error) e
 				return filepath.SkipDir
 			}
 			logger.Warn().Err(err).Msg("skipping")
+			return nil
+		}
+
+		if !ShouldScanPath(path, s.IncludeGlobs, s.ExcludeGlobs) {
+			if d.IsDir() {
+				logger.Debug().Msg("skipping directory: include/exclude glob")
+				return filepath.SkipDir
+			}
+			logger.Debug().Msg("skipping file: include/exclude glob")
 			return nil
 		}
 

--- a/sources/pathglob.go
+++ b/sources/pathglob.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// ShouldScanPath reports whether path should be scanned given optional include
-// and exclude glob patterns. Exclude is checked first. When include is
-// non-empty, the path must match at least one include pattern.
+// ShouldScanPath reports whether a file path should be scanned. Exclude is
+// checked first. When include is non-empty, the path must match at least one
+// include pattern.
 func ShouldScanPath(path string, include, exclude []string) bool {
 	path = filepath.ToSlash(path)
 	if pathMatchesAnyGlob(path, exclude) {
@@ -19,9 +19,27 @@ func ShouldScanPath(path string, include, exclude []string) bool {
 	return true
 }
 
+// ShouldWalkDir reports whether a directory should be entered during a walk.
+// Unlike ShouldScanPath, a directory that does not itself match an include
+// pattern is still walked when it is an ancestor of a matching path (e.g. "."
+// with include "src/**").
+func ShouldWalkDir(path string, include, exclude []string) bool {
+	path = filepath.ToSlash(filepath.Clean(path))
+	if pathMatchesAnyGlob(path, exclude) {
+		return false
+	}
+	if len(include) == 0 {
+		return true
+	}
+	if pathMatchesAnyGlob(path, include) {
+		return true
+	}
+	return isAncestorOfAnyInclude(path, include)
+}
+
 // pathMatchesAnyGlob reports whether path matches any glob pattern.
-// Patterns use filepath.Match syntax. A trailing "/" or "/**" matches that
-// directory and all descendants.
+// Patterns use filepath.Match syntax against the full path. A trailing "/" or
+// "/**" matches that directory and all descendants.
 func pathMatchesAnyGlob(path string, globs []string) bool {
 	if len(globs) == 0 {
 		return false
@@ -48,9 +66,48 @@ func pathMatchesAnyGlob(path string, globs []string) bool {
 		if matched, _ := filepath.Match(pattern, path); matched {
 			return true
 		}
-		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
-			return true
+	}
+	return false
+}
+
+// isAncestorOfAnyInclude reports whether path is a parent (or walk root) of a
+// path that could match one of the include patterns.
+func isAncestorOfAnyInclude(path string, includes []string) bool {
+	if path == "." {
+		path = ""
+	}
+	for _, pattern := range includes {
+		pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+		if pattern == "" {
+			continue
+		}
+		for _, prefix := range includePathPrefixes(pattern) {
+			if prefix == "" {
+				// Pattern has no directory anchor (e.g. "*.go"); walk full tree.
+				return true
+			}
+			if path == "" {
+				return true
+			}
+			if prefix == path || strings.HasPrefix(prefix, path+"/") {
+				return true
+			}
 		}
 	}
 	return false
+}
+
+// includePathPrefixes returns directory prefixes that must be traversed to
+// reach paths matched by pattern.
+func includePathPrefixes(pattern string) []string {
+	if strings.HasSuffix(pattern, "/**") {
+		return []string{strings.TrimSuffix(pattern, "/**")}
+	}
+	if strings.HasSuffix(pattern, "/") {
+		return []string{strings.TrimSuffix(pattern, "/")}
+	}
+	if idx := strings.LastIndex(pattern, "/"); idx >= 0 {
+		return []string{pattern[:idx]}
+	}
+	return []string{""}
 }

--- a/sources/pathglob.go
+++ b/sources/pathglob.go
@@ -1,0 +1,56 @@
+package sources
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// ShouldScanPath reports whether path should be scanned given optional include
+// and exclude glob patterns. Exclude is checked first. When include is
+// non-empty, the path must match at least one include pattern.
+func ShouldScanPath(path string, include, exclude []string) bool {
+	path = filepath.ToSlash(path)
+	if pathMatchesAnyGlob(path, exclude) {
+		return false
+	}
+	if len(include) > 0 && !pathMatchesAnyGlob(path, include) {
+		return false
+	}
+	return true
+}
+
+// pathMatchesAnyGlob reports whether path matches any glob pattern.
+// Patterns use filepath.Match syntax. A trailing "/" or "/**" matches that
+// directory and all descendants.
+func pathMatchesAnyGlob(path string, globs []string) bool {
+	if len(globs) == 0 {
+		return false
+	}
+	for _, pattern := range globs {
+		pattern = filepath.ToSlash(strings.TrimSpace(pattern))
+		if pattern == "" {
+			continue
+		}
+		if strings.HasSuffix(pattern, "/**") {
+			prefix := strings.TrimSuffix(pattern, "/**")
+			if path == prefix || strings.HasPrefix(path, prefix+"/") {
+				return true
+			}
+			continue
+		}
+		if strings.HasSuffix(pattern, "/") {
+			prefix := strings.TrimSuffix(pattern, "/")
+			if path == prefix || strings.HasPrefix(path, prefix+"/") {
+				return true
+			}
+			continue
+		}
+		if matched, _ := filepath.Match(pattern, path); matched {
+			return true
+		}
+		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+			return true
+		}
+	}
+	return false
+}

--- a/sources/pathglob_test.go
+++ b/sources/pathglob_test.go
@@ -1,0 +1,68 @@
+package sources
+
+import "testing"
+
+func TestShouldScanPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		include []string
+		exclude []string
+		want    bool
+	}{
+		{
+			name:    "no filters",
+			path:    "src/main.go",
+			want:    true,
+		},
+		{
+			name:    "exclude directory prefix",
+			path:    "fixtures/keys/secret.txt",
+			exclude: []string{"fixtures/keys/**"},
+			want:    false,
+		},
+		{
+			name:    "exclude does not match sibling",
+			path:    "fixtures/other/secret.txt",
+			exclude: []string{"fixtures/keys/**"},
+			want:    true,
+		},
+		{
+			name:    "include limits scan",
+			path:    "pkg/a.go",
+			include: []string{"src/**"},
+			want:    false,
+		},
+		{
+			name:    "include allows match",
+			path:    "src/a.go",
+			include: []string{"src/**"},
+			want:    true,
+		},
+		{
+			name:    "exclude wins over include",
+			path:    "src/ignored.txt",
+			include: []string{"src/**"},
+			exclude: []string{"src/ignored.txt"},
+			want:    false,
+		},
+		{
+			name:    "glob file pattern",
+			path:    "tmp/notes.txt",
+			exclude: []string{"tmp/*.txt"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ShouldScanPath(tt.path, tt.include, tt.exclude)
+			if got != tt.want {
+				t.Fatalf("ShouldScanPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/sources/pathglob_test.go
+++ b/sources/pathglob_test.go
@@ -13,9 +13,9 @@ func TestShouldScanPath(t *testing.T) {
 		want    bool
 	}{
 		{
-			name:    "no filters",
-			path:    "src/main.go",
-			want:    true,
+			name: "no filters",
+			path: "src/main.go",
+			want: true,
 		},
 		{
 			name:    "exclude directory prefix",
@@ -49,10 +49,16 @@ func TestShouldScanPath(t *testing.T) {
 			want:    false,
 		},
 		{
-			name:    "glob file pattern",
+			name:    "glob file pattern full path",
 			path:    "tmp/notes.txt",
 			exclude: []string{"tmp/*.txt"},
 			want:    false,
+		},
+		{
+			name:    "exclude basename pattern does not match nested file",
+			path:    "pkg/main.go",
+			exclude: []string{"*.go"},
+			want:    true,
 		},
 	}
 
@@ -62,6 +68,53 @@ func TestShouldScanPath(t *testing.T) {
 			got := ShouldScanPath(tt.path, tt.include, tt.exclude)
 			if got != tt.want {
 				t.Fatalf("ShouldScanPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldWalkDir(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		include []string
+		exclude []string
+		want    bool
+	}{
+		{
+			name:    "walk root with subdirectory include",
+			path:    ".",
+			include: []string{"src/**"},
+			want:    true,
+		},
+		{
+			name:    "skip unrelated directory with include filter",
+			path:    "pkg",
+			include: []string{"src/**"},
+			want:    false,
+		},
+		{
+			name:    "walk included directory prefix",
+			path:    "src",
+			include: []string{"src/**"},
+			want:    true,
+		},
+		{
+			name:    "exclude prunes directory tree",
+			path:    "fixtures/keys",
+			exclude: []string{"fixtures/keys/**"},
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ShouldWalkDir(tt.path, tt.include, tt.exclude)
+			if got != tt.want {
+				t.Fatalf("ShouldWalkDir(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add `--include` and `--exclude` path glob flags to `betterleaks dir` (aligned with maintainer feedback on #150).
- Allow `.betterleaksignore` / `.gitleaksignore` to list **path globs** in addition to finding fingerprints, so repos can skip directories (e.g. test key fixtures) without changing a shared Docker image or CLI args.

Fixes #150

## Motivation

Issue #150 asked for a way to ignore whole directories when scanning. Maintainers suggested `--include`/`--exclude` on the directory command; reporters also need repository-local rules via `.betterleaksignore` when the launch command is fixed org-wide.

## Changes

| Area | What |
|------|------|
| `cmd/directory.go` | `--include`, `--exclude` flags |
| `sources/pathglob.go` | Glob matching (`**`, trailing `/`) |
| `sources/files.go` | Skip paths during directory walk |
| `detect/detect.go` | Parse non-fingerprint lines in ignore files as path excludes |
| `docs/scanning.md` | Usage examples |

## Test plan

- [x] `go test ./sources/... -run TestShouldScanPath`
- [x] `go test ./detect/... -run TestAddGitleaksIgnore_pathGlobs`
- [ ] Manual: `betterleaks dir . --exclude 'fixtures/**'`
- [ ] Manual: add `fixtures/test-keys/**` to `.betterleaksignore` and confirm directory is skipped

## Example

```sh
betterleaks dir . --exclude 'fixtures/test-keys/**'
```

```gitignore
# .betterleaksignore
fixtures/test-keys/**
api/api.go:aws-access-key:7
```