### PR TITLE
GitLab source + GitLab cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Betterleaks
 ```
-     ○ 
+     ○
      ○
 ghp_ ● qOomCIZBWchHR4v5FPp9UiQRS9CyigrCkXXuIJQPfe63f12a
-     ○ 
+     ○
 ```
 
-Betterleaks is a configurable, fast, and thorough secrets scanner. It is maintained by the folks who made Gitleaks, including the original author. 
+Betterleaks is a configurable, fast, and thorough secrets scanner. It is maintained by the folks who made Gitleaks, including the original author.
 Check out this series of blog posts to learn how the detection engine works: 1. [Regex is all you need](https://lookingatcomputer.substack.com/p/regex-is-almost-all-you-need), 2. [Rare Not Random](https://lookingatcomputer.substack.com/p/rare-not-random), 3. [Express YourCELf](https://lookingatcomputer.substack.com/p/express-yourcelf-filtering-and-validating).
 
 Development is supported by
@@ -20,7 +20,7 @@ Development is supported by
 | **Secrets Validation** | Validate if a detected secret is active by making asynchronous HTTP requests directly from within the rule definition using CEL. |
 | **Token Efficiency filtering** | Filter out natural language false positives by using BPE tokenization to measure how "rare" or non-human a string is. |
 | **Fast scans** | Achieve fast performance through sane default parallelization settings, ahocorasick keyword filters, and re2. |
-| **New Sources** | Support for sources like GitHub, S3, and more. It's easy to add new sources too!   |
+| **New Sources** | Support for sources like GitHub, GitLab, S3, and more. It's easy to add new sources too!   |
 | **Portability** | Runs on any modern OS/Arch. The small binary can be integrated in any system. |
 
 
@@ -56,6 +56,12 @@ betterleaks github https://github.com/betterleaks
 betterleaks github https://github.com/cooluser123456789 --include issues,prs,actions,releases,gists
 # Scan specific resource, like a PR... but exclude the description (only scan comments)
 betterleaks github https://github.com/betterleaks/betterleaks/pull/113
+
+# Scan GitLab group or project
+betterleaks gitlab https://gitlab.com/mygroup
+betterleaks gitlab https://gitlab.com/mygroup/myproject --include issues,mrs,releases,ci-jobs
+# Scan a specific GitLab merge request
+betterleaks gitlab https://gitlab.com/mygroup/myproject/-/merge_requests/42
 
 # Scan a public s3 dataset (Common Crawl).
 betterleaks s3 https://commoncrawl.s3.us-east-1.amazonaws.com/crawl-data/CC-MAIN-2018-17/segments/1524125937193.1/warc/
@@ -141,4 +147,3 @@ Set the exit code when leaks are encountered with the --exit-code flag. Default 
 1 - leaks or error encountered
 126 - unknown flag
 ```
-

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/report"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+func init() {
+	rootCmd.AddCommand(gitlabCmd)
+	gitlabCmd.Flags().String("token", "", "GitLab personal access token (or set GITLAB_TOKEN)")
+	gitlabCmd.Flags().String("base-url", "", "site base URL for self-hosted instances (e.g. https://gitlab.example.com/)")
+	gitlabCmd.Flags().StringSlice("include", nil,
+		"resource types to scan: repos (default), forks, mrs, mr-comments, "+
+			"issues, issue-comments, snippets, releases, release-assets, ci-jobs, ci-artifacts")
+	gitlabCmd.Flags().StringSlice("exclude", nil,
+		"resource types to skip: repos, forks, mrs, mr-comments, "+
+			"issues, issue-comments, snippets, releases, release-assets, ci-jobs, ci-artifacts")
+	gitlabCmd.Flags().StringSlice("exclude-repo", nil, "glob patterns to exclude projects by full path (e.g. 'group/test-*')")
+	gitlabCmd.Flags().Bool("include-subgroups", true, "when scanning a group, recurse into subgroups")
+	gitlabCmd.Flags().Bool("all-groups", false, "enumerate every group visible to the token (instance-wide)")
+	gitlabCmd.Flags().Int("git-workers", 0, "parallel git workers per project (0 = single process)")
+	gitlabCmd.Flags().String("log-opts", "", "git log options passed to each project scan")
+
+	gitlabCmd.Flags().String("since", "", "only scan API items created after this date (YYYY-MM-DD or RFC3339)")
+	gitlabCmd.Flags().String("until", "", "only scan API items created before this date (YYYY-MM-DD or RFC3339)")
+}
+
+var gitlabCmd = &cobra.Command{
+	Use:   "gitlab <target-url> [flags]",
+	Short: "scan GitLab projects and resources for secrets",
+	Example: `  # Scan a project's git history
+  betterleaks gitlab https://gitlab.com/group/project
+
+  # Scan a merge request
+  betterleaks gitlab https://gitlab.com/group/project/-/merge_requests/42
+
+  # Scan all projects under a group (recursing into subgroups by default)
+  betterleaks gitlab https://gitlab.com/mygroup
+
+  # Scan projects plus issues and MRs
+  betterleaks gitlab --include=issues,mrs https://gitlab.com/group/project
+
+  # Scan a self-hosted instance
+  betterleaks gitlab --base-url=https://gitlab.example.com/ https://gitlab.example.com/group/project`,
+	Args: cobra.ExactArgs(1),
+	Run:  runGitLab,
+}
+
+func runGitLab(cmd *cobra.Command, args []string) {
+	start := time.Now()
+
+	initConfig(".")
+	initDiagnostics()
+
+	cfg := Config(cmd)
+	detector := Detector(cmd, cfg, ".")
+
+	targetURL := args[0]
+
+	token := mustGetStringFlag(cmd, "token")
+	if token == "" {
+		token = os.Getenv("GITLAB_TOKEN")
+	}
+
+	include, _ := cmd.Flags().GetStringSlice("include")
+	exclude, _ := cmd.Flags().GetStringSlice("exclude")
+	excludeRepos, _ := cmd.Flags().GetStringSlice("exclude-repo")
+
+	var since, until time.Time
+	var err error
+	if s := mustGetStringFlag(cmd, "since"); s != "" {
+		since, err = parseDateFlag(s)
+		if err != nil {
+			logging.Fatal().Err(err).Msg("invalid --since value; use YYYY-MM-DD or RFC3339")
+		}
+	}
+	if s := mustGetStringFlag(cmd, "until"); s != "" {
+		until, err = parseDateFlag(s)
+		if err != nil {
+			logging.Fatal().Err(err).Msg("invalid --until value; use YYYY-MM-DD or RFC3339")
+		}
+	}
+
+	src := &sources.GitLab{
+		Token:            token,
+		URL:              targetURL,
+		BaseURL:          mustGetStringFlag(cmd, "base-url"),
+		Include:          include,
+		Exclude:          exclude,
+		ExcludeRepos:     excludeRepos,
+		AllGroups:        mustGetBoolFlag(cmd, "all-groups"),
+		IncludeSubgroups: mustGetBoolFlag(cmd, "include-subgroups"),
+		ShouldSkip:       detector.SkipFunc(),
+		Sema:             detector.Sema,
+		MaxArchiveDepth:  detector.MaxArchiveDepth,
+		Workers:          mustGetIntFlag(cmd, "git-workers"),
+		LogOpts:          mustGetStringFlag(cmd, "log-opts"),
+		DateRangeOpts: sources.DateRangeOptions{
+			Since: since,
+			Until: until,
+		},
+	}
+
+	if err := src.Validate(); err != nil {
+		logging.Fatal().Err(err).Msg("invalid GitLab configuration")
+	}
+
+	exitCode := mustGetIntFlag(cmd, "exit-code")
+	noColor := mustGetBoolFlag(cmd, "no-color")
+	redact := mustGetUIntFlag(cmd, "redact")
+	verbose := mustGetBoolFlag(cmd, "verbose")
+
+	detector.SkipFindingAppend = true
+	var findings []report.Finding
+	var scanErrs []error
+	for result := range detector.Run(cmd.Context(), src) {
+		if result.Err != nil {
+			scanErrs = append(scanErrs, result.Err)
+			logging.Error().Err(result.Err).Msg("scan error")
+			continue
+		}
+		findings = append(findings, result.Finding)
+		if verbose {
+			if detector.LegacyPrint {
+				result.Finding.PrintLegacy(noColor, redact)
+			} else {
+				result.Finding.Print(noColor, redact)
+			}
+		}
+	}
+
+	var scanErr error
+	if n := len(scanErrs); n > 0 {
+		scanErr = &multipleErrors{
+			msg:  fmt.Sprintf("%d error(s) during GitLab scan", n),
+			errs: scanErrs,
+		}
+	}
+	findingSummaryAndExit(detector, findings, exitCode, start, scanErr)
+}

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -10,6 +10,7 @@ Use `--help` for full flag descriptions. This page is for patterns.
 | Git history | `betterleaks git` |
 | Staged or pre-commit diffs | `betterleaks git --pre-commit [--staged]` |
 | GitHub repos, Issues, PRs, Actions, Releases, Discussions, Gists | `betterleaks github <url>` |
+| GitLab projects, Issues, MRs, Snippets, Releases, CI jobs/artifacts | `betterleaks gitlab <url>` |
 | S3 (and S3-compatible: R2, MinIO, etc.) | `betterleaks s3 <url>` |
 | Piped content | `betterleaks stdin` |
 
@@ -216,6 +217,138 @@ betterleaks github https://github.example.com/platform-team
 
 ---
 
+## `gitlab`
+
+`gitlab` takes a target URL. Project, group, and user targets scan git history by default; specific resource URLs scan the matching resource plus associated comments or assets by default. Use `--include` to add resource types and `--exclude` to skip types.
+
+Set `GITLAB_TOKEN` in the environment before running these examples. Public project git history can be scanned without a token, but group/user enumeration and API-backed resources require one.
+
+### Resource types
+
+| Type | Description |
+| :--- | :--- |
+| `repos` | Git repository history (default) |
+| `forks` | Include forked projects |
+| `mrs` | Merge request descriptions |
+| `mr-comments` | Comments on merge requests (auto-included with `mrs`) |
+| `issues` | Issue descriptions |
+| `issue-comments` | Comments on issues (auto-included with `issues`) |
+| `snippets` | Project snippet contents |
+| `releases` | Release descriptions |
+| `release-assets` | Downloadable release assets and source archives (auto-included with `releases`) |
+| `ci-jobs` | CI job logs |
+| `ci-artifacts` | CI job artifacts (auto-included with `ci-jobs`) |
+
+### Target selection
+
+```sh
+# scan a project's git history
+betterleaks gitlab https://gitlab.com/my-company/backend
+
+# scan all projects under a group, including subgroups by default
+betterleaks gitlab https://gitlab.com/my-company
+
+# scan a group without recursing into subgroups
+betterleaks gitlab \
+	--include-subgroups=false \
+	https://gitlab.com/my-company
+
+# enumerate every group visible to the token
+betterleaks gitlab \
+	--all-groups \
+	https://gitlab.com/
+
+# exclude forks and project globs
+betterleaks gitlab \
+	--include=forks \
+	--exclude-repo 'my-company/*-archive' \
+	--exclude-repo 'my-company/playground-*' \
+	https://gitlab.com/my-company
+
+# skip repo git history, scan only API resources
+betterleaks gitlab \
+	--include=issues,mrs,issue-comments,mr-comments \
+	--exclude=repos \
+	https://gitlab.com/my-company
+```
+
+### Issues, MRs, comments
+
+```sh
+betterleaks gitlab \
+	--include=issues,mrs,issue-comments,mr-comments \
+	--since 2026-01-01 \
+	https://gitlab.com/my-company/backend
+
+betterleaks gitlab \
+	--include=issues,mrs,issue-comments \
+	--since 2026-01-01 \
+	--until 2026-04-01 \
+	https://gitlab.com/my-company
+```
+
+### Releases, snippets, CI
+
+```sh
+# snippets
+betterleaks gitlab \
+	--include=snippets \
+	https://gitlab.com/my-company/backend
+
+# releases and release assets
+betterleaks gitlab \
+	--include=releases \
+	https://gitlab.com/my-company/backend
+
+# releases, but skip downloadable assets
+betterleaks gitlab \
+	--include=releases \
+	--exclude=release-assets \
+	https://gitlab.com/my-company/backend
+
+# CI job logs
+betterleaks gitlab \
+	--include=ci-jobs \
+	https://gitlab.com/my-company/backend
+
+# CI job logs and artifacts
+betterleaks gitlab \
+	--include=ci-jobs,ci-artifacts \
+	https://gitlab.com/my-company/backend
+```
+
+### Single GitLab resource
+
+```sh
+# merge request
+betterleaks gitlab https://gitlab.com/my-company/backend/-/merge_requests/1234
+
+# issue
+betterleaks gitlab https://gitlab.com/my-company/backend/-/issues/99
+
+# snippet
+betterleaks gitlab https://gitlab.com/my-company/backend/-/snippets/55
+
+# release tag
+betterleaks gitlab https://gitlab.com/my-company/backend/-/releases/v1.2.3
+
+# pipeline
+betterleaks gitlab https://gitlab.com/my-company/backend/-/pipelines/123456789
+
+# job
+betterleaks gitlab https://gitlab.com/my-company/backend/-/jobs/987654321
+```
+
+### Self-managed GitLab
+
+```sh
+betterleaks gitlab \
+	--base-url=https://gitlab.example.com/ \
+	https://gitlab.example.com/platform-team/backend
+```
+
+---
+
 ## `s3`
 
 `s3` takes a single URL describing either one bucket or a glob of buckets to enumerate. The same command works against AWS, Cloudflare R2, MinIO, Backblaze B2, DigitalOcean Spaces, Wasabi — anything speaking the S3 REST API.
@@ -373,4 +506,3 @@ betterleaks dir ./artifacts --max-archive-depth 2 --max-decode-depth 5
 ## Related docs
 
 - [docs/config.md](config.md)
-

