### PR TITLE
feat(github): validate tokens against GHES base URL

### DIFF
--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -7,20 +7,22 @@ import (
 	"github.com/betterleaks/betterleaks/regexp"
 )
 
-const githubTokenCEL = `cel.bind(r,
-  http.get("https://api.github.com/user", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "token " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?login.orValue("") != "" ? {
-    "result": "valid",
-    "username": r.json.?login.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "scopes": r.headers[?"x-oauth-scopes"].orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+const githubTokenCEL = `cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/user", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "token " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?login.orValue("") != "" ? {
+      "result": "valid",
+      "username": r.json.?login.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "scopes": r.headers[?"x-oauth-scopes"].orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )`
 
 var githubPathFilter = `matchesAny(attributes[?"path"].orValue(""), [r"""(?:^|/)@octokit/auth-token/README\.md$"""])`
@@ -85,21 +87,23 @@ func GitHubOauth() *config.Rule {
 
 // TODO add this later once we confirm orValue({}) is working
 // "permissions": r.json.?permissions.orValue({})
-const githubAppTokenCEL = `cel.bind(r,
-  http.get("https://api.github.com/app", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "Bearer " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?slug.orValue("") != "" ? {
-    "result": "valid",
-    "slug": r.json.?slug.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "html_url": r.json.?html_url.orValue(""),
-	"external_url": r.json.?external_url.orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+const githubAppTokenCEL = `cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/app", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "Bearer " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?slug.orValue("") != "" ? {
+      "result": "valid",
+      "slug": r.json.?slug.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "html_url": r.json.?html_url.orValue(""),
+      "external_url": r.json.?external_url.orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )`
 
 func GitHubApp() *config.Rule {

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2869,21 +2869,23 @@ keywords = [
     "ghs_",
 ]
 validate = '''
-cel.bind(r,
-  http.get("https://api.github.com/app", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "Bearer " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?slug.orValue("") != "" ? {
-    "result": "valid",
-    "slug": r.json.?slug.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "html_url": r.json.?html_url.orValue(""),
-	"external_url": r.json.?external_url.orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/app", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "Bearer " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?slug.orValue("") != "" ? {
+      "result": "valid",
+      "slug": r.json.?slug.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "html_url": r.json.?html_url.orValue(""),
+      "external_url": r.json.?external_url.orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )
 '''
 filter = '''
@@ -2900,20 +2902,22 @@ description = "Found a GitHub Fine-Grained Personal Access Token, risking unauth
 regex = '''github_pat_\w{82}'''
 keywords = ["github_pat_"]
 validate = '''
-cel.bind(r,
-  http.get("https://api.github.com/user", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "token " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?login.orValue("") != "" ? {
-    "result": "valid",
-    "username": r.json.?login.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "scopes": r.headers[?"x-oauth-scopes"].orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/user", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "token " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?login.orValue("") != "" ? {
+      "result": "valid",
+      "username": r.json.?login.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "scopes": r.headers[?"x-oauth-scopes"].orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )
 '''
 filter = '''
@@ -2929,20 +2933,22 @@ description = "Discovered a GitHub OAuth Access Token, posing a risk of compromi
 regex = '''gho_[0-9a-zA-Z]{36}'''
 keywords = ["gho_"]
 validate = '''
-cel.bind(r,
-  http.get("https://api.github.com/user", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "token " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?login.orValue("") != "" ? {
-    "result": "valid",
-    "username": r.json.?login.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "scopes": r.headers[?"x-oauth-scopes"].orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/user", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "token " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?login.orValue("") != "" ? {
+      "result": "valid",
+      "username": r.json.?login.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "scopes": r.headers[?"x-oauth-scopes"].orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )
 '''
 filter = '''
@@ -2958,20 +2964,22 @@ description = "Uncovered a GitHub Personal Access Token, potentially leading to 
 regex = '''ghp_[0-9a-zA-Z]{36}'''
 keywords = ["ghp_"]
 validate = '''
-cel.bind(r,
-  http.get("https://api.github.com/user", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "token " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?login.orValue("") != "" ? {
-    "result": "valid",
-    "username": r.json.?login.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "scopes": r.headers[?"x-oauth-scopes"].orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/user", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "token " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?login.orValue("") != "" ? {
+      "result": "valid",
+      "username": r.json.?login.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "scopes": r.headers[?"x-oauth-scopes"].orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )
 '''
 filter = '''
@@ -2988,20 +2996,22 @@ description = "Detected a GitHub Refresh Token, which could allow prolonged unau
 regex = '''ghr_[0-9a-zA-Z]{36}'''
 keywords = ["ghr_"]
 validate = '''
-cel.bind(r,
-  http.get("https://api.github.com/user", {
-    "Accept": "application/vnd.github+json",
-    "Authorization": "token " + finding["secret"]
-  }),
-  r.status == 200 && r.json.?login.orValue("") != "" ? {
-    "result": "valid",
-    "username": r.json.?login.orValue(""),
-    "name": r.json.?name.orValue(""),
-    "scopes": r.headers[?"x-oauth-scopes"].orValue("")
-  } : r.status in [401, 403] ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : unknown(r)
+cel.bind(base_url, env.get("GITHUB_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://api.github.com") + "/user", {
+      "Accept": "application/vnd.github+json",
+      "Authorization": "token " + finding["secret"]
+    }),
+    r.status == 200 && r.json.?login.orValue("") != "" ? {
+      "result": "valid",
+      "username": r.json.?login.orValue(""),
+      "name": r.json.?name.orValue(""),
+      "scopes": r.headers[?"x-oauth-scopes"].orValue("")
+    } : r.status in [401, 403] ? {
+      "result": "invalid",
+      "reason": "Unauthorized"
+    } : unknown(r)
+  )
 )
 '''
 filter = '''

--- a/docs/config.md
+++ b/docs/config.md
@@ -176,22 +176,33 @@ For more complex validation setups, such as Basic Auth, dynamic request bodies,
 HMAC signatures, or composite `[[rules.required]]` rules, check the built-in
 rules in `cmd/generate/config/rules`.
 
-### Validating against GitHub Enterprise Server
+### Overriding rule defaults with env vars
 
-The `github-*` validation rules read `GITHUB_BASE_URL` via `env.get` and fall
-back to `https://api.github.com` when it's empty. To validate tokens minted by a
-GHES instance, allowlist the variable and export it before running:
+`env.get` lets a rule treat any hardcoded value — an API host, a region, an
+account ID — as a default that the user can override at scan time. The rule
+reads an allowlisted variable and falls back to the literal when it's empty:
+
+```cel
+cel.bind(base_url, env.get("SOME_BASE_URL"),
+  cel.bind(r,
+    http.get((base_url != "" ? base_url : "https://default.example.com") + "/whoami", { ... }),
+    ...
+  )
+)
+```
+
+The variable must be passed via `--validation-env-vars`; without the flag,
+`env.get` returns a CEL error and the finding's validation status becomes
+`error`. When the var is allowlisted but unset, `env.get` returns `""` and the
+ternary falls back to the literal default.
+
+The built-in `github-*` rules use this pattern with `GITHUB_BASE_URL` so the
+same rules validate against GitHub Enterprise Server:
 
 ```sh
 export GITHUB_BASE_URL=https://github.example.com/api/v3
 betterleaks github --validation --validation-env-vars GITHUB_BASE_URL https://github.example.com/owner
 ```
-
-`--validation-env-vars GITHUB_BASE_URL` is required whenever `--validation` is
-used on github tokens — without the flag, `env.get` returns a CEL error and the
-finding's validation status becomes `error`. When the env var is allowlisted but
-unset (the common github.com case), `env.get` returns `""` and the ternary falls
-back to `api.github.com`.
 
 ## Validation with an LLM
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -176,6 +176,23 @@ For more complex validation setups, such as Basic Auth, dynamic request bodies,
 HMAC signatures, or composite `[[rules.required]]` rules, check the built-in
 rules in `cmd/generate/config/rules`.
 
+### Validating against GitHub Enterprise Server
+
+The `github-*` validation rules read `GITHUB_BASE_URL` via `env.get` and fall
+back to `https://api.github.com` when it's empty. To validate tokens minted by a
+GHES instance, allowlist the variable and export it before running:
+
+```sh
+export GITHUB_BASE_URL=https://github.example.com/api/v3
+betterleaks github --validation --validation-env-vars GITHUB_BASE_URL https://github.example.com/owner
+```
+
+`--validation-env-vars GITHUB_BASE_URL` is required whenever `--validation` is
+used on github tokens — without the flag, `env.get` returns a CEL error and the
+finding's validation status becomes `error`. When the env var is allowlisted but
+unset (the common github.com case), `env.get` returns `""` and the ternary falls
+back to `api.github.com`.
+
 ## Validation with an LLM
 
 For generic high-entropy matches that no live API can adjudicate, a validation


### PR DESCRIPTION
The five github-* rules previously hardcoded https://api.github.com in their ValidateCEL blocks, so tokens minted by a GitHub Enterprise Server instance were always reported as invalid even when scanning that GHES instance directly.

Thread the resolved BaseURL from cmd/github.go through to a new generic config(key, default) CEL binding. The five rules use the binding in place of the hardcoded URL and fall back to api.github.com when the key is unset, preserving existing behavior for non-GHES users.

Notes:
- Generic config() rather than a vendor-specific github.api_base(): scales to GitLab self-hosted, Bitbucket DC, etc. without another binding per vendor.
- No allowlist gating on config(): values come exclusively from betterleaks's own code paths, not OS env or rule-author surface, so env()'s allowlist motivation does not apply.
- --base-url is optional; auto-derivation from the target URL host (now hoisted from dispatchURL into Validate()) populates it.
- githubAPIBaseFromBaseURL rejects non-https schemes and any URL carrying a userinfo component (u.User != nil) to prevent token exfiltration via a crafted base URL.

Tests:
- internal/celenv/bindings_config_test.go: binding mechanics, thread-safety, nil-receiver safety.
- internal/celenv/cel_test.go: end-to-end via httptest server proves the github-pat ValidateCEL routes to the configured base and carries the secret in the Authorization header; companion test confirms the default fallback path is unchanged.
- cmd/github_test.go: 9 cases for the URL helper including userinfo-injection and non-https rejection.

Closes #114.