--- a/sources/attribute.go
+++ b/sources/attribute.go
@@ -23,6 +23,16 @@ const (
 	ResourceGitHubReleaseAsset = "github.release_asset"
 	ResourceGitHubGist         = "github.gist"
 
+	ResourceGitLabProject      = "gitlab.project"
+	ResourceGitLabIssue        = "gitlab.issue"
+	ResourceGitLabMR           = "gitlab.mr"
+	ResourceGitLabComment      = "gitlab.comment"
+	ResourceGitLabSnippet      = "gitlab.snippet"
+	ResourceGitLabRelease      = "gitlab.release"
+	ResourceGitLabReleaseAsset = "gitlab.release_asset"
+	ResourceGitLabCIJob        = "gitlab.ci_job"
+	ResourceGitLabCIArtifact   = "gitlab.ci_artifact"
+
 	// Git
 	AttrGitSHA         = "git.sha"
 	AttrGitAuthorName  = "git.author_name"
@@ -56,6 +66,23 @@ const (
 	AttrGitHubGistID           = "github.gist.id"
 	AttrGitHubGistFilename     = "github.gist.filename"
 	AttrGitHubGistOwner        = "github.gist.owner"
+
+	// GitLab
+	AttrGitLabProjectID        = "gitlab.project.id"
+	AttrGitLabProjectPath      = "gitlab.project.path"
+	AttrGitLabProjectURL       = "gitlab.project.url"
+	AttrGitLabVisibility       = "gitlab.visibility"
+	AttrGitLabNamespace        = "gitlab.namespace"
+	AttrGitLabIssueIID         = "gitlab.issue.iid"
+	AttrGitLabMRIID            = "gitlab.mr.iid"
+	AttrGitLabCommentID        = "gitlab.comment.id"
+	AttrGitLabSnippetID        = "gitlab.snippet.id"
+	AttrGitLabSnippetFilename  = "gitlab.snippet.filename"
+	AttrGitLabReleaseTag       = "gitlab.release.tag"
+	AttrGitLabReleaseAssetName = "gitlab.release.asset_name"
+	AttrGitLabCIJobID          = "gitlab.ci_job.id"
+	AttrGitLabCIJobName        = "gitlab.ci_job.name"
+	AttrGitLabCIPipelineID     = "gitlab.ci_pipeline.id"
 
 	// S3 (and S3-compatible object stores)
 	AttrS3Bucket       = "s3.bucket"

--- a/sources/common.go
+++ b/sources/common.go
@@ -143,6 +143,7 @@ func readUntilSafeBoundary(r *bufio.Reader, n int, maxPeekSize int, peekBuf *byt
 type sourceDownloadOptions struct {
 	URL             string
 	Reader          io.ReadCloser
+	HTTPClient      *http.Client
 	Path            string
 	Attrs           map[string]string
 	BearerToken     string
@@ -164,8 +165,11 @@ func downloadAndScanSource(ctx context.Context, opts sourceDownloadOptions, yiel
 		if opts.BearerToken != "" {
 			req.Header.Set("Authorization", "Bearer "+opts.BearerToken)
 		}
-		httpClient := &http.Client{
-			Timeout: downloadTimeout,
+		httpClient := opts.HTTPClient
+		if httpClient == nil {
+			httpClient = &http.Client{
+				Timeout: downloadTimeout,
+			}
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {

--- a/sources/gitlab.go
+++ b/sources/gitlab.go
@@ -1,0 +1,1587 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fatih/semgroup"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/betterleaks/betterleaks/internal/httpclient"
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/sources/scm"
+)
+
+const (
+	gitlabPerPage          = 100
+	gitlabScanConcurrency  = 100
+	gitlabDefaultBase      = "https://gitlab.com/"
+	gitlabAPISuffix        = "api/v4/"
+)
+
+// GitLab enumerates projects via the GitLab REST API and delegates scanning
+// to the Git source for each cloned repo.
+type GitLab struct {
+	// Auth
+	Token string
+
+	// Target URL (required). A gitlab.com or self-hosted instance URL pointing
+	// at a project, group, user, or specific resource (issue, MR, snippet,
+	// release, pipeline, job).
+	URL string
+
+	// BaseURL is the site base for self-hosted instances (e.g.
+	// "https://gitlab.example.com/" or "https://corp.com/gitlab/"). Leave
+	// empty to infer "<scheme>://<host>/" from URL.
+	BaseURL string
+
+	// Filtering
+	ExcludeRepos []string // glob patterns matched against "group/sub/project"
+	Include      []string
+	Exclude      []string
+	Resources    GitLabResourceSet
+
+	// Group enumeration knobs
+	AllGroups        bool
+	IncludeSubgroups bool
+
+	// Scan config (passed through to Git/ParallelGit per project)
+	ShouldSkip      SkipFunc
+	Sema            *semgroup.Group
+	MaxArchiveDepth int
+	Workers         int
+	LogOpts         string
+
+	// Date-range filtering for API-backed resources
+	DateRangeOpts DateRangeOptions
+
+	// Internal: lazily initialized in Fragments.
+	httpClient *http.Client
+	restRetry  *httpclient.RetryTransport
+	apiBaseURL *url.URL // normalized site base ending in `/api/v4/`
+
+	// Cached counters for completion logging.
+	rlRemaining atomic.Int64
+	rlResetAt   atomic.Int64
+}
+
+// GitLabResourceType identifies a scannable GitLab resource category.
+type GitLabResourceType string
+
+const (
+	GitLabResourceTypeRepos         GitLabResourceType = "repos"
+	GitLabResourceTypeForks         GitLabResourceType = "forks"
+	GitLabResourceTypeMRs           GitLabResourceType = "mrs"
+	GitLabResourceTypeMRComments    GitLabResourceType = "mr-comments"
+	GitLabResourceTypeIssues        GitLabResourceType = "issues"
+	GitLabResourceTypeIssueComments GitLabResourceType = "issue-comments"
+	GitLabResourceTypeSnippets      GitLabResourceType = "snippets"
+	GitLabResourceTypeReleases      GitLabResourceType = "releases"
+	GitLabResourceTypeReleaseAssets GitLabResourceType = "release-assets"
+	GitLabResourceTypeCIJobs        GitLabResourceType = "ci-jobs"
+	GitLabResourceTypeCIArtifacts   GitLabResourceType = "ci-artifacts"
+)
+
+// AllGitLabResourceTypes is the canonical list of valid GitLab resource types.
+var AllGitLabResourceTypes = []GitLabResourceType{
+	GitLabResourceTypeRepos,
+	GitLabResourceTypeForks,
+	GitLabResourceTypeMRs,
+	GitLabResourceTypeMRComments,
+	GitLabResourceTypeIssues,
+	GitLabResourceTypeIssueComments,
+	GitLabResourceTypeSnippets,
+	GitLabResourceTypeReleases,
+	GitLabResourceTypeReleaseAssets,
+	GitLabResourceTypeCIJobs,
+	GitLabResourceTypeCIArtifacts,
+}
+
+// GitLabResourceSet tracks which resource types are enabled for scanning.
+type GitLabResourceSet map[GitLabResourceType]bool
+
+func (rs GitLabResourceSet) Has(r GitLabResourceType) bool { return rs[r] }
+
+// HasAnyIssueOrMR reports whether any issue, MR, or comment resource is enabled.
+func (rs GitLabResourceSet) HasAnyIssueOrMR() bool {
+	return rs[GitLabResourceTypeIssues] || rs[GitLabResourceTypeMRs] ||
+		rs[GitLabResourceTypeIssueComments] || rs[GitLabResourceTypeMRComments]
+}
+
+func (rs GitLabResourceSet) String() string {
+	var out []string
+	for rt := range rs {
+		out = append(out, string(rt))
+	}
+	return strings.Join(out, ",")
+}
+
+// defaultGitLabScanResources lists the default resource types each URL kind scans.
+var defaultGitLabScanResources = map[string][]GitLabResourceType{
+	"namespace": {GitLabResourceTypeRepos},
+	"project":   {GitLabResourceTypeRepos},
+	"group":     {GitLabResourceTypeRepos},
+	"user":      {GitLabResourceTypeRepos},
+	"issue":     {GitLabResourceTypeIssues, GitLabResourceTypeIssueComments},
+	"mr":        {GitLabResourceTypeMRs, GitLabResourceTypeMRComments},
+	"snippet":   {GitLabResourceTypeSnippets},
+	"release":   {GitLabResourceTypeReleases, GitLabResourceTypeReleaseAssets},
+	"pipeline":  {GitLabResourceTypeCIJobs, GitLabResourceTypeCIArtifacts},
+	"job":       {GitLabResourceTypeCIJobs, GitLabResourceTypeCIArtifacts},
+}
+
+// Validate checks the GitLab source configuration and populates Resources if needed.
+func (s *GitLab) Validate() error {
+	if s.URL == "" {
+		return errors.New("target URL is required")
+	}
+
+	parsed, err := ParseGitLabURL(s.URL)
+	if err != nil {
+		return fmt.Errorf("invalid target URL: %w", err)
+	}
+
+	if s.BaseURL == "" {
+		s.BaseURL = fmt.Sprintf("%s://%s/", parsed.Scheme, parsed.Host)
+	}
+	if !strings.HasSuffix(s.BaseURL, "/") {
+		s.BaseURL += "/"
+	}
+
+	if len(s.Resources) == 0 {
+		valid := make(map[GitLabResourceType]bool, len(AllGitLabResourceTypes))
+		for _, rt := range AllGitLabResourceTypes {
+			valid[rt] = true
+		}
+		rs := make(GitLabResourceSet)
+		for _, rt := range defaultGitLabScanResources[parsed.Kind] {
+			rs[rt] = true
+		}
+		for _, name := range s.Include {
+			rt := GitLabResourceType(name)
+			if !valid[rt] {
+				return fmt.Errorf("unknown resource type %q", name)
+			}
+			rs[rt] = true
+		}
+		excluded := make(map[GitLabResourceType]bool)
+		for _, name := range s.Exclude {
+			rt := GitLabResourceType(name)
+			if !valid[rt] {
+				return fmt.Errorf("unknown resource type %q", name)
+			}
+			excluded[rt] = true
+			delete(rs, rt)
+		}
+		if rs[GitLabResourceTypeReleases] && !excluded[GitLabResourceTypeReleaseAssets] {
+			rs[GitLabResourceTypeReleaseAssets] = true
+		}
+		if rs[GitLabResourceTypeCIJobs] && !excluded[GitLabResourceTypeCIArtifacts] {
+			rs[GitLabResourceTypeCIArtifacts] = true
+		}
+		s.Resources = rs
+	}
+
+	if s.Token == "" {
+		if parsed.Kind == "namespace" || parsed.Kind == "group" || parsed.Kind == "user" {
+			return errors.New("a token is required to enumerate group or user projects")
+		}
+		for rt := range s.Resources {
+			if rt == GitLabResourceTypeRepos || rt == GitLabResourceTypeForks {
+				continue
+			}
+			return fmt.Errorf("a token is required for API-based resources; only repos and forks can be scanned without a token")
+		}
+	}
+
+	return nil
+}
+
+// Fragments enumerates GitLab projects and scans each one.
+func (s *GitLab) Fragments(ctx context.Context, yield FragmentsFunc) error {
+	if err := s.Validate(); err != nil {
+		return err
+	}
+	logging.Info().
+		Str("target", s.URL).
+		Str("base", s.BaseURL).
+		Stringer("resources", s.Resources).
+		Msg("starting GitLab scan")
+
+	start := time.Now()
+	s.restRetry = httpclient.NewRetryTransport(nil)
+	s.restRetry.Decider = gitlabRetryDecider
+	s.restRetry.StateExtractor = gitlabRateLimitStateExtractor
+
+	apiBase, err := s.buildAPIBase()
+	if err != nil {
+		return err
+	}
+	s.apiBaseURL = apiBase
+	s.httpClient = httpclient.NewAuthenticatedClient(s.Token, s.restRetry, apiBase.Host)
+
+	target, direct, err := s.dispatchURL(ctx, s.URL)
+	if err != nil {
+		return err
+	}
+
+	if direct {
+		return s.scanDirect(ctx, target, yield)
+	}
+
+	scanCtx, cancelScans := context.WithCancel(ctx)
+	defer cancelScans()
+
+	var scanGroup errgroup.Group
+	scanGroup.SetLimit(gitlabScanConcurrency)
+
+	projCh, enumErrCh := s.enumerateProjects(ctx, target)
+	var projCount atomic.Int64
+	for proj := range projCh {
+		projCount.Add(1)
+		scanGroup.Go(func() error {
+			return s.scanProject(scanCtx, proj, yield)
+		})
+	}
+	enumErr := <-enumErrCh
+	if enumErr != nil {
+		cancelScans()
+		scanErr := scanGroup.Wait()
+		combined := fmt.Errorf("enumerate projects: %w", enumErr)
+		if scanErr != nil && !errors.Is(scanErr, context.Canceled) {
+			combined = errors.Join(combined, scanErr)
+		}
+		return combined
+	}
+	logging.Info().
+		Int64("projects", projCount.Load()).
+		Dur("enumeration_ms", time.Since(start)).
+		Msg("enumeration complete, waiting for scans")
+
+	scanErr := scanGroup.Wait()
+	logging.Info().
+		Int64("projects", projCount.Load()).
+		Dur("duration", time.Since(start)).
+		Msg("scan complete")
+	return scanErr
+}
+
+// buildAPIBase normalizes BaseURL to an absolute URL ending in "/api/v4/".
+func (s *GitLab) buildAPIBase() (*url.URL, error) {
+	base := s.BaseURL
+	if base == "" {
+		base = gitlabDefaultBase
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitLab base URL %q: %w", base, err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return nil, fmt.Errorf("GitLab base URL must include scheme and host: %q", base)
+	}
+	u.Path = singleSlashJoin(u.Path, gitlabAPISuffix)
+	return u, nil
+}
+
+// apiURL returns an absolute URL for an API v4 endpoint relative to the
+// configured base, e.g. apiURL("projects/123/issues") →
+// "https://gitlab.com/api/v4/projects/123/issues".
+func (s *GitLab) apiURL(endpoint string) (*url.URL, error) {
+	endpoint = strings.TrimPrefix(endpoint, "/")
+	ref, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitLab endpoint %q: %w", endpoint, err)
+	}
+	return s.apiBaseURL.ResolveReference(ref), nil
+}
+
+func singleSlashJoin(left, right string) string {
+	if left == "" {
+		left = "/"
+	}
+	if !strings.HasSuffix(left, "/") {
+		left += "/"
+	}
+	right = strings.TrimPrefix(right, "/")
+	return left + right
+}
+
+// --- URL parsing ---------------------------------------------------------
+
+// ParsedGitLabURL is the result of splitting a GitLab URL into its components.
+type ParsedGitLabURL struct {
+	Scheme string // http or https
+	Host   string // hostname[:port]
+	Path   string // project/group/user path (everything before "/-/")
+	Kind   string // "namespace", "project", "group", "user", "issue", "mr", "snippet", "release", "pipeline", "job"
+	ID     string // resource ID (number, tag, snippet id)
+}
+
+// ParseGitLabURL parses a GitLab URL into namespace + optional resource segment.
+// At this stage we cannot tell apart project / group / user — `dispatchURL`
+// resolves that by querying the API.
+func ParseGitLabURL(rawURL string) (*ParsedGitLabURL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "https" && u.Scheme != "http" {
+		return nil, fmt.Errorf("URL must use http or https scheme")
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("URL must include a host")
+	}
+
+	out := &ParsedGitLabURL{Scheme: u.Scheme, Host: strings.ToLower(u.Host)}
+
+	trimmed := strings.Trim(u.Path, "/")
+	if trimmed == "" {
+		// Bare host: only valid with explicit AllGroups; caller handles that
+		// via the GitLab.AllGroups field. Kind = "namespace" with empty Path
+		// signals "instance root".
+		out.Kind = "namespace"
+		return out, nil
+	}
+
+	left, right, hasResource := splitOnce(trimmed, "/-/")
+	out.Path = strings.Trim(left, "/")
+	if !hasResource {
+		out.Kind = "namespace"
+		return out, nil
+	}
+
+	parts := strings.Split(strings.Trim(right, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("GitLab resource URL must be .../-/{kind}/{id}")
+	}
+	kind, id := parts[0], parts[1]
+	switch kind {
+	case "issues":
+		out.Kind = "issue"
+		out.ID = id
+	case "merge_requests":
+		out.Kind = "mr"
+		out.ID = id
+	case "snippets":
+		out.Kind = "snippet"
+		out.ID = id
+	case "releases":
+		out.Kind = "release"
+		out.ID = id
+	case "pipelines":
+		out.Kind = "pipeline"
+		out.ID = id
+	case "jobs":
+		out.Kind = "job"
+		out.ID = id
+	default:
+		return nil, fmt.Errorf("unsupported GitLab URL type %q; supported: issues, merge_requests, snippets, releases, pipelines, jobs", kind)
+	}
+	return out, nil
+}
+
+func splitOnce(s, sep string) (left, right string, ok bool) {
+	return strings.Cut(s, sep)
+}
+
+// --- Dispatch ------------------------------------------------------------
+
+// gitlabTarget describes what the URL resolved to: either a single project,
+// or a namespace (group/user) to enumerate.
+type gitlabTarget struct {
+	Kind     string         // "project", "group", "user", "all-groups", "issue", "mr", "snippet", "release", "pipeline", "job"
+	Project  *gitlabProject // populated when Kind in {project, issue, mr, snippet, release, pipeline, job}
+	Group    *gitlabGroup
+	User     *gitlabUser
+	Resource ParsedGitLabURL // original parse result; preserves ID/Kind for direct resource scans
+}
+
+// dispatchURL resolves a raw GitLab URL into either a direct resource scan or
+// a project-enumeration target. For namespace URLs, it probes the API to
+// determine whether the path is a project, group, or user.
+func (s *GitLab) dispatchURL(ctx context.Context, rawURL string) (*gitlabTarget, bool, error) {
+	parsed, err := ParseGitLabURL(rawURL)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid target URL: %w", err)
+	}
+
+	// Specific resource URL: project path lives in parsed.Path; fetch the
+	// project, then return Direct=true so scanDirect handles just this resource.
+	switch parsed.Kind {
+	case "issue", "mr", "snippet", "release", "pipeline", "job":
+		proj, err := s.fetchProjectByPath(ctx, parsed.Path)
+		if err != nil {
+			return nil, false, fmt.Errorf("fetch project %q: %w", parsed.Path, err)
+		}
+		return &gitlabTarget{Kind: parsed.Kind, Project: proj, Resource: *parsed}, true, nil
+	}
+
+	// Namespace URL with empty path = instance root → enumerate all groups
+	// (only meaningful when AllGroups is set; otherwise it's an error).
+	if parsed.Path == "" {
+		if !s.AllGroups {
+			return nil, false, errors.New("URL points at the GitLab instance root; set --all-groups to enumerate all visible groups")
+		}
+		return &gitlabTarget{Kind: "all-groups"}, false, nil
+	}
+
+	// Try project first, then group, then user.
+	if proj, err := s.fetchProjectByPath(ctx, parsed.Path); err == nil {
+		return &gitlabTarget{Kind: "project", Project: proj}, false, nil
+	} else if !isGitLabStatusErr(err, http.StatusNotFound, http.StatusForbidden) {
+		return nil, false, fmt.Errorf("probe project %q: %w", parsed.Path, err)
+	}
+	if grp, err := s.fetchGroupByPath(ctx, parsed.Path); err == nil {
+		return &gitlabTarget{Kind: "group", Group: grp}, false, nil
+	} else if !isGitLabStatusErr(err, http.StatusNotFound, http.StatusForbidden) {
+		return nil, false, fmt.Errorf("probe group %q: %w", parsed.Path, err)
+	}
+	if !strings.Contains(parsed.Path, "/") {
+		if usr, err := s.fetchUserByUsername(ctx, parsed.Path); err == nil && usr != nil {
+			return &gitlabTarget{Kind: "user", User: usr}, false, nil
+		}
+	}
+	return nil, false, fmt.Errorf("could not resolve %q as a GitLab project, group, or user", parsed.Path)
+}
+
+// --- API entity types ----------------------------------------------------
+
+type gitlabProject struct {
+	ID                int    `json:"id"`
+	Name              string `json:"name"`
+	Path              string `json:"path"`
+	PathWithNamespace string `json:"path_with_namespace"`
+	Visibility        string `json:"visibility"`
+	WebURL            string `json:"web_url"`
+	HTTPURLToRepo     string `json:"http_url_to_repo"`
+	DefaultBranch     string `json:"default_branch"`
+	Namespace         struct {
+		Path     string `json:"path"`
+		FullPath string `json:"full_path"`
+		Kind     string `json:"kind"`
+	} `json:"namespace"`
+	ForkedFromProject *struct {
+		ID int `json:"id"`
+	} `json:"forked_from_project,omitempty"`
+}
+
+func (p *gitlabProject) IsFork() bool { return p != nil && p.ForkedFromProject != nil }
+
+type gitlabGroup struct {
+	ID       int    `json:"id"`
+	FullPath string `json:"full_path"`
+	WebURL   string `json:"web_url"`
+}
+
+type gitlabUser struct {
+	ID       int    `json:"id"`
+	Username string `json:"username"`
+	WebURL   string `json:"web_url"`
+}
+
+type gitlabAuthor struct {
+	Name     string `json:"name"`
+	Username string `json:"username"`
+}
+
+type gitlabIssue struct {
+	IID         int          `json:"iid"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	WebURL      string       `json:"web_url"`
+	CreatedAt   time.Time    `json:"created_at"`
+	Author      gitlabAuthor `json:"author"`
+}
+
+type gitlabMR struct {
+	IID         int          `json:"iid"`
+	Title       string       `json:"title"`
+	Description string       `json:"description"`
+	WebURL      string       `json:"web_url"`
+	CreatedAt   time.Time    `json:"created_at"`
+	Author      gitlabAuthor `json:"author"`
+}
+
+type gitlabNote struct {
+	ID        int64        `json:"id"`
+	Body      string       `json:"body"`
+	CreatedAt time.Time    `json:"created_at"`
+	Author    gitlabAuthor `json:"author"`
+	System    bool         `json:"system"`
+}
+
+type gitlabSnippet struct {
+	ID       int64  `json:"id"`
+	Title    string `json:"title"`
+	FileName string `json:"file_name"`
+	WebURL   string `json:"web_url"`
+	RawURL   string `json:"raw_url"`
+}
+
+type gitlabReleaseAssetLink struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+type gitlabReleaseAssetSource struct {
+	Format string `json:"format"`
+	URL    string `json:"url"`
+}
+
+type gitlabRelease struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	ReleasedAt  time.Time `json:"released_at"`
+	Assets      struct {
+		Sources []gitlabReleaseAssetSource `json:"sources"`
+		Links   []gitlabReleaseAssetLink   `json:"links"`
+	} `json:"assets"`
+}
+
+type gitlabJob struct {
+	ID         int64     `json:"id"`
+	Name       string    `json:"name"`
+	Stage      string    `json:"stage"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+	FinishedAt time.Time `json:"finished_at"`
+	Pipeline   struct {
+		ID int64 `json:"id"`
+	} `json:"pipeline"`
+	WebURL    string `json:"web_url"`
+	Artifacts []struct {
+		FileType string `json:"file_type"`
+		Filename string `json:"filename"`
+		Size     int64  `json:"size"`
+	} `json:"artifacts"`
+}
+
+// --- HTTP helpers --------------------------------------------------------
+
+// doJSON issues a GET against the GitLab API and decodes the body into out.
+// Returns a *gitlabStatusError on non-2xx so callers can inspect status codes.
+func (s *GitLab) doJSON(ctx context.Context, u *url.URL, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return &gitlabStatusError{Status: resp.StatusCode, URL: u.String(), Body: string(body)}
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// paginateJSON fetches a paged endpoint, calling collect once per page until
+// the server stops returning a next-page header. base may already contain
+// query parameters; per_page and page are appended.
+func (s *GitLab) paginateJSON(ctx context.Context, base *url.URL, collect func(body []byte) (more bool, err error)) error {
+	page := 1
+	for {
+		u := withQuery(base, "per_page", strconv.Itoa(gitlabPerPage), "page", strconv.Itoa(page))
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			return err
+		}
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return readErr
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return &gitlabStatusError{Status: resp.StatusCode, URL: u.String(), Body: string(body)}
+		}
+		more, err := collect(body)
+		if err != nil {
+			return err
+		}
+		if !more {
+			return nil
+		}
+		next := resp.Header.Get("X-Next-Page")
+		if next == "" || next == "0" {
+			return nil
+		}
+		nextPage, err := strconv.Atoi(next)
+		if err != nil || nextPage <= page {
+			return nil
+		}
+		page = nextPage
+	}
+}
+
+func withQuery(base *url.URL, kv ...string) *url.URL {
+	out := *base
+	q := out.Query()
+	for i := 0; i+1 < len(kv); i += 2 {
+		q.Set(kv[i], kv[i+1])
+	}
+	out.RawQuery = q.Encode()
+	return &out
+}
+
+type gitlabStatusError struct {
+	Status int
+	URL    string
+	Body   string
+}
+
+func (e *gitlabStatusError) Error() string {
+	return fmt.Sprintf("GitLab API %s: HTTP %d: %s", e.URL, e.Status, strings.TrimSpace(e.Body))
+}
+
+func isGitLabStatusErr(err error, codes ...int) bool {
+	var ge *gitlabStatusError
+	if !errors.As(err, &ge) {
+		return false
+	}
+	for _, c := range codes {
+		if ge.Status == c {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Entity fetches ------------------------------------------------------
+
+func (s *GitLab) fetchProjectByPath(ctx context.Context, projectPath string) (*gitlabProject, error) {
+	encoded := url.PathEscape(projectPath)
+	u, err := s.apiURL("projects/" + encoded)
+	if err != nil {
+		return nil, err
+	}
+	var proj gitlabProject
+	if err := s.doJSON(ctx, u, &proj); err != nil {
+		return nil, err
+	}
+	return &proj, nil
+}
+
+func (s *GitLab) fetchGroupByPath(ctx context.Context, groupPath string) (*gitlabGroup, error) {
+	encoded := url.PathEscape(groupPath)
+	u, err := s.apiURL("groups/" + encoded)
+	if err != nil {
+		return nil, err
+	}
+	var grp gitlabGroup
+	if err := s.doJSON(ctx, u, &grp); err != nil {
+		return nil, err
+	}
+	return &grp, nil
+}
+
+func (s *GitLab) fetchUserByUsername(ctx context.Context, username string) (*gitlabUser, error) {
+	u, err := s.apiURL("users")
+	if err != nil {
+		return nil, err
+	}
+	u = withQuery(u, "username", username)
+	var users []gitlabUser
+	if err := s.doJSON(ctx, u, &users); err != nil {
+		return nil, err
+	}
+	if len(users) == 0 {
+		return nil, nil
+	}
+	return &users[0], nil
+}
+
+// --- Enumeration ---------------------------------------------------------
+
+func (s *GitLab) enumerateProjects(ctx context.Context, target *gitlabTarget) (<-chan *gitlabProject, <-chan error) {
+	ch := make(chan *gitlabProject, 100)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(ch)
+		defer close(errCh)
+
+		seen := make(map[int]bool)
+		send := func(p *gitlabProject) {
+			if p == nil || seen[p.ID] {
+				return
+			}
+			if !s.Resources.Has(GitLabResourceTypeForks) && p.IsFork() {
+				return
+			}
+			if s.isExcluded(p.PathWithNamespace) {
+				logging.Debug().Str("project", p.PathWithNamespace).Msg("excluding project")
+				return
+			}
+			seen[p.ID] = true
+			select {
+			case ch <- p:
+			case <-ctx.Done():
+			}
+		}
+
+		switch target.Kind {
+		case "project":
+			send(target.Project)
+		case "group":
+			if err := s.streamGroupProjects(ctx, target.Group.ID, send); err != nil {
+				errCh <- fmt.Errorf("list group %d projects: %w", target.Group.ID, err)
+				return
+			}
+		case "user":
+			if err := s.streamUserProjects(ctx, target.User.ID, send); err != nil {
+				errCh <- fmt.Errorf("list user %d projects: %w", target.User.ID, err)
+				return
+			}
+		case "all-groups":
+			groups, err := s.listAllGroups(ctx)
+			if err != nil {
+				errCh <- fmt.Errorf("list all groups: %w", err)
+				return
+			}
+			for _, g := range groups {
+				if err := s.streamGroupProjects(ctx, g.ID, send); err != nil {
+					errCh <- fmt.Errorf("list group %d projects: %w", g.ID, err)
+					return
+				}
+			}
+		default:
+			errCh <- fmt.Errorf("unsupported enumeration target %q", target.Kind)
+		}
+	}()
+
+	return ch, errCh
+}
+
+func (s *GitLab) streamGroupProjects(ctx context.Context, groupID int, send func(*gitlabProject)) error {
+	u, err := s.apiURL(fmt.Sprintf("groups/%d/projects", groupID))
+	if err != nil {
+		return err
+	}
+	if s.IncludeSubgroups {
+		u = withQuery(u, "include_subgroups", "true")
+	}
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var projects []gitlabProject
+		if err := json.Unmarshal(body, &projects); err != nil {
+			return false, fmt.Errorf("decode group projects: %w", err)
+		}
+		for i := range projects {
+			send(&projects[i])
+		}
+		return len(projects) == gitlabPerPage, nil
+	})
+}
+
+func (s *GitLab) streamUserProjects(ctx context.Context, userID int, send func(*gitlabProject)) error {
+	u, err := s.apiURL(fmt.Sprintf("users/%d/projects", userID))
+	if err != nil {
+		return err
+	}
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var projects []gitlabProject
+		if err := json.Unmarshal(body, &projects); err != nil {
+			return false, fmt.Errorf("decode user projects: %w", err)
+		}
+		for i := range projects {
+			send(&projects[i])
+		}
+		return len(projects) == gitlabPerPage, nil
+	})
+}
+
+func (s *GitLab) listAllGroups(ctx context.Context) ([]gitlabGroup, error) {
+	u, err := s.apiURL("groups")
+	if err != nil {
+		return nil, err
+	}
+	u = withQuery(u, "all_available", "true")
+	var all []gitlabGroup
+	err = s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabGroup
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode groups: %w", err)
+		}
+		all = append(all, page...)
+		return len(page) == gitlabPerPage, nil
+	})
+	return all, err
+}
+
+// isExcluded matches a project's full path against the user-configured glob
+// list, case-folded for predictability.
+func (s *GitLab) isExcluded(fullPath string) bool {
+	lp := strings.ToLower(fullPath)
+	for _, pattern := range s.ExcludeRepos {
+		if matched, _ := filepath.Match(strings.ToLower(pattern), lp); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Per-project scan ----------------------------------------------------
+
+// projectAttributes builds the L1 attribute set for a project. When resource
+// is non-empty it is stamped as AttrResource — used to distinguish the early
+// "skip this whole project" check from the per-fragment attribute stamp.
+func (s *GitLab) projectAttributes(proj *gitlabProject, resource string) map[string]string {
+	attrs := map[string]string{
+		AttrGitLabProjectID:   strconv.Itoa(proj.ID),
+		AttrGitLabProjectPath: proj.PathWithNamespace,
+		AttrGitLabProjectURL:  proj.WebURL,
+		AttrGitLabVisibility:  proj.Visibility,
+		AttrGitLabNamespace:   proj.Namespace.FullPath,
+	}
+	if resource != "" {
+		attrs[AttrResource] = resource
+	}
+	return attrs
+}
+
+// wrapGitLabYield stamps project-level attributes onto every fragment and
+// applies ShouldSkip as a final per-fragment filter (L3). Callers must use
+// the returned yield in place of the original.
+func wrapGitLabYield(skip SkipFunc, attrs map[string]string, yield FragmentsFunc) FragmentsFunc {
+	var mu sync.Mutex
+	return func(fragment Fragment, err error) error {
+		if err == nil {
+			for k, v := range attrs {
+				if v == "" || fragment.Attr(k) != "" {
+					continue
+				}
+				fragment.SetAttr(k, v)
+			}
+			if skip != nil && skip(fragment.Attributes) {
+				return nil
+			}
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		return yield(fragment, err)
+	}
+}
+
+// inDateRange mirrors GitHub.inDateRange for use in API listings ordered DESC
+// by created_at. Returns (ok, terminate) where terminate=true means we can
+// stop pagination because subsequent items will all be older than Since.
+func (s *GitLab) inDateRange(t time.Time) (ok bool, terminate bool) {
+	if !s.DateRangeOpts.Since.IsZero() && t.Before(s.DateRangeOpts.Since) {
+		return false, true
+	}
+	if !s.DateRangeOpts.Until.IsZero() && !t.Before(s.DateRangeOpts.Until) {
+		return false, false
+	}
+	return true, false
+}
+
+// scanProject is the main dispatch for one project. It implements the L1 +
+// L3 skip layers and delegates to per-resource scanners which add their own
+// L2 skips.
+func (s *GitLab) scanProject(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	logger := logging.With().Str("project", proj.PathWithNamespace).Logger()
+	projectAttrs := s.projectAttributes(proj, "")
+
+	// L1 — drop the whole project early.
+	if s.ShouldSkip != nil && s.ShouldSkip(s.projectAttributes(proj, ResourceGitLabProject)) {
+		logger.Debug().Msg("skipping project based on prefilter")
+		return nil
+	}
+
+	// L3 — every fragment from this project gets project attrs + per-fragment skip.
+	glYield := wrapGitLabYield(s.ShouldSkip, projectAttrs, yield)
+
+	run := func(label string, fn func() error) error {
+		logger.Info().Str("resource", label).Msg("scanning")
+		if err := fn(); err != nil {
+			logger.Error().Err(err).Msg(label + " scan failed")
+			return err
+		}
+		ev := logger.Info().Str("resource", label)
+		if r := s.rlRemaining.Load(); r > 0 {
+			ev = ev.Int64("rl_remaining", r)
+		}
+		ev.Msg("completed")
+		return nil
+	}
+
+	if s.Resources.Has(GitLabResourceTypeRepos) {
+		_ = run("repos", func() error { return s.scanProjectGit(ctx, proj, glYield) })
+	}
+	if s.Resources.HasAnyIssueOrMR() {
+		if err := run("issues_mrs", func() error { return s.scanIssuesAndMRs(ctx, proj, glYield) }); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeSnippets) {
+		if err := run("snippets", func() error { return s.scanSnippets(ctx, proj, glYield) }); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeReleases) {
+		if err := run("releases", func() error { return s.scanReleases(ctx, proj, glYield) }); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeCIJobs) {
+		if err := run("ci_jobs", func() error { return s.scanCIJobs(ctx, proj, glYield) }); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// scanProjectGit clones the project and scans its git history.
+func (s *GitLab) scanProjectGit(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	if proj.HTTPURLToRepo == "" {
+		return nil
+	}
+	return scm.CloneToTempDir(ctx, proj.HTTPURLToRepo, s.Token, "betterleaks-gitlab-*", scm.CloneOptions{Mirror: true}, func(repoPath string) error {
+		var src Source
+		if s.Workers > 0 {
+			src = &ParallelGit{
+				RepoPath: repoPath, ShouldSkip: s.ShouldSkip,
+				Platform: scm.GitLabPlatform, RemoteURL: proj.WebURL,
+				Sema: s.Sema, MaxArchiveDepth: s.MaxArchiveDepth,
+				LogOpts: s.LogOpts, Workers: s.Workers,
+			}
+		} else {
+			gitCmd, err := NewGitLogCmdContext(ctx, repoPath, s.LogOpts)
+			if err != nil {
+				return err
+			}
+			src = &Git{
+				Cmd: gitCmd, ShouldSkip: s.ShouldSkip,
+				Platform: scm.GitLabPlatform, RemoteURL: proj.WebURL,
+				Sema: s.Sema, MaxArchiveDepth: s.MaxArchiveDepth,
+			}
+		}
+		return src.Fragments(ctx, yield)
+	})
+}
+
+// --- Issues & MRs --------------------------------------------------------
+
+func (s *GitLab) scanIssuesAndMRs(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	if s.Resources.Has(GitLabResourceTypeIssues) || s.Resources.Has(GitLabResourceTypeIssueComments) {
+		if err := s.scanIssues(ctx, proj, yield); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeMRs) || s.Resources.Has(GitLabResourceTypeMRComments) {
+		if err := s.scanMRs(ctx, proj, yield); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *GitLab) scanIssues(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/issues", proj.ID))
+	if err != nil {
+		return err
+	}
+	u = withQuery(u, "scope", "all", "state", "all", "order_by", "created_at", "sort", "desc")
+	u = s.applyDateRange(u, "created_after", "created_before")
+
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabIssue
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode issues: %w", err)
+		}
+		for _, issue := range page {
+			if ok, stop := s.inDateRange(issue.CreatedAt); stop {
+				return false, nil
+			} else if !ok {
+				continue
+			}
+			attrs := map[string]string{
+				AttrResource:       ResourceGitLabIssue,
+				AttrGitLabIssueIID: strconv.Itoa(issue.IID),
+				AttrURL:            issue.WebURL,
+			}
+			// L2 skip: drop this whole issue (body + comments) without fetching notes.
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			if s.Resources.Has(GitLabResourceTypeIssues) {
+				frag := Fragment{Raw: strings.TrimSpace(issue.Title + "\n" + issue.Description), Attributes: cloneAttrs(attrs)}
+				if err := yield(frag, nil); err != nil {
+					return false, err
+				}
+			}
+			if s.Resources.Has(GitLabResourceTypeIssueComments) {
+				if err := s.scanItemNotes(ctx, proj.ID, "issues", issue.IID, issue.WebURL, AttrGitLabIssueIID, strconv.Itoa(issue.IID), yield); err != nil {
+					return false, err
+				}
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+func (s *GitLab) scanMRs(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/merge_requests", proj.ID))
+	if err != nil {
+		return err
+	}
+	u = withQuery(u, "scope", "all", "state", "all", "order_by", "created_at", "sort", "desc")
+	u = s.applyDateRange(u, "created_after", "created_before")
+
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabMR
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode merge requests: %w", err)
+		}
+		for _, mr := range page {
+			if ok, stop := s.inDateRange(mr.CreatedAt); stop {
+				return false, nil
+			} else if !ok {
+				continue
+			}
+			attrs := map[string]string{
+				AttrResource:    ResourceGitLabMR,
+				AttrGitLabMRIID: strconv.Itoa(mr.IID),
+				AttrURL:         mr.WebURL,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			if s.Resources.Has(GitLabResourceTypeMRs) {
+				frag := Fragment{Raw: strings.TrimSpace(mr.Title + "\n" + mr.Description), Attributes: cloneAttrs(attrs)}
+				if err := yield(frag, nil); err != nil {
+					return false, err
+				}
+			}
+			if s.Resources.Has(GitLabResourceTypeMRComments) {
+				if err := s.scanItemNotes(ctx, proj.ID, "merge_requests", mr.IID, mr.WebURL, AttrGitLabMRIID, strconv.Itoa(mr.IID), yield); err != nil {
+					return false, err
+				}
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+// scanItemNotes paginates notes (comments) for an issue or MR.
+// itemKind is "issues" or "merge_requests"; parentAttrKey/Val identifies the
+// parent (e.g. AttrGitLabMRIID + the IID).
+func (s *GitLab) scanItemNotes(ctx context.Context, projectID int, itemKind string, itemIID int, parentURL, parentAttrKey, parentAttrVal string, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/%s/%d/notes", projectID, itemKind, itemIID))
+	if err != nil {
+		return err
+	}
+	u = withQuery(u, "order_by", "created_at", "sort", "asc")
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabNote
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode notes: %w", err)
+		}
+		for _, note := range page {
+			if note.System {
+				continue // skip "merged", "assigned", and other system notes
+			}
+			attrs := map[string]string{
+				AttrResource:        ResourceGitLabComment,
+				AttrGitLabCommentID: strconv.FormatInt(note.ID, 10),
+				AttrURL:             parentURL,
+				parentAttrKey:       parentAttrVal,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			frag := Fragment{Raw: note.Body, Attributes: cloneAttrs(attrs)}
+			if err := yield(frag, nil); err != nil {
+				return false, err
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+// --- Snippets ------------------------------------------------------------
+
+func (s *GitLab) scanSnippets(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/snippets", proj.ID))
+	if err != nil {
+		return err
+	}
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabSnippet
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode snippets: %w", err)
+		}
+		for _, snip := range page {
+			attrs := map[string]string{
+				AttrResource:              ResourceGitLabSnippet,
+				AttrGitLabSnippetID:       strconv.FormatInt(snip.ID, 10),
+				AttrGitLabSnippetFilename: snip.FileName,
+				AttrURL:                   snip.WebURL,
+				AttrPath:                  snip.FileName,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			raw, err := s.apiURL(fmt.Sprintf("projects/%d/snippets/%d/raw", proj.ID, snip.ID))
+			if err != nil {
+				return false, err
+			}
+			if err := s.downloadAndScan(ctx, raw.String(), snip.FileName, attrs, yield); err != nil {
+				logging.Error().Err(err).Str("snippet", snip.FileName).Msg("could not scan snippet")
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+// --- Releases ------------------------------------------------------------
+
+func (s *GitLab) scanReleases(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/releases", proj.ID))
+	if err != nil {
+		return err
+	}
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabRelease
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode releases: %w", err)
+		}
+		for _, rel := range page {
+			if ok, stop := s.inDateRange(timeOr(rel.ReleasedAt, rel.CreatedAt)); stop {
+				return false, nil
+			} else if !ok {
+				continue
+			}
+			attrs := map[string]string{
+				AttrResource:         ResourceGitLabRelease,
+				AttrGitLabReleaseTag: rel.TagName,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			if rel.Description != "" {
+				frag := Fragment{Raw: rel.Description, Attributes: cloneAttrs(attrs)}
+				if err := yield(frag, nil); err != nil {
+					return false, err
+				}
+			}
+			if !s.Resources.Has(GitLabResourceTypeReleaseAssets) {
+				continue
+			}
+			for _, src := range rel.Assets.Sources {
+				if src.URL == "" {
+					continue
+				}
+				assetAttrs := map[string]string{
+					AttrResource:               ResourceGitLabReleaseAsset,
+					AttrGitLabReleaseTag:       rel.TagName,
+					AttrGitLabReleaseAssetName: "source." + src.Format,
+				}
+				if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
+					continue
+				}
+				if err := s.downloadAndScan(ctx, src.URL, "release/"+rel.TagName+"/source."+src.Format, assetAttrs, yield); err != nil {
+					logging.Error().Err(err).Str("tag", rel.TagName).Msg("could not scan release source archive")
+				}
+			}
+			for _, link := range rel.Assets.Links {
+				if link.URL == "" {
+					continue
+				}
+				assetAttrs := map[string]string{
+					AttrResource:               ResourceGitLabReleaseAsset,
+					AttrGitLabReleaseTag:       rel.TagName,
+					AttrGitLabReleaseAssetName: link.Name,
+				}
+				if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
+					continue
+				}
+				if err := s.downloadAndScan(ctx, link.URL, "release/"+rel.TagName+"/"+link.Name, assetAttrs, yield); err != nil {
+					logging.Error().Err(err).Str("tag", rel.TagName).Str("asset", link.Name).Msg("could not scan release asset")
+				}
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+// --- CI jobs / artifacts -------------------------------------------------
+
+func (s *GitLab) scanCIJobs(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/jobs", proj.ID))
+	if err != nil {
+		return err
+	}
+	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
+		var page []gitlabJob
+		if err := json.Unmarshal(body, &page); err != nil {
+			return false, fmt.Errorf("decode jobs: %w", err)
+		}
+		for _, job := range page {
+			if ok, _ := s.inDateRange(job.CreatedAt); !ok {
+				continue
+			}
+			attrs := map[string]string{
+				AttrResource:           ResourceGitLabCIJob,
+				AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
+				AttrGitLabCIJobName:    job.Name,
+				AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
+				AttrURL:                job.WebURL,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, attrs) {
+				continue
+			}
+			traceURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/trace", proj.ID, job.ID))
+			if err != nil {
+				return false, err
+			}
+			logPath := fmt.Sprintf("ci/jobs/%s/job_%d.log", safePath(job.Name), job.ID)
+			if err := s.downloadAndScan(ctx, traceURL.String(), logPath, attrs, yield); err != nil {
+				logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job trace")
+			}
+			if !s.Resources.Has(GitLabResourceTypeCIArtifacts) || len(job.Artifacts) == 0 {
+				continue
+			}
+			artifactAttrs := map[string]string{
+				AttrResource:           ResourceGitLabCIArtifact,
+				AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
+				AttrGitLabCIJobName:    job.Name,
+				AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
+				AttrURL:                job.WebURL,
+			}
+			if shouldSkipAttrs(s.ShouldSkip, artifactAttrs) {
+				continue
+			}
+			artURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/artifacts", proj.ID, job.ID))
+			if err != nil {
+				return false, err
+			}
+			artifactPath := fmt.Sprintf("ci/artifacts/%s/job_%d.zip", safePath(job.Name), job.ID)
+			if err := s.downloadAndScan(ctx, artURL.String(), artifactPath, artifactAttrs, yield); err != nil {
+				logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job artifacts")
+			}
+		}
+		return len(page) == gitlabPerPage, nil
+	})
+}
+
+// --- Direct resource scan (URL points at a specific issue/MR/etc.) -------
+
+func (s *GitLab) scanDirect(ctx context.Context, target *gitlabTarget, yield FragmentsFunc) error {
+	if target.Project == nil {
+		return fmt.Errorf("direct scan requires a resolved project")
+	}
+	projectAttrs := s.projectAttributes(target.Project, "")
+	if s.ShouldSkip != nil && s.ShouldSkip(s.projectAttributes(target.Project, ResourceGitLabProject)) {
+		return nil
+	}
+	glYield := wrapGitLabYield(s.ShouldSkip, projectAttrs, yield)
+
+	switch target.Kind {
+	case "issue":
+		iid, err := strconv.Atoi(target.Resource.ID)
+		if err != nil {
+			return fmt.Errorf("invalid issue iid %q", target.Resource.ID)
+		}
+		return s.scanSingleIssue(ctx, target.Project, iid, glYield)
+	case "mr":
+		iid, err := strconv.Atoi(target.Resource.ID)
+		if err != nil {
+			return fmt.Errorf("invalid mr iid %q", target.Resource.ID)
+		}
+		return s.scanSingleMR(ctx, target.Project, iid, glYield)
+	case "snippet":
+		sid, err := strconv.ParseInt(target.Resource.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid snippet id %q", target.Resource.ID)
+		}
+		return s.scanSingleSnippet(ctx, target.Project, sid, glYield)
+	case "release":
+		return s.scanSingleRelease(ctx, target.Project, target.Resource.ID, glYield)
+	case "pipeline", "job":
+		// For pipeline or job URLs we fall through to the full CI job scan
+		// of the project, filtered by the user's resource selection.
+		return s.scanCIJobs(ctx, target.Project, glYield)
+	default:
+		return fmt.Errorf("unsupported direct resource %q", target.Kind)
+	}
+}
+
+func (s *GitLab) scanSingleIssue(ctx context.Context, proj *gitlabProject, iid int, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/issues/%d", proj.ID, iid))
+	if err != nil {
+		return err
+	}
+	var issue gitlabIssue
+	if err := s.doJSON(ctx, u, &issue); err != nil {
+		return err
+	}
+	attrs := map[string]string{
+		AttrResource:       ResourceGitLabIssue,
+		AttrGitLabIssueIID: strconv.Itoa(issue.IID),
+		AttrURL:            issue.WebURL,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, attrs) {
+		return nil
+	}
+	if s.Resources.Has(GitLabResourceTypeIssues) {
+		frag := Fragment{Raw: strings.TrimSpace(issue.Title + "\n" + issue.Description), Attributes: cloneAttrs(attrs)}
+		if err := yield(frag, nil); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeIssueComments) {
+		return s.scanItemNotes(ctx, proj.ID, "issues", issue.IID, issue.WebURL, AttrGitLabIssueIID, strconv.Itoa(issue.IID), yield)
+	}
+	return nil
+}
+
+func (s *GitLab) scanSingleMR(ctx context.Context, proj *gitlabProject, iid int, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/merge_requests/%d", proj.ID, iid))
+	if err != nil {
+		return err
+	}
+	var mr gitlabMR
+	if err := s.doJSON(ctx, u, &mr); err != nil {
+		return err
+	}
+	attrs := map[string]string{
+		AttrResource:    ResourceGitLabMR,
+		AttrGitLabMRIID: strconv.Itoa(mr.IID),
+		AttrURL:         mr.WebURL,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, attrs) {
+		return nil
+	}
+	if s.Resources.Has(GitLabResourceTypeMRs) {
+		frag := Fragment{Raw: strings.TrimSpace(mr.Title + "\n" + mr.Description), Attributes: cloneAttrs(attrs)}
+		if err := yield(frag, nil); err != nil {
+			return err
+		}
+	}
+	if s.Resources.Has(GitLabResourceTypeMRComments) {
+		return s.scanItemNotes(ctx, proj.ID, "merge_requests", mr.IID, mr.WebURL, AttrGitLabMRIID, strconv.Itoa(mr.IID), yield)
+	}
+	return nil
+}
+
+func (s *GitLab) scanSingleSnippet(ctx context.Context, proj *gitlabProject, snippetID int64, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/snippets/%d", proj.ID, snippetID))
+	if err != nil {
+		return err
+	}
+	var snip gitlabSnippet
+	if err := s.doJSON(ctx, u, &snip); err != nil {
+		return err
+	}
+	attrs := map[string]string{
+		AttrResource:              ResourceGitLabSnippet,
+		AttrGitLabSnippetID:       strconv.FormatInt(snip.ID, 10),
+		AttrGitLabSnippetFilename: snip.FileName,
+		AttrURL:                   snip.WebURL,
+		AttrPath:                  snip.FileName,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, attrs) {
+		return nil
+	}
+	raw, err := s.apiURL(fmt.Sprintf("projects/%d/snippets/%d/raw", proj.ID, snip.ID))
+	if err != nil {
+		return err
+	}
+	return s.downloadAndScan(ctx, raw.String(), snip.FileName, attrs, yield)
+}
+
+func (s *GitLab) scanSingleRelease(ctx context.Context, proj *gitlabProject, tag string, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/releases/%s", proj.ID, url.PathEscape(tag)))
+	if err != nil {
+		return err
+	}
+	var rel gitlabRelease
+	if err := s.doJSON(ctx, u, &rel); err != nil {
+		return err
+	}
+	attrs := map[string]string{
+		AttrResource:         ResourceGitLabRelease,
+		AttrGitLabReleaseTag: rel.TagName,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, attrs) {
+		return nil
+	}
+	if rel.Description != "" && s.Resources.Has(GitLabResourceTypeReleases) {
+		frag := Fragment{Raw: rel.Description, Attributes: cloneAttrs(attrs)}
+		if err := yield(frag, nil); err != nil {
+			return err
+		}
+	}
+	if !s.Resources.Has(GitLabResourceTypeReleaseAssets) {
+		return nil
+	}
+	for _, link := range rel.Assets.Links {
+		if link.URL == "" {
+			continue
+		}
+		assetAttrs := map[string]string{
+			AttrResource:               ResourceGitLabReleaseAsset,
+			AttrGitLabReleaseTag:       rel.TagName,
+			AttrGitLabReleaseAssetName: link.Name,
+		}
+		if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
+			continue
+		}
+		if err := s.downloadAndScan(ctx, link.URL, "release/"+rel.TagName+"/"+link.Name, assetAttrs, yield); err != nil {
+			logging.Error().Err(err).Str("tag", rel.TagName).Str("asset", link.Name).Msg("could not scan release asset")
+		}
+	}
+	return nil
+}
+
+// --- Misc helpers --------------------------------------------------------
+
+// downloadAndScan streams a GitLab API resource through downloadAndScanSource,
+// attaching the PRIVATE-TOKEN as the bearer if a token is configured (the
+// underlying client transport already host-scopes the header).
+func (s *GitLab) downloadAndScan(ctx context.Context, rawURL, path string, attrs map[string]string, yield FragmentsFunc) error {
+	return downloadAndScanSource(ctx, sourceDownloadOptions{
+		URL:             rawURL,
+		Path:            path,
+		Attrs:           attrs,
+		BearerToken:     s.Token,
+		MaxArchiveDepth: s.MaxArchiveDepth,
+		ShouldSkip:      s.ShouldSkip,
+		TempPattern:     "betterleaks-gitlab-dl-*",
+	}, yield)
+}
+
+// applyDateRange appends GitLab's standard date-range query parameters when
+// DateRangeOpts.Since/Until are set.
+func (s *GitLab) applyDateRange(u *url.URL, sinceKey, untilKey string) *url.URL {
+	out := *u
+	q := out.Query()
+	if !s.DateRangeOpts.Since.IsZero() {
+		q.Set(sinceKey, s.DateRangeOpts.Since.UTC().Format(time.RFC3339))
+	}
+	if !s.DateRangeOpts.Until.IsZero() {
+		q.Set(untilKey, s.DateRangeOpts.Until.UTC().Format(time.RFC3339))
+	}
+	out.RawQuery = q.Encode()
+	return &out
+}
+
+// safePath returns a filesystem-safe form of name suitable for log/artifact
+// paths under our temp dirs (no path separators, no leading dots).
+func safePath(name string) string {
+	cleaned := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_' || r == '.':
+			return r
+		default:
+			return '_'
+		}
+	}, name)
+	cleaned = strings.TrimLeft(cleaned, ".")
+	if cleaned == "" {
+		return "unnamed"
+	}
+	return path.Clean(cleaned)
+}
+
+func cloneAttrs(m map[string]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+func timeOr(primary, fallback time.Time) time.Time {
+	if !primary.IsZero() {
+		return primary
+	}
+	return fallback
+}
+
+// --- Retry / rate-limit --------------------------------------------------
+
+func gitlabRetryDecider(req *http.Request, resp *http.Response, err error, now time.Time) (bool, time.Duration) {
+	retry, wait := httpclient.DefaultRetryDecider(req, resp, err, now)
+	if retry {
+		return retry, wait
+	}
+	if resp == nil || resp.StatusCode != http.StatusForbidden {
+		return false, 0
+	}
+	remaining := firstHeader(resp, "RateLimit-Remaining", "X-RateLimit-Remaining")
+	if remaining != "0" {
+		return false, 0
+	}
+	if reset := firstHeader(resp, "RateLimit-Reset", "X-RateLimit-Reset"); reset != "" {
+		if epoch, err := strconv.ParseInt(reset, 10, 64); err == nil {
+			if d := time.Unix(epoch, 0).Sub(now); d > 0 {
+				return true, d
+			}
+		}
+	}
+	return true, 60 * time.Second
+}
+
+func gitlabRateLimitStateExtractor(resp *http.Response) (int64, time.Time, bool) {
+	if resp == nil {
+		return 0, time.Time{}, false
+	}
+	remainingRaw := firstHeader(resp, "RateLimit-Remaining", "X-RateLimit-Remaining")
+	resetRaw := firstHeader(resp, "RateLimit-Reset", "X-RateLimit-Reset")
+	if remainingRaw == "" && resetRaw == "" {
+		return 0, time.Time{}, false
+	}
+	var (
+		remaining int64
+		resetAt   time.Time
+	)
+	if remainingRaw != "" {
+		if parsed, err := strconv.ParseInt(remainingRaw, 10, 64); err == nil {
+			remaining = parsed
+		}
+	}
+	if resetRaw != "" {
+		if epoch, err := strconv.ParseInt(resetRaw, 10, 64); err == nil && epoch > 0 {
+			resetAt = time.Unix(epoch, 0)
+		}
+	}
+	return remaining, resetAt, true
+}
+
+func firstHeader(resp *http.Response, keys ...string) string {
+	for _, k := range keys {
+		if v := resp.Header.Get(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/sources/gitlab.go
+++ b/sources/gitlab.go
@@ -955,7 +955,9 @@ func (s *GitLab) scanProject(ctx context.Context, proj *gitlabProject, yield Fra
 	}
 
 	if s.Resources.Has(GitLabResourceTypeRepos) {
-		_ = run("repos", func() error { return s.scanProjectGit(ctx, proj, glYield) })
+		if err := run("repos", func() error { return s.scanProjectGit(ctx, proj, glYield) }); err != nil {
+			return err
+		}
 	}
 	if s.Resources.HasAnyIssueOrMR() {
 		if err := run("issues_mrs", func() error { return s.scanIssuesAndMRs(ctx, proj, glYield) }); err != nil {
@@ -1208,40 +1210,8 @@ func (s *GitLab) scanReleases(ctx context.Context, proj *gitlabProject, yield Fr
 					return false, err
 				}
 			}
-			if !s.Resources.Has(GitLabResourceTypeReleaseAssets) {
-				continue
-			}
-			for _, src := range rel.Assets.Sources {
-				if src.URL == "" {
-					continue
-				}
-				assetAttrs := map[string]string{
-					AttrResource:               ResourceGitLabReleaseAsset,
-					AttrGitLabReleaseTag:       rel.TagName,
-					AttrGitLabReleaseAssetName: "source." + src.Format,
-				}
-				if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
-					continue
-				}
-				if err := s.downloadAndScan(ctx, src.URL, "release/"+rel.TagName+"/source."+src.Format, assetAttrs, yield); err != nil {
-					logging.Error().Err(err).Str("tag", rel.TagName).Msg("could not scan release source archive")
-				}
-			}
-			for _, link := range rel.Assets.Links {
-				if link.URL == "" {
-					continue
-				}
-				assetAttrs := map[string]string{
-					AttrResource:               ResourceGitLabReleaseAsset,
-					AttrGitLabReleaseTag:       rel.TagName,
-					AttrGitLabReleaseAssetName: link.Name,
-				}
-				if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
-					continue
-				}
-				if err := s.downloadAndScan(ctx, link.URL, "release/"+rel.TagName+"/"+link.Name, assetAttrs, yield); err != nil {
-					logging.Error().Err(err).Str("tag", rel.TagName).Str("asset", link.Name).Msg("could not scan release asset")
-				}
+			if err := s.scanReleaseAssets(ctx, rel, yield); err != nil {
+				return false, err
 			}
 		}
 		return len(page) == gitlabPerPage, nil
@@ -1499,6 +1469,30 @@ func (s *GitLab) scanSingleRelease(ctx context.Context, proj *gitlabProject, tag
 	}
 	if !s.Resources.Has(GitLabResourceTypeReleaseAssets) {
 		return nil
+	}
+	return s.scanReleaseAssets(ctx, rel, yield)
+}
+
+func (s *GitLab) scanReleaseAssets(ctx context.Context, rel gitlabRelease, yield FragmentsFunc) error {
+	if !s.Resources.Has(GitLabResourceTypeReleaseAssets) {
+		return nil
+	}
+	for _, src := range rel.Assets.Sources {
+		if src.URL == "" {
+			continue
+		}
+		name := "source." + src.Format
+		assetAttrs := map[string]string{
+			AttrResource:               ResourceGitLabReleaseAsset,
+			AttrGitLabReleaseTag:       rel.TagName,
+			AttrGitLabReleaseAssetName: name,
+		}
+		if shouldSkipAttrs(s.ShouldSkip, assetAttrs) {
+			continue
+		}
+		if err := s.downloadAndScan(ctx, src.URL, "release/"+rel.TagName+"/"+name, assetAttrs, yield); err != nil {
+			logging.Error().Err(err).Str("tag", rel.TagName).Str("asset", name).Msg("could not scan release source archive")
+		}
 	}
 	for _, link := range rel.Assets.Links {
 		if link.URL == "" {

--- a/sources/gitlab.go
+++ b/sources/gitlab.go
@@ -25,10 +25,11 @@ import (
 )
 
 const (
-	gitlabPerPage          = 100
-	gitlabScanConcurrency  = 100
-	gitlabDefaultBase      = "https://gitlab.com/"
-	gitlabAPISuffix        = "api/v4/"
+	gitlabPerPage         = 100
+	gitlabScanConcurrency = 100
+	gitlabAPIConcurrency  = 10
+	gitlabDefaultBase     = "https://gitlab.com/"
+	gitlabAPISuffix       = "api/v4/"
 )
 
 // GitLab enumerates projects via the GitLab REST API and delegates scanning
@@ -71,10 +72,7 @@ type GitLab struct {
 	httpClient *http.Client
 	restRetry  *httpclient.RetryTransport
 	apiBaseURL *url.URL // normalized site base ending in `/api/v4/`
-
-	// Cached counters for completion logging.
-	rlRemaining atomic.Int64
-	rlResetAt   atomic.Int64
+	apiSem     chan struct{}
 }
 
 // GitLabResourceType identifies a scannable GitLab resource category.
@@ -221,16 +219,9 @@ func (s *GitLab) Fragments(ctx context.Context, yield FragmentsFunc) error {
 		Msg("starting GitLab scan")
 
 	start := time.Now()
-	s.restRetry = httpclient.NewRetryTransport(nil)
-	s.restRetry.Decider = gitlabRetryDecider
-	s.restRetry.StateExtractor = gitlabRateLimitStateExtractor
-
-	apiBase, err := s.buildAPIBase()
-	if err != nil {
+	if err := s.ensureClient(); err != nil {
 		return err
 	}
-	s.apiBaseURL = apiBase
-	s.httpClient = httpclient.NewAuthenticatedClient(s.Token, s.restRetry, apiBase.Host)
 
 	target, direct, err := s.dispatchURL(ctx, s.URL)
 	if err != nil {
@@ -302,12 +293,49 @@ func (s *GitLab) buildAPIBase() (*url.URL, error) {
 // configured base, e.g. apiURL("projects/123/issues") →
 // "https://gitlab.com/api/v4/projects/123/issues".
 func (s *GitLab) apiURL(endpoint string) (*url.URL, error) {
+	if err := s.ensureClient(); err != nil {
+		return nil, err
+	}
 	endpoint = strings.TrimPrefix(endpoint, "/")
 	ref, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid GitLab endpoint %q: %w", endpoint, err)
 	}
 	return s.apiBaseURL.ResolveReference(ref), nil
+}
+
+func (s *GitLab) ensureClient() error {
+	if s.restRetry == nil {
+		s.restRetry = httpclient.NewRetryTransport(nil)
+		s.restRetry.Decider = gitlabRetryDecider
+		s.restRetry.StateExtractor = gitlabRateLimitStateExtractor
+	}
+	if s.apiBaseURL == nil {
+		apiBase, err := s.buildAPIBase()
+		if err != nil {
+			return err
+		}
+		s.apiBaseURL = apiBase
+	}
+	if s.httpClient == nil {
+		s.httpClient = httpclient.NewAuthenticatedClient(s.Token, s.restRetry, s.apiBaseURL.Host)
+	}
+	if s.apiSem == nil {
+		s.apiSem = make(chan struct{}, gitlabAPIConcurrency)
+	}
+	return nil
+}
+
+func (s *GitLab) acquireAPISlot(ctx context.Context) (func(), error) {
+	if s.apiSem == nil {
+		return func() {}, nil
+	}
+	select {
+	case s.apiSem <- struct{}{}:
+		return func() { <-s.apiSem }, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }
 
 func singleSlashJoin(left, right string) string {
@@ -320,8 +348,6 @@ func singleSlashJoin(left, right string) string {
 	right = strings.TrimPrefix(right, "/")
 	return left + right
 }
-
-// --- URL parsing ---------------------------------------------------------
 
 // ParsedGitLabURL is the result of splitting a GitLab URL into its components.
 type ParsedGitLabURL struct {
@@ -399,8 +425,6 @@ func splitOnce(s, sep string) (left, right string, ok bool) {
 	return strings.Cut(s, sep)
 }
 
-// --- Dispatch ------------------------------------------------------------
-
 // gitlabTarget describes what the URL resolved to: either a single project,
 // or a namespace (group/user) to enumerate.
 type gitlabTarget struct {
@@ -458,8 +482,6 @@ func (s *GitLab) dispatchURL(ctx context.Context, rawURL string) (*gitlabTarget,
 	}
 	return nil, false, fmt.Errorf("could not resolve %q as a GitLab project, group, or user", parsed.Path)
 }
-
-// --- API entity types ----------------------------------------------------
 
 type gitlabProject struct {
 	ID                int    `json:"id"`
@@ -573,8 +595,6 @@ type gitlabJob struct {
 	} `json:"artifacts"`
 }
 
-// --- HTTP helpers --------------------------------------------------------
-
 // doJSON issues a GET against the GitLab API and decodes the body into out.
 // Returns a *gitlabStatusError on non-2xx so callers can inspect status codes.
 func (s *GitLab) doJSON(ctx context.Context, u *url.URL, out any) error {
@@ -582,6 +602,11 @@ func (s *GitLab) doJSON(ctx context.Context, u *url.URL, out any) error {
 	if err != nil {
 		return err
 	}
+	release, err := s.acquireAPISlot(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return err
@@ -608,7 +633,12 @@ func (s *GitLab) paginateJSON(ctx context.Context, base *url.URL, collect func(b
 		if err != nil {
 			return err
 		}
+		release, err := s.acquireAPISlot(ctx)
+		if err != nil {
+			return err
+		}
 		resp, err := s.httpClient.Do(req)
+		release()
 		if err != nil {
 			return err
 		}
@@ -672,8 +702,6 @@ func isGitLabStatusErr(err error, codes ...int) bool {
 	return false
 }
 
-// --- Entity fetches ------------------------------------------------------
-
 func (s *GitLab) fetchProjectByPath(ctx context.Context, projectPath string) (*gitlabProject, error) {
 	encoded := url.PathEscape(projectPath)
 	u, err := s.apiURL("projects/" + encoded)
@@ -715,8 +743,6 @@ func (s *GitLab) fetchUserByUsername(ctx context.Context, username string) (*git
 	}
 	return &users[0], nil
 }
-
-// --- Enumeration ---------------------------------------------------------
 
 func (s *GitLab) enumerateProjects(ctx context.Context, target *gitlabTarget) (<-chan *gitlabProject, <-chan error) {
 	ch := make(chan *gitlabProject, 100)
@@ -845,8 +871,6 @@ func (s *GitLab) isExcluded(fullPath string) bool {
 	return false
 }
 
-// --- Per-project scan ----------------------------------------------------
-
 // projectAttributes builds the L1 attribute set for a project. When resource
 // is non-empty it is stamped as AttrResource — used to distinguish the early
 // "skip this whole project" check from the per-fragment attribute stamp.
@@ -923,7 +947,7 @@ func (s *GitLab) scanProject(ctx context.Context, proj *gitlabProject, yield Fra
 			return err
 		}
 		ev := logger.Info().Str("resource", label)
-		if r := s.rlRemaining.Load(); r > 0 {
+		if r := s.rateLimitRemaining(); r > 0 {
 			ev = ev.Int64("rl_remaining", r)
 		}
 		ev.Msg("completed")
@@ -984,8 +1008,6 @@ func (s *GitLab) scanProjectGit(ctx context.Context, proj *gitlabProject, yield 
 		return src.Fragments(ctx, yield)
 	})
 }
-
-// --- Issues & MRs --------------------------------------------------------
 
 func (s *GitLab) scanIssuesAndMRs(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
 	if s.Resources.Has(GitLabResourceTypeIssues) || s.Resources.Has(GitLabResourceTypeIssueComments) {
@@ -1109,7 +1131,7 @@ func (s *GitLab) scanItemNotes(ctx context.Context, projectID int, itemKind stri
 			attrs := map[string]string{
 				AttrResource:        ResourceGitLabComment,
 				AttrGitLabCommentID: strconv.FormatInt(note.ID, 10),
-				AttrURL:             parentURL,
+				AttrURL:             gitlabNoteURL(parentURL, note.ID),
 				parentAttrKey:       parentAttrVal,
 			}
 			if shouldSkipAttrs(s.ShouldSkip, attrs) {
@@ -1123,8 +1145,6 @@ func (s *GitLab) scanItemNotes(ctx context.Context, projectID int, itemKind stri
 		return len(page) == gitlabPerPage, nil
 	})
 }
-
-// --- Snippets ------------------------------------------------------------
 
 func (s *GitLab) scanSnippets(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
 	u, err := s.apiURL(fmt.Sprintf("projects/%d/snippets", proj.ID))
@@ -1158,8 +1178,6 @@ func (s *GitLab) scanSnippets(ctx context.Context, proj *gitlabProject, yield Fr
 		return len(page) == gitlabPerPage, nil
 	})
 }
-
-// --- Releases ------------------------------------------------------------
 
 func (s *GitLab) scanReleases(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
 	u, err := s.apiURL(fmt.Sprintf("projects/%d/releases", proj.ID))
@@ -1230,67 +1248,100 @@ func (s *GitLab) scanReleases(ctx context.Context, proj *gitlabProject, yield Fr
 	})
 }
 
-// --- CI jobs / artifacts -------------------------------------------------
-
 func (s *GitLab) scanCIJobs(ctx context.Context, proj *gitlabProject, yield FragmentsFunc) error {
 	u, err := s.apiURL(fmt.Sprintf("projects/%d/jobs", proj.ID))
 	if err != nil {
 		return err
 	}
+	return s.scanCIJobsURL(ctx, proj, u, yield)
+}
+
+func (s *GitLab) scanPipelineJobs(ctx context.Context, proj *gitlabProject, pipelineID int64, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/pipelines/%d/jobs", proj.ID, pipelineID))
+	if err != nil {
+		return err
+	}
+	return s.scanCIJobsURL(ctx, proj, u, yield)
+}
+
+func (s *GitLab) scanSingleCIJob(ctx context.Context, proj *gitlabProject, jobID int64, yield FragmentsFunc) error {
+	u, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d", proj.ID, jobID))
+	if err != nil {
+		return err
+	}
+	var job gitlabJob
+	if err := s.doJSON(ctx, u, &job); err != nil {
+		return err
+	}
+	ok, _ := s.inDateRange(job.CreatedAt)
+	if !ok {
+		return nil
+	}
+	return s.scanCIJob(ctx, proj, job, yield)
+}
+
+func (s *GitLab) scanCIJobsURL(ctx context.Context, proj *gitlabProject, u *url.URL, yield FragmentsFunc) error {
 	return s.paginateJSON(ctx, u, func(body []byte) (bool, error) {
 		var page []gitlabJob
 		if err := json.Unmarshal(body, &page); err != nil {
 			return false, fmt.Errorf("decode jobs: %w", err)
 		}
 		for _, job := range page {
-			if ok, _ := s.inDateRange(job.CreatedAt); !ok {
+			if ok, stop := s.inDateRange(job.CreatedAt); stop {
+				return false, nil
+			} else if !ok {
 				continue
 			}
-			attrs := map[string]string{
-				AttrResource:           ResourceGitLabCIJob,
-				AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
-				AttrGitLabCIJobName:    job.Name,
-				AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
-				AttrURL:                job.WebURL,
-			}
-			if shouldSkipAttrs(s.ShouldSkip, attrs) {
-				continue
-			}
-			traceURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/trace", proj.ID, job.ID))
-			if err != nil {
+			if err := s.scanCIJob(ctx, proj, job, yield); err != nil {
 				return false, err
-			}
-			logPath := fmt.Sprintf("ci/jobs/%s/job_%d.log", safePath(job.Name), job.ID)
-			if err := s.downloadAndScan(ctx, traceURL.String(), logPath, attrs, yield); err != nil {
-				logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job trace")
-			}
-			if !s.Resources.Has(GitLabResourceTypeCIArtifacts) || len(job.Artifacts) == 0 {
-				continue
-			}
-			artifactAttrs := map[string]string{
-				AttrResource:           ResourceGitLabCIArtifact,
-				AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
-				AttrGitLabCIJobName:    job.Name,
-				AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
-				AttrURL:                job.WebURL,
-			}
-			if shouldSkipAttrs(s.ShouldSkip, artifactAttrs) {
-				continue
-			}
-			artURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/artifacts", proj.ID, job.ID))
-			if err != nil {
-				return false, err
-			}
-			artifactPath := fmt.Sprintf("ci/artifacts/%s/job_%d.zip", safePath(job.Name), job.ID)
-			if err := s.downloadAndScan(ctx, artURL.String(), artifactPath, artifactAttrs, yield); err != nil {
-				logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job artifacts")
 			}
 		}
 		return len(page) == gitlabPerPage, nil
 	})
 }
 
-// --- Direct resource scan (URL points at a specific issue/MR/etc.) -------
+func (s *GitLab) scanCIJob(ctx context.Context, proj *gitlabProject, job gitlabJob, yield FragmentsFunc) error {
+	attrs := map[string]string{
+		AttrResource:           ResourceGitLabCIJob,
+		AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
+		AttrGitLabCIJobName:    job.Name,
+		AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
+		AttrURL:                job.WebURL,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, attrs) {
+		return nil
+	}
+	traceURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/trace", proj.ID, job.ID))
+	if err != nil {
+		return err
+	}
+	logPath := fmt.Sprintf("ci/jobs/%s/job_%d.log", safePath(job.Name), job.ID)
+	if err := s.downloadAndScan(ctx, traceURL.String(), logPath, attrs, yield); err != nil {
+		logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job trace")
+	}
+	if !s.Resources.Has(GitLabResourceTypeCIArtifacts) || len(job.Artifacts) == 0 {
+		return nil
+	}
+	artifactAttrs := map[string]string{
+		AttrResource:           ResourceGitLabCIArtifact,
+		AttrGitLabCIJobID:      strconv.FormatInt(job.ID, 10),
+		AttrGitLabCIJobName:    job.Name,
+		AttrGitLabCIPipelineID: strconv.FormatInt(job.Pipeline.ID, 10),
+		AttrURL:                job.WebURL,
+	}
+	if shouldSkipAttrs(s.ShouldSkip, artifactAttrs) {
+		return nil
+	}
+	artURL, err := s.apiURL(fmt.Sprintf("projects/%d/jobs/%d/artifacts", proj.ID, job.ID))
+	if err != nil {
+		return err
+	}
+	artifactPath := fmt.Sprintf("ci/artifacts/%s/job_%d.zip", safePath(job.Name), job.ID)
+	if err := s.downloadAndScan(ctx, artURL.String(), artifactPath, artifactAttrs, yield); err != nil {
+		logging.Debug().Err(err).Int64("job", job.ID).Msg("could not scan job artifacts")
+	}
+	return nil
+}
 
 func (s *GitLab) scanDirect(ctx context.Context, target *gitlabTarget, yield FragmentsFunc) error {
 	if target.Project == nil {
@@ -1323,10 +1374,18 @@ func (s *GitLab) scanDirect(ctx context.Context, target *gitlabTarget, yield Fra
 		return s.scanSingleSnippet(ctx, target.Project, sid, glYield)
 	case "release":
 		return s.scanSingleRelease(ctx, target.Project, target.Resource.ID, glYield)
-	case "pipeline", "job":
-		// For pipeline or job URLs we fall through to the full CI job scan
-		// of the project, filtered by the user's resource selection.
-		return s.scanCIJobs(ctx, target.Project, glYield)
+	case "pipeline":
+		pipelineID, err := strconv.ParseInt(target.Resource.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid pipeline id %q", target.Resource.ID)
+		}
+		return s.scanPipelineJobs(ctx, target.Project, pipelineID, glYield)
+	case "job":
+		jobID, err := strconv.ParseInt(target.Resource.ID, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid job id %q", target.Resource.ID)
+		}
+		return s.scanSingleCIJob(ctx, target.Project, jobID, glYield)
 	default:
 		return fmt.Errorf("unsupported direct resource %q", target.Kind)
 	}
@@ -1460,17 +1519,22 @@ func (s *GitLab) scanSingleRelease(ctx context.Context, proj *gitlabProject, tag
 	return nil
 }
 
-// --- Misc helpers --------------------------------------------------------
-
-// downloadAndScan streams a GitLab API resource through downloadAndScanSource,
-// attaching the PRIVATE-TOKEN as the bearer if a token is configured (the
-// underlying client transport already host-scopes the header).
+// downloadAndScan streams a GitLab resource through the shared GitLab client so
+// retries, rate-limit pauses, and host-scoped auth match API requests.
 func (s *GitLab) downloadAndScan(ctx context.Context, rawURL, path string, attrs map[string]string, yield FragmentsFunc) error {
+	if err := s.ensureClient(); err != nil {
+		return err
+	}
+	release, err := s.acquireAPISlot(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
 	return downloadAndScanSource(ctx, sourceDownloadOptions{
 		URL:             rawURL,
+		HTTPClient:      s.httpClient,
 		Path:            path,
 		Attrs:           attrs,
-		BearerToken:     s.Token,
 		MaxArchiveDepth: s.MaxArchiveDepth,
 		ShouldSkip:      s.ShouldSkip,
 		TempPattern:     "betterleaks-gitlab-dl-*",
@@ -1527,7 +1591,24 @@ func timeOr(primary, fallback time.Time) time.Time {
 	return fallback
 }
 
-// --- Retry / rate-limit --------------------------------------------------
+func gitlabNoteURL(parentURL string, noteID int64) string {
+	if parentURL == "" || noteID == 0 {
+		return parentURL
+	}
+	u, err := url.Parse(parentURL)
+	if err != nil {
+		return parentURL + "#note_" + strconv.FormatInt(noteID, 10)
+	}
+	u.Fragment = "note_" + strconv.FormatInt(noteID, 10)
+	return u.String()
+}
+
+func (s *GitLab) rateLimitRemaining() int64 {
+	if s.restRetry == nil {
+		return 0
+	}
+	return s.restRetry.RateLimitRemaining()
+}
 
 func gitlabRetryDecider(req *http.Request, resp *http.Response, err error, now time.Time) (bool, time.Duration) {
 	retry, wait := httpclient.DefaultRetryDecider(req, resp, err, now)

--- a/sources/gitlab_test.go
+++ b/sources/gitlab_test.go
@@ -202,6 +202,23 @@ func TestGitLab_scanProject_L1Skip(t *testing.T) {
 	}
 }
 
+func TestGitLab_scanProject_PropagatesRepoScanError(t *testing.T) {
+	s := &GitLab{
+		Resources: GitLabResourceSet{GitLabResourceTypeRepos: true},
+	}
+	proj := &gitlabProject{
+		ID:                1,
+		PathWithNamespace: "g/p",
+		WebURL:            "https://gitlab.example.com/g/p",
+		HTTPURLToRepo:     "://bad-url",
+	}
+
+	err := s.scanProject(context.Background(), proj, func(Fragment, error) error { return nil })
+	if err == nil {
+		t.Fatal("expected repo scan error")
+	}
+}
+
 // TestGitLab_scanIssues_L2Skip: an item-level ShouldSkip drops a specific
 // issue (and crucially does NOT fetch its notes), but lets other issues through.
 func TestGitLab_scanIssues_L2Skip(t *testing.T) {
@@ -307,6 +324,44 @@ func TestGitlabNoteURL_ReplacesExistingFragment(t *testing.T) {
 	want := "https://gitlab.com/g/p/-/issues/1?discussion=abc#note_42"
 	if got != want {
 		t.Fatalf("gitlabNoteURL = %q, want %q", got, want)
+	}
+}
+
+func TestGitLab_scanSingleRelease_ScansSourceArchives(t *testing.T) {
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v4/projects/1/releases/v1.0":
+			rel := gitlabRelease{TagName: "v1.0", Description: "release notes"}
+			rel.Assets.Sources = []gitlabReleaseAssetSource{{Format: "zip", URL: "http://" + r.Host + "/archives/v1.0.zip"}}
+			rel.Assets.Links = []gitlabReleaseAssetLink{{Name: "binary.txt", URL: "http://" + r.Host + "/downloads/binary.txt"}}
+			_ = json.NewEncoder(w).Encode(rel)
+		case "/archives/v1.0.zip", "/downloads/binary.txt":
+			_, _ = w.Write([]byte("asset content"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:       server.URL + "/g/p/-/releases/v1.0",
+		BaseURL:   server.URL + "/",
+		Token:     "t",
+		Resources: GitLabResourceSet{GitLabResourceTypeReleases: true, GitLabResourceTypeReleaseAssets: true},
+	}
+	err := s.scanSingleRelease(context.Background(), &gitlabProject{ID: 1, PathWithNamespace: "g/p"}, "v1.0", func(Fragment, error) error { return nil })
+	if err != nil {
+		t.Fatalf("scanSingleRelease: %v", err)
+	}
+
+	got := strings.Join(requested, ",")
+	if !strings.Contains(got, "/archives/v1.0.zip") {
+		t.Fatalf("source archive was not downloaded; paths=%v", requested)
+	}
+	if !strings.Contains(got, "/downloads/binary.txt") {
+		t.Fatalf("release link was not downloaded; paths=%v", requested)
 	}
 }
 

--- a/sources/gitlab_test.go
+++ b/sources/gitlab_test.go
@@ -1,0 +1,381 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseGitLabURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		url      string
+		wantPath string
+		wantKind string
+		wantID   string
+		wantErr  bool
+	}{
+		{name: "root", url: "https://gitlab.com/", wantKind: "namespace"},
+		{name: "namespace", url: "https://gitlab.com/group", wantPath: "group", wantKind: "namespace"},
+		{name: "nested namespace", url: "https://gitlab.com/group/sub/project", wantPath: "group/sub/project", wantKind: "namespace"},
+		{name: "issue", url: "https://gitlab.com/group/project/-/issues/42", wantPath: "group/project", wantKind: "issue", wantID: "42"},
+		{name: "merge request", url: "https://gitlab.com/g/sub/p/-/merge_requests/7", wantPath: "g/sub/p", wantKind: "mr", wantID: "7"},
+		{name: "snippet", url: "https://gitlab.com/g/p/-/snippets/9", wantPath: "g/p", wantKind: "snippet", wantID: "9"},
+		{name: "release", url: "https://gitlab.com/g/p/-/releases/v1.2.3", wantPath: "g/p", wantKind: "release", wantID: "v1.2.3"},
+		{name: "pipeline", url: "https://gitlab.com/g/p/-/pipelines/8001", wantPath: "g/p", wantKind: "pipeline", wantID: "8001"},
+		{name: "job", url: "https://gitlab.com/g/p/-/jobs/9001", wantPath: "g/p", wantKind: "job", wantID: "9001"},
+		{name: "self-hosted with port", url: "https://gitlab.example.com:8443/g/p/-/issues/1", wantPath: "g/p", wantKind: "issue", wantID: "1"},
+		{name: "unsupported resource", url: "https://gitlab.com/g/p/-/wiki/Home", wantErr: true},
+		{name: "missing id", url: "https://gitlab.com/g/p/-/issues", wantErr: true},
+		{name: "bad scheme", url: "ftp://gitlab.com/g/p", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseGitLabURL(tc.url)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Path != tc.wantPath {
+				t.Errorf("Path = %q, want %q", got.Path, tc.wantPath)
+			}
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tc.wantKind)
+			}
+			if got.ID != tc.wantID {
+				t.Errorf("ID = %q, want %q", got.ID, tc.wantID)
+			}
+		})
+	}
+}
+
+func TestGitLab_isExcluded(t *testing.T) {
+	s := &GitLab{ExcludeRepos: []string{"group/test-*", "OTHER/abandoned"}}
+	cases := map[string]bool{
+		"group/test-foo":     true,
+		"group/Test-Bar":     true, // case-insensitive
+		"other/abandoned":    true,
+		"group/keep-me":      false,
+		"unrelated/anything": false,
+	}
+	for path, want := range cases {
+		if got := s.isExcluded(path); got != want {
+			t.Errorf("isExcluded(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestGitLab_projectAttributes(t *testing.T) {
+	proj := &gitlabProject{
+		ID:                42,
+		PathWithNamespace: "group/sub/project",
+		Visibility:        "private",
+		WebURL:            "https://gitlab.com/group/sub/project",
+	}
+	proj.Namespace.FullPath = "group/sub"
+	s := &GitLab{}
+
+	got := s.projectAttributes(proj, ResourceGitLabProject)
+	want := map[string]string{
+		AttrGitLabProjectID:   "42",
+		AttrGitLabProjectPath: "group/sub/project",
+		AttrGitLabProjectURL:  "https://gitlab.com/group/sub/project",
+		AttrGitLabVisibility:  "private",
+		AttrGitLabNamespace:   "group/sub",
+		AttrResource:          ResourceGitLabProject,
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("attr %q = %q, want %q", k, got[k], v)
+		}
+	}
+
+	// resource is empty → no AttrResource key set
+	bare := s.projectAttributes(proj, "")
+	if _, ok := bare[AttrResource]; ok {
+		t.Errorf("expected no AttrResource when resource=\"\", got %q", bare[AttrResource])
+	}
+}
+
+func TestGitLab_Validate(t *testing.T) {
+	cases := []struct {
+		name      string
+		source    func() *GitLab
+		wantErr   bool
+		wantResrc []GitLabResourceType
+	}{
+		{
+			name:    "missing URL",
+			source:  func() *GitLab { return &GitLab{Token: "t"} },
+			wantErr: true,
+		},
+		{
+			name:    "namespace URL without token",
+			source:  func() *GitLab { return &GitLab{URL: "https://gitlab.com/group"} },
+			wantErr: true,
+		},
+		{
+			name:    "project URL without token",
+			source:  func() *GitLab { return &GitLab{URL: "https://gitlab.com/group/project"} },
+			wantErr: true, // namespace kind → requires token
+		},
+		{
+			name:      "release URL stamps release+assets default",
+			source:    func() *GitLab { return &GitLab{URL: "https://gitlab.com/g/p/-/releases/v1.0", Token: "t"} },
+			wantResrc: []GitLabResourceType{GitLabResourceTypeReleases, GitLabResourceTypeReleaseAssets},
+		},
+		{
+			name:    "include unknown",
+			source:  func() *GitLab { return &GitLab{URL: "https://gitlab.com/g/p", Token: "t", Include: []string{"bogus"}} },
+			wantErr: true,
+		},
+		{
+			name:      "exclude drops resource",
+			source:    func() *GitLab { return &GitLab{URL: "https://gitlab.com/g/p/-/releases/v1", Token: "t", Exclude: []string{"release-assets"}} },
+			wantResrc: []GitLabResourceType{GitLabResourceTypeReleases},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.source()
+			err := src.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, rt := range tc.wantResrc {
+				if !src.Resources.Has(rt) {
+					t.Errorf("expected Resources to have %q; got %v", rt, src.Resources)
+				}
+			}
+		})
+	}
+}
+
+// TestGitLab_scanProject_L1Skip: when ShouldSkip returns true for a
+// project's L1 attrs, no fragments are yielded — even for resource types
+// that are enabled, because the per-resource scanners are never reached.
+func TestGitLab_scanProject_L1Skip(t *testing.T) {
+	skipped := 0
+	s := &GitLab{
+		Resources: GitLabResourceSet{GitLabResourceTypeIssues: true},
+		ShouldSkip: func(attrs map[string]string) bool {
+			if attrs[AttrResource] == ResourceGitLabProject {
+				skipped++
+				return true
+			}
+			return false
+		},
+	}
+	proj := &gitlabProject{ID: 1, PathWithNamespace: "g/p", WebURL: "https://gitlab.com/g/p"}
+
+	yielded := 0
+	yield := func(f Fragment, err error) error { yielded++; return nil }
+	if err := s.scanProject(context.Background(), proj, yield); err != nil {
+		t.Fatalf("scanProject: %v", err)
+	}
+	if skipped != 1 {
+		t.Errorf("expected L1 skip to fire exactly once, got %d", skipped)
+	}
+	if yielded != 0 {
+		t.Errorf("expected 0 fragments, got %d", yielded)
+	}
+}
+
+// TestGitLab_scanIssues_L2Skip: an item-level ShouldSkip drops a specific
+// issue (and crucially does NOT fetch its notes), but lets other issues through.
+func TestGitLab_scanIssues_L2Skip(t *testing.T) {
+	var notesFetchedFor []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/issues"):
+			page, _ := json.Marshal([]gitlabIssue{
+				{IID: 1, Title: "keep me", Description: "body1", WebURL: "https://example/issues/1", CreatedAt: time.Now()},
+				{IID: 2, Title: "drop me", Description: "body2", WebURL: "https://example/issues/2", CreatedAt: time.Now()},
+			})
+			w.Header().Set("X-Next-Page", "")
+			_, _ = w.Write(page)
+		case strings.Contains(r.URL.Path, "/notes"):
+			// Track which issue's notes were requested.
+			notesFetchedFor = append(notesFetchedFor, r.URL.Path)
+			_, _ = w.Write([]byte("[]"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:        server.URL + "/g/p/-/issues/0",
+		BaseURL:    server.URL + "/",
+		Token:      "t",
+		Resources:  GitLabResourceSet{GitLabResourceTypeIssues: true, GitLabResourceTypeIssueComments: true},
+		ShouldSkip: func(attrs map[string]string) bool { return attrs[AttrGitLabIssueIID] == "2" },
+	}
+	if err := s.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if base, err := s.buildAPIBase(); err != nil {
+		t.Fatalf("buildAPIBase: %v", err)
+	} else {
+		s.apiBaseURL = base
+		s.httpClient = http.DefaultClient
+	}
+	proj := &gitlabProject{ID: 1, PathWithNamespace: "g/p"}
+
+	var got []string
+	var mu sync.Mutex
+	yield := func(f Fragment, err error) error {
+		if err != nil {
+			return err
+		}
+		mu.Lock()
+		got = append(got, f.Attr(AttrGitLabIssueIID))
+		mu.Unlock()
+		return nil
+	}
+	if err := s.scanIssues(context.Background(), proj, yield); err != nil {
+		t.Fatalf("scanIssues: %v", err)
+	}
+	if want := []string{"1"}; len(got) != 1 || got[0] != want[0] {
+		t.Errorf("yielded issue IIDs = %v, want %v", got, want)
+	}
+	// The dropped issue (IID=2) must NOT have had its notes fetched —
+	// that's the entire point of an L2 skip.
+	for _, p := range notesFetchedFor {
+		if strings.Contains(p, "/issues/2/") {
+			t.Errorf("notes fetched for skipped issue: %s", p)
+		}
+	}
+}
+
+// TestGitLab_wrapGitLabYield_stampsAndSkips: the L3 wrapper stamps project
+// attrs on incoming fragments and applies the per-fragment skip filter.
+func TestGitLab_wrapGitLabYield_stampsAndSkips(t *testing.T) {
+	projectAttrs := map[string]string{
+		AttrGitLabProjectID:   "1",
+		AttrGitLabProjectPath: "g/p",
+	}
+	var got []map[string]string
+	yield := func(f Fragment, err error) error {
+		got = append(got, f.Attributes)
+		return nil
+	}
+
+	skip := func(attrs map[string]string) bool {
+		return attrs[AttrGitSHA] == "deadbeef"
+	}
+	wrapped := wrapGitLabYield(skip, projectAttrs, yield)
+
+	// 1) Fragment with no overlap → both attrs stamped, not skipped.
+	_ = wrapped(Fragment{Attributes: map[string]string{AttrGitSHA: "cafe"}}, nil)
+	// 2) Fragment matching skip predicate → dropped.
+	_ = wrapped(Fragment{Attributes: map[string]string{AttrGitSHA: "deadbeef"}}, nil)
+	// 3) Fragment with overlapping attr → existing value preserved.
+	_ = wrapped(Fragment{Attributes: map[string]string{AttrGitLabProjectID: "999"}}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("yielded %d fragments, want 2", len(got))
+	}
+	if got[0][AttrGitLabProjectID] != "1" || got[0][AttrGitLabProjectPath] != "g/p" {
+		t.Errorf("first fragment missing stamped project attrs: %v", got[0])
+	}
+	if got[1][AttrGitLabProjectID] != "999" {
+		t.Errorf("overlapping attr should not be overwritten; got %v", got[1])
+	}
+}
+
+func TestGitlabRetryDecider_PrimaryRateLimit403(t *testing.T) {
+	now := time.Now()
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header:     http.Header{},
+	}
+	resp.Header.Set("RateLimit-Remaining", "0")
+	resp.Header.Set("RateLimit-Reset", "9999999999") // far future
+	retry, wait := gitlabRetryDecider(nil, resp, nil, now)
+	if !retry {
+		t.Fatal("expected retry=true for primary rate limit")
+	}
+	if wait <= 0 {
+		t.Errorf("expected positive wait, got %v", wait)
+	}
+
+	// Without RateLimit-Remaining=0, 403 should NOT trigger retry.
+	resp.Header.Set("RateLimit-Remaining", "10")
+	if r, _ := gitlabRetryDecider(nil, resp, nil, now); r {
+		t.Errorf("expected no retry for ordinary 403")
+	}
+}
+
+func TestGitlabRateLimitStateExtractor_ParsesBothHeaderForms(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers map[string]string
+		want    int64
+	}{
+		{name: "no-prefix", headers: map[string]string{"RateLimit-Remaining": "42"}, want: 42},
+		{name: "x-prefix", headers: map[string]string{"X-RateLimit-Remaining": "7"}, want: 7},
+		{name: "absent", headers: nil, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: http.Header{}}
+			for k, v := range tc.headers {
+				resp.Header.Set(k, v)
+			}
+			remaining, _, ok := gitlabRateLimitStateExtractor(resp)
+			if tc.headers == nil {
+				if ok {
+					t.Errorf("expected ok=false with no headers")
+				}
+				return
+			}
+			if !ok {
+				t.Fatal("expected ok=true with headers present")
+			}
+			if remaining != tc.want {
+				t.Errorf("remaining = %d, want %d", remaining, tc.want)
+			}
+		})
+	}
+}
+
+func TestGitLab_buildAPIBase(t *testing.T) {
+	cases := []struct {
+		base string
+		want string
+	}{
+		{base: "https://gitlab.com/", want: "https://gitlab.com/api/v4/"},
+		{base: "https://gitlab.com", want: "https://gitlab.com/api/v4/"},
+		{base: "https://corp.com/gitlab/", want: "https://corp.com/gitlab/api/v4/"},
+		{base: "https://gitlab.example.com:8443/", want: "https://gitlab.example.com:8443/api/v4/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.base, func(t *testing.T) {
+			s := &GitLab{BaseURL: tc.base}
+			u, err := s.buildAPIBase()
+			if err != nil {
+				t.Fatalf("buildAPIBase: %v", err)
+			}
+			if u.String() != tc.want {
+				t.Errorf("got %q, want %q", u.String(), tc.want)
+			}
+		})
+	}
+}

--- a/sources/gitlab_test.go
+++ b/sources/gitlab_test.go
@@ -3,12 +3,15 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/betterleaks/betterleaks/internal/httpclient"
 )
 
 func TestParseGitLabURL(t *testing.T) {
@@ -140,8 +143,10 @@ func TestGitLab_Validate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "exclude drops resource",
-			source:    func() *GitLab { return &GitLab{URL: "https://gitlab.com/g/p/-/releases/v1", Token: "t", Exclude: []string{"release-assets"}} },
+			name: "exclude drops resource",
+			source: func() *GitLab {
+				return &GitLab{URL: "https://gitlab.com/g/p/-/releases/v1", Token: "t", Exclude: []string{"release-assets"}}
+			},
 			wantResrc: []GitLabResourceType{GitLabResourceTypeReleases},
 		},
 	}
@@ -264,6 +269,47 @@ func TestGitLab_scanIssues_L2Skip(t *testing.T) {
 	}
 }
 
+func TestGitLab_scanItemNotes_StampsCommentURL(t *testing.T) {
+	parentURL := "https://gitlab.com/g/p/-/merge_requests/7"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/merge_requests/7/notes") {
+			http.NotFound(w, r)
+			return
+		}
+		notes := []gitlabNote{{ID: 12345, Body: "comment body", CreatedAt: time.Now()}}
+		_ = json.NewEncoder(w).Encode(notes)
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:     server.URL + "/g/p/-/merge_requests/7",
+		BaseURL: server.URL + "/",
+		Token:   "t",
+	}
+	var gotURL string
+	err := s.scanItemNotes(context.Background(), 1, "merge_requests", 7, parentURL, AttrGitLabMRIID, "7", func(f Fragment, err error) error {
+		if err != nil {
+			return err
+		}
+		gotURL = f.Attr(AttrURL)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("scanItemNotes: %v", err)
+	}
+	if want := parentURL + "#note_12345"; gotURL != want {
+		t.Fatalf("comment URL = %q, want %q", gotURL, want)
+	}
+}
+
+func TestGitlabNoteURL_ReplacesExistingFragment(t *testing.T) {
+	got := gitlabNoteURL("https://gitlab.com/g/p/-/issues/1?discussion=abc#old", 42)
+	want := "https://gitlab.com/g/p/-/issues/1?discussion=abc#note_42"
+	if got != want {
+		t.Fatalf("gitlabNoteURL = %q, want %q", got, want)
+	}
+}
+
 // TestGitLab_wrapGitLabYield_stampsAndSkips: the L3 wrapper stamps project
 // attrs on incoming fragments and applies the per-fragment skip filter.
 func TestGitLab_wrapGitLabYield_stampsAndSkips(t *testing.T) {
@@ -377,5 +423,193 @@ func TestGitLab_buildAPIBase(t *testing.T) {
 				t.Errorf("got %q, want %q", u.String(), tc.want)
 			}
 		})
+	}
+}
+
+func TestGitLab_downloadAndScan_UsesRetryTransport(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_, _ = w.Write([]byte("plain content"))
+	}))
+	defer server.Close()
+
+	var slept time.Duration
+	s := &GitLab{
+		URL:     server.URL + "/g/p/-/snippets/1",
+		BaseURL: server.URL + "/",
+		Token:   "t",
+		restRetry: &httpclient.RetryTransport{
+			MaxRetries:     1,
+			Decider:        gitlabRetryDecider,
+			StateExtractor: gitlabRateLimitStateExtractor,
+			Sleep: func(_ context.Context, d time.Duration) error {
+				slept += d
+				return nil
+			},
+		},
+	}
+	if err := s.downloadAndScan(context.Background(), server.URL+"/raw", "raw.txt", map[string]string{AttrResource: ResourceGitLabSnippet}, func(Fragment, error) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("downloadAndScan: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("requests = %d, want 2", requests)
+	}
+	if slept != time.Second {
+		t.Fatalf("slept = %s, want 1s", slept)
+	}
+}
+
+func TestGitLab_downloadAndScan_DoesNotSendTokenToExternalURL(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer api.Close()
+
+	var gotAuth string
+	external := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("plain content"))
+	}))
+	defer external.Close()
+
+	s := &GitLab{URL: api.URL + "/g/p/-/releases/v1", BaseURL: api.URL + "/", Token: "secret"}
+	externalURL := strings.Replace(external.URL, "127.0.0.1", "localhost", 1)
+	if err := s.downloadAndScan(context.Background(), externalURL+"/asset.zip", "asset.txt", map[string]string{AttrResource: ResourceGitLabReleaseAsset}, func(Fragment, error) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("downloadAndScan: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("Authorization leaked to external host: %q", gotAuth)
+	}
+}
+
+func TestGitLab_downloadAndScan_SendsTokenToGitLabHost(t *testing.T) {
+	var gotAuth string
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("plain content"))
+	}))
+	defer api.Close()
+
+	s := &GitLab{URL: api.URL + "/g/p/-/snippets/1", BaseURL: api.URL + "/", Token: "secret"}
+	if err := s.downloadAndScan(context.Background(), api.URL+"/api/v4/projects/1/snippets/1/raw", "snippet.txt", map[string]string{AttrResource: ResourceGitLabSnippet}, func(Fragment, error) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("downloadAndScan: %v", err)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Fatalf("Authorization = %q, want Bearer secret", gotAuth)
+	}
+}
+
+func TestGitLab_scanDirectJob_ScansOnlyRequestedJob(t *testing.T) {
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v4/projects/1/jobs/9001":
+			job := gitlabJob{ID: 9001, Name: "build", CreatedAt: time.Now(), WebURL: "https://example/jobs/9001"}
+			job.Pipeline.ID = 8001
+			_ = json.NewEncoder(w).Encode(job)
+		case "/api/v4/projects/1/jobs/9001/trace":
+			_, _ = w.Write([]byte("trace"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:       server.URL + "/g/p/-/jobs/9001",
+		BaseURL:   server.URL + "/",
+		Token:     "t",
+		Resources: GitLabResourceSet{GitLabResourceTypeCIJobs: true, GitLabResourceTypeCIArtifacts: true},
+	}
+	target := &gitlabTarget{Kind: "job", Project: &gitlabProject{ID: 1, PathWithNamespace: "g/p"}, Resource: ParsedGitLabURL{ID: "9001"}}
+	if err := s.scanDirect(context.Background(), target, func(Fragment, error) error { return nil }); err != nil {
+		t.Fatalf("scanDirect: %v", err)
+	}
+	for _, p := range requested {
+		if p == "/api/v4/projects/1/jobs" {
+			t.Fatalf("listed all jobs for direct job scan: %v", requested)
+		}
+	}
+	if got := strings.Join(requested, ","); !strings.Contains(got, "/api/v4/projects/1/jobs/9001/trace") {
+		t.Fatalf("trace was not requested; paths=%v", requested)
+	}
+}
+
+func TestGitLab_scanDirectPipeline_UsesPipelineJobsEndpoint(t *testing.T) {
+	var requested []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requested = append(requested, r.URL.Path)
+		switch r.URL.Path {
+		case "/api/v4/projects/1/pipelines/8001/jobs":
+			job := gitlabJob{ID: 9001, Name: "build", CreatedAt: time.Now(), WebURL: "https://example/jobs/9001"}
+			job.Pipeline.ID = 8001
+			_ = json.NewEncoder(w).Encode([]gitlabJob{job})
+		case "/api/v4/projects/1/jobs/9001/trace":
+			_, _ = w.Write([]byte("trace"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:       server.URL + "/g/p/-/pipelines/8001",
+		BaseURL:   server.URL + "/",
+		Token:     "t",
+		Resources: GitLabResourceSet{GitLabResourceTypeCIJobs: true},
+	}
+	target := &gitlabTarget{Kind: "pipeline", Project: &gitlabProject{ID: 1, PathWithNamespace: "g/p"}, Resource: ParsedGitLabURL{ID: "8001"}}
+	if err := s.scanDirect(context.Background(), target, func(Fragment, error) error { return nil }); err != nil {
+		t.Fatalf("scanDirect: %v", err)
+	}
+	for _, p := range requested {
+		if p == "/api/v4/projects/1/jobs" {
+			t.Fatalf("listed all jobs for direct pipeline scan: %v", requested)
+		}
+	}
+	if requested[0] != "/api/v4/projects/1/pipelines/8001/jobs" {
+		t.Fatalf("first request = %q, want pipeline jobs endpoint; paths=%v", requested[0], requested)
+	}
+}
+
+func TestGitLab_scanCIJobs_StopsAtSinceBoundary(t *testing.T) {
+	var pages []string
+	since := time.Date(2026, 1, 10, 0, 0, 0, 0, time.UTC)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pages = append(pages, r.URL.Query().Get("page"))
+		if r.URL.Query().Get("page") != "1" {
+			t.Fatalf("unexpected page request: %s", r.URL.RawQuery)
+		}
+		old := gitlabJob{ID: 1, Name: "old", CreatedAt: since.Add(-time.Hour), WebURL: "https://example/jobs/1"}
+		w.Header().Set("X-Next-Page", "2")
+		_ = json.NewEncoder(w).Encode([]gitlabJob{old})
+	}))
+	defer server.Close()
+
+	s := &GitLab{
+		URL:           server.URL + "/g/p",
+		BaseURL:       server.URL + "/",
+		Token:         "t",
+		Resources:     GitLabResourceSet{GitLabResourceTypeCIJobs: true},
+		DateRangeOpts: DateRangeOptions{Since: since},
+	}
+	if err := s.scanCIJobs(context.Background(), &gitlabProject{ID: 1, PathWithNamespace: "g/p"}, func(Fragment, error) error { return nil }); err != nil {
+		t.Fatalf("scanCIJobs: %v", err)
+	}
+	if got := fmt.Sprint(pages); got != "[1]" {
+		t.Fatalf("requested pages = %s, want [1]", got)
 	}
 }


### PR DESCRIPTION
This pull request adds comprehensive support for scanning GitLab projects and resources for secrets. It introduces a new `gitlab` command with extensive configuration options, defines new resource and attribute constants for GitLab entities, and improves HTTP client handling for source downloads.

Follows the same shape as the GitHub source

```
~/code/betterleaks/betterleaks (source/gitlab) ./betterleaks gitlab --help
scan GitLab projects and resources for secrets

Usage:
  betterleaks gitlab <target-url> [flags]

Examples:
  # Scan a project's git history
  betterleaks gitlab https://gitlab.com/group/project

  # Scan a merge request
  betterleaks gitlab https://gitlab.com/group/project/-/merge_requests/42

  # Scan all projects under a group (recursing into subgroups by default)
  betterleaks gitlab https://gitlab.com/mygroup

  # Scan projects plus issues and MRs
  betterleaks gitlab --include=issues,mrs https://gitlab.com/group/project

  # Scan a self-hosted instance
  betterleaks gitlab --base-url=https://gitlab.example.com/ https://gitlab.example.com/group/project

Flags:
      --all-groups             enumerate every group visible to the token (instance-wide)
      --base-url string        site base URL for self-hosted instances (e.g. https://gitlab.example.com/)
      --exclude strings        resource types to skip: repos, forks, mrs, mr-comments, issues, issue-comments, snippets, releases, release-assets, ci-jobs, ci-artifacts
      --exclude-repo strings   glob patterns to exclude projects by full path (e.g. 'group/test-*')
      --git-workers int        parallel git workers per project (0 = single process)
  -h, --help                   help for gitlab
      --include strings        resource types to scan: repos (default), forks, mrs, mr-comments, issues, issue-comments, snippets, releases, release-assets, ci-jobs, ci-artifacts
      --include-subgroups      when scanning a group, recurse into subgroups (default true)
      --log-opts string        git log options passed to each project scan
      --since string           only scan API items created after this date (YYYY-MM-DD or RFC3339)
      --token string           GitLab personal access token (or set GITLAB_TOKEN)
      --until string           only scan API items created before this date (YYYY-MM-DD or RFC3339)
```