### PR TITLE
gcp service tokens and app default creds

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -166,8 +166,8 @@ func main() {
 		rules.Freemius(),
 		rules.FreshbooksAccessToken(),
 		rules.GoCardless(),
-		// TODO figure out what makes sense for GCP
-		// rules.GCPServiceAccount(),
+		rules.GCPApplicationDefaultCredentials(),
+		rules.GCPServiceAccount(),
 		rules.GCPAPIKey(),
 		rules.GiteaAccessToken(),
 		rules.GitHubPat(),

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -7,21 +7,64 @@ import (
 	"github.com/betterleaks/betterleaks/regexp"
 )
 
-// TODO this one could probably use some work
+func GCPApplicationDefaultCredentials() *config.Rule {
+	r := config.Rule{
+		Description: "Google (GCP) Application Default Credentials",
+		RuleID:      "gcp-application-default-credentials",
+		Regex:       regexp.MustCompile(`\{[^{]+(?:(?:"client_secret"\s*:\s*"[^"]+"[^}]+"refresh_token"\s*:\s*"[^"]+")|(?:"refresh_token"\s*:\s*"[^"]+"[^}]+"client_secret"\s*:\s*"[^"]+"))[^}]+\}`),
+		Keywords:    []string{".apps.googleusercontent.com"},
+		ValidateCEL: `cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid",
+    "credential_type": r.credential_type,
+    "client_id": r.client_id
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "error_code": r.error_code,
+    "error_message": r.error_message
+  } : unknown(r)
+)
+`,
+	}
+
+	tps := []string{
+		`{"client_id":"1234567890.apps.googleusercontent.com","client_secret":"GOCSPX-example","refresh_token":"1//refresh-token","type":"authorized_user"}`,
+	}
+	return utils.Validate(r, tps, nil)
+}
+
 func GCPServiceAccount() *config.Rule {
-	// define rule
 	r := config.Rule{
 		Description: "Google (GCP) Service-account",
 		RuleID:      "gcp-service-account",
-		Regex:       regexp.MustCompile(`\"type\": \"service_account\"`),
-		Keywords:    []string{`\"type\": \"service_account\"`},
+		Regex:       regexp.MustCompile(`\{[^{]+(?:(?:"private_key"\s*:\s*"-----BEGIN (?:RSA )?PRIVATE KEY-----[^}]+auth_provider_x509_cert_url)|(?:auth_provider_x509_cert_url[^}]+"private_key"\s*:\s*"-----BEGIN (?:RSA )?PRIVATE KEY-----))[^}]+\}`),
+		Keywords:    []string{"provider_x509"},
+		ValidateCEL: `cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid",
+    "credential_type": r.credential_type,
+    "project_id": r.project_id,
+    "client_email": r.client_email
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "error_code": r.error_code,
+    "error_message": r.error_message
+  } : unknown(r)
+)
+`,
+		Filter: `containsAny(finding["secret"], ["image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"])`,
 	}
 
-	// validate
 	tps := []string{
-		`"type": "service_account"`,
+		`{"type":"service_account","project_id":"project-123","private_key_id":"key-id","private_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASC\n-----END PRIVATE KEY-----\n","client_email":"svc@project-123.iam.gserviceaccount.com","client_id":"1234567890","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_x509_cert_url":"https://www.googleapis.com/robot/v1/metadata/x509/svc%40project-123.iam.gserviceaccount.com"}`,
+		`{"auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","token_uri":"https://oauth2.googleapis.com/token","client_email":"svc@project-123.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASC\n-----END PRIVATE KEY-----\n","project_id":"project-123","type":"service_account"}`,
 	}
-	return utils.Validate(r, tps, nil)
+	fps := []string{
+		`{"description":"Google service account key","type":"object","required":["type","project_id","private_key_id","private_key","client_email","client_id","auth_uri","token_uri","auth_provider_x509_cert_url","client_x509_cert_url"],"properties":{"type":{"const":"service_account"},"project_id":{"type":"string"},"private_key_id":{"type":"string"},"private_key":{"type":"string"},"client_email":{"type":"string"},"client_id":{"type":"string"},"auth_uri":{"type":"string"},"token_uri":{"type":"string"},"auth_provider_x509_cert_url":{"type":"string"},"client_x509_cert_url":{"type":"string"}}}`,
+	}
+	return utils.Validate(r, tps, fps)
 }
 
 func GCPAPIKey() *config.Rule {

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -1359,6 +1359,58 @@ entropy(finding["secret"]) <= 4.0
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# gcp-application-default-credentials
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "gcp-application-default-credentials"
+description = "Google (GCP) Application Default Credentials"
+regex = '''\{[^{]+(?:(?:"client_secret"\s*:\s*"[^"]+"[^}]+"refresh_token"\s*:\s*"[^"]+")|(?:"refresh_token"\s*:\s*"[^"]+"[^}]+"client_secret"\s*:\s*"[^"]+"))[^}]+\}'''
+keywords = [".apps.googleusercontent.com"]
+validate = '''
+cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid",
+    "credential_type": r.credential_type,
+    "client_id": r.client_id
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "error_code": r.error_code,
+    "error_message": r.error_message
+  } : unknown(r)
+)
+
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
+# gcp-service-account
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "gcp-service-account"
+description = "Google (GCP) Service-account"
+regex = '''\{[^{]+(?:(?:"private_key"\s*:\s*"-----BEGIN (?:RSA )?PRIVATE KEY-----[^}]+auth_provider_x509_cert_url)|(?:auth_provider_x509_cert_url[^}]+"private_key"\s*:\s*"-----BEGIN (?:RSA )?PRIVATE KEY-----))[^}]+\}'''
+keywords = ["provider_x509"]
+validate = '''
+cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid",
+    "credential_type": r.credential_type,
+    "project_id": r.project_id,
+    "client_email": r.client_email
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "error_code": r.error_code,
+    "error_message": r.error_message
+  } : unknown(r)
+)
+
+'''
+filter = '''
+containsAny(finding["secret"], ["image-pulling@authenticated-image-pulling.iam.gserviceaccount.com"])
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # generic-api-key
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]

--- a/docs/config.md
+++ b/docs/config.md
@@ -137,6 +137,7 @@ Any additional keys are attached to the finding as validation metadata, such as
 | `hex.encode(bytes)` | Returns lowercase hex encoding. |
 | `time.nowUnix()` | Returns the current Unix timestamp as a string. |
 | `aws.validate(key, secret)` | Makes a SigV4-signed AWS STS request to validate AWS credentials. |
+| `gcp.validate(json)` | Exchanges GCP service-account or ADC JSON for an OAuth token and returns validation metadata. |
 | `base64.encode(bytes)` / `base64.decode(string)` | Provided by CEL's encoder extension. |
 | `cel.bind(name, value, expr)` | Binds a variable to avoid repeating sub-expressions. |
 

--- a/internal/celenv/bindings_gcp.go
+++ b/internal/celenv/bindings_gcp.go
@@ -1,0 +1,299 @@
+package celenv
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/functions"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+const (
+	defaultGCPTokenEndpoint = "https://oauth2.googleapis.com/token"
+	gcpOAuthScope           = "https://www.googleapis.com/auth/cloud-platform"
+	gcpJWTBearerGrant       = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+)
+
+type gcpCredential struct {
+	Type         string `json:"type"`
+	ProjectID    string `json:"project_id"`
+	PrivateKey   string `json:"private_key"`
+	ClientEmail  string `json:"client_email"`
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	RefreshToken string `json:"refresh_token"`
+	TokenURI     string `json:"token_uri"`
+}
+
+type gcpTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	Error       string `json:"error"`
+	ErrorDesc   string `json:"error_description"`
+}
+
+func gcpBindings(e *ValidationEnvironment) []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("gcp.validate",
+			cel.Overload("gcp_validate_string",
+				[]*cel.Type{cel.StringType},
+				cel.MapType(cel.StringType, cel.DynType),
+				cel.UnaryBinding(gcpValidateBinding(e)),
+			),
+		),
+	}
+}
+
+func gcpValidateBinding(e *ValidationEnvironment) functions.UnaryOp {
+	return func(arg ref.Val) ref.Val {
+		credentialJSON, ok := arg.(types.String)
+		if !ok {
+			return types.NewErr("gcp.validate: credential_json must be a string")
+		}
+
+		result := validateGCPCredential(e, string(credentialJSON))
+		return types.DefaultTypeAdapter.NativeToValue(result)
+	}
+}
+
+func validateGCPCredential(e *ValidationEnvironment, credentialJSON string) map[string]any {
+	creds, err := parseGCPCredential(credentialJSON)
+	if err != nil {
+		return map[string]any{
+			"status":        int64(400),
+			"error_code":    "invalid_credential_json",
+			"error_message": err.Error(),
+		}
+	}
+
+	tokenURL := strings.TrimSpace(creds.TokenURI)
+	if tokenURL == "" {
+		tokenURL = defaultGCPTokenEndpoint
+	}
+	if e.GCPTokenEndpoint != "" {
+		tokenURL = e.GCPTokenEndpoint
+	} else if !isAllowedGCPTokenEndpoint(tokenURL) {
+		return map[string]any{
+			"status":        int64(0),
+			"error_code":    "unsupported_token_uri",
+			"error_message": "GCP token URI is not an allowed Google OAuth endpoint",
+		}
+	}
+
+	form, err := gcpTokenRequestForm(creds, tokenURL)
+	if err != nil {
+		return map[string]any{
+			"status":          int64(400),
+			"error_code":      "invalid_credential",
+			"error_message":   err.Error(),
+			"credential_type": creds.Type,
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodPost, tokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return map[string]any{"status": int64(0)}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.client.Do(req)
+	if err != nil {
+		return map[string]any{"status": int64(0)}
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if err != nil {
+		return map[string]any{"status": int64(resp.StatusCode)}
+	}
+
+	if e.DebugResponse {
+		e.captureDebug("POST", tokenURL, form.Encode(), req, resp, respBody)
+	}
+
+	result := map[string]any{
+		"status":          int64(resp.StatusCode),
+		"credential_type": creds.Type,
+	}
+	if creds.ProjectID != "" {
+		result["project_id"] = creds.ProjectID
+	}
+	if creds.ClientEmail != "" {
+		result["client_email"] = creds.ClientEmail
+	}
+	if creds.ClientID != "" {
+		result["client_id"] = creds.ClientID
+	}
+
+	var tokenResp gcpTokenResponse
+	if err := json.Unmarshal(respBody, &tokenResp); err == nil {
+		if tokenResp.Error != "" {
+			result["error_code"] = tokenResp.Error
+		}
+		if tokenResp.ErrorDesc != "" {
+			result["error_message"] = tokenResp.ErrorDesc
+		}
+		if resp.StatusCode == http.StatusOK && tokenResp.AccessToken == "" {
+			result["status"] = int64(0)
+			result["error_code"] = "missing_access_token"
+			result["error_message"] = "GCP token response did not include access_token"
+		}
+	}
+
+	return result
+}
+
+func parseGCPCredential(input string) (gcpCredential, error) {
+	input = cleanGCPCredentialInput(input)
+
+	var creds gcpCredential
+	if err := json.Unmarshal([]byte(input), &creds); err != nil {
+		return gcpCredential{}, err
+	}
+
+	creds.ClientEmail = cleanGCPCredentialString(creds.ClientEmail)
+	creds.TokenURI = cleanGCPCredentialString(creds.TokenURI)
+
+	switch creds.Type {
+	case "service_account":
+		if creds.ProjectID == "" || creds.ClientEmail == "" || creds.PrivateKey == "" {
+			return gcpCredential{}, errMissingGCPFields("project_id/client_email/private_key")
+		}
+	case "authorized_user":
+		if creds.ClientID == "" || creds.ClientSecret == "" || creds.RefreshToken == "" {
+			return gcpCredential{}, errMissingGCPFields("client_id/client_secret/refresh_token")
+		}
+	default:
+		return gcpCredential{}, errMissingGCPFields("supported type")
+	}
+
+	return creds, nil
+}
+
+type errMissingGCPFields string
+
+func (e errMissingGCPFields) Error() string {
+	return "missing required GCP fields: " + string(e)
+}
+
+func gcpTokenRequestForm(creds gcpCredential, tokenURL string) (url.Values, error) {
+	switch creds.Type {
+	case "service_account":
+		jwt, err := createGCPServiceAccountJWT(creds.ClientEmail, creds.PrivateKey, tokenURL)
+		if err != nil {
+			return nil, err
+		}
+		return url.Values{
+			"grant_type": {gcpJWTBearerGrant},
+			"assertion":  {jwt},
+		}, nil
+	case "authorized_user":
+		return url.Values{
+			"grant_type":    {"refresh_token"},
+			"client_id":     {creds.ClientID},
+			"client_secret": {creds.ClientSecret},
+			"refresh_token": {creds.RefreshToken},
+		}, nil
+	default:
+		return nil, errMissingGCPFields("supported type")
+	}
+}
+
+func createGCPServiceAccountJWT(clientEmail, privateKeyPEM, tokenURI string) (string, error) {
+	now := time.Now()
+	claims := map[string]any{
+		"iss":   clientEmail,
+		"scope": gcpOAuthScope,
+		"aud":   tokenURI,
+		"exp":   now.Add(time.Hour).Unix(),
+		"iat":   now.Unix(),
+	}
+	headerJSON, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+	claimsJSON, err := json.Marshal(claims)
+	if err != nil {
+		return "", err
+	}
+
+	encodedHeader := base64.RawURLEncoding.EncodeToString(headerJSON)
+	encodedClaims := base64.RawURLEncoding.EncodeToString(claimsJSON)
+	signingInput := encodedHeader + "." + encodedClaims
+
+	privateKey, err := parseGCPPrivateKey(privateKeyPEM)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, privateKey, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", err
+	}
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func parseGCPPrivateKey(privateKeyPEM string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		return nil, errMissingGCPFields("PEM private_key")
+	}
+
+	if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+		rsaKey, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errMissingGCPFields("RSA private_key")
+		}
+		return rsaKey, nil
+	}
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
+func cleanGCPCredentialInput(input string) string {
+	input = strings.ReplaceAll(input, `,\\n`, `\n`)
+	input = strings.ReplaceAll(input, `\"\\n`, `\n`)
+	input = strings.ReplaceAll(input, `\\"`, `"`)
+	if strings.Contains(input, `\"type\"`) {
+		if unquoted, err := strconv.Unquote(`"` + input + `"`); err == nil {
+			return unquoted
+		}
+	}
+	return input
+}
+
+func cleanGCPCredentialString(s string) string {
+	s = strings.TrimSpace(s)
+	if strings.Contains(s, "<mailto:") {
+		s = strings.Split(strings.Split(s, "<mailto:")[1], "|")[0]
+	}
+	s = strings.TrimPrefix(s, "<")
+	s = strings.TrimSuffix(s, ">")
+	return s
+}
+
+func isAllowedGCPTokenEndpoint(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	if host == "oauth2.googleapis.com" || host == "accounts.google.com" {
+		return true
+	}
+	return strings.HasSuffix(host, ".googleapis.com")
+}

--- a/internal/celenv/bindings_gcp.go
+++ b/internal/celenv/bindings_gcp.go
@@ -292,8 +292,12 @@ func isAllowedGCPTokenEndpoint(rawURL string) bool {
 		return false
 	}
 	host := strings.ToLower(u.Hostname())
-	if host == "oauth2.googleapis.com" || host == "accounts.google.com" {
+	path := strings.TrimRight(u.EscapedPath(), "/")
+	if host == "oauth2.googleapis.com" && path == "/token" {
 		return true
 	}
-	return strings.HasSuffix(host, ".googleapis.com")
+	if host == "accounts.google.com" && path == "/o/oauth2/token" {
+		return true
+	}
+	return false
 }

--- a/internal/celenv/bindings_gcp_test.go
+++ b/internal/celenv/bindings_gcp_test.go
@@ -1,0 +1,184 @@
+package celenv
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGCPValidateCELBinding_ServiceAccountValid(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != gcpJWTBearerGrant {
+			t.Errorf("unexpected grant_type %q", got)
+		}
+		if assertion := r.Form.Get("assertion"); strings.Count(assertion, ".") != 2 {
+			t.Errorf("expected JWT assertion, got %q", assertion)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"access_token":"ya29.test","expires_in":3600,"token_type":"Bearer"}`)
+	}))
+	defer ts.Close()
+
+	env, err := NewEnvironment(ts.Client())
+	if err != nil {
+		t.Fatalf("NewEnvironment: %v", err)
+	}
+	env.GCPTokenEndpoint = ts.URL
+
+	prg, err := env.Compile(`cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid",
+    "project_id": r.project_id,
+    "client_email": r.client_email,
+    "credential_type": r.credential_type
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "reason": r.error_code
+  } : unknown(r)
+)`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	got, err := env.Eval(prg, map[string]string{"secret": testGCPServiceAccountJSON(t, ts.URL)}, nil)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+
+	m, err := got.ConvertToNative(mapAnyType)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	result := m.(map[string]any)
+	if result["result"] != "valid" {
+		t.Fatalf("expected valid, got %v", result["result"])
+	}
+	if result["project_id"] != "test-project" {
+		t.Errorf("unexpected project_id: %v", result["project_id"])
+	}
+	if result["client_email"] != "svc@test-project.iam.gserviceaccount.com" {
+		t.Errorf("unexpected client_email: %v", result["client_email"])
+	}
+	if result["credential_type"] != "service_account" {
+		t.Errorf("unexpected credential_type: %v", result["credential_type"])
+	}
+}
+
+func TestGCPValidateCELBinding_ApplicationDefaultCredentialsInvalid(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm: %v", err)
+		}
+		if got := r.Form.Get("grant_type"); got != "refresh_token" {
+			t.Errorf("unexpected grant_type %q", got)
+		}
+		if got := r.Form.Get("client_id"); got != "client.apps.googleusercontent.com" {
+			t.Errorf("unexpected client_id %q", got)
+		}
+		if got := r.Form.Get("refresh_token"); got != "refresh-token" {
+			t.Errorf("unexpected refresh_token %q", got)
+		}
+
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`)
+	}))
+	defer ts.Close()
+
+	env, err := NewEnvironment(ts.Client())
+	if err != nil {
+		t.Fatalf("NewEnvironment: %v", err)
+	}
+	env.GCPTokenEndpoint = ts.URL
+
+	prg, err := env.Compile(`cel.bind(r,
+  gcp.validate(finding["secret"]),
+  r.status == 200 ? {
+    "result": "valid"
+  } : r.status in [400, 401] ? {
+    "result": "invalid",
+    "error_code": r.error_code
+  } : unknown(r)
+)`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	adc := `{"type":"authorized_user","client_id":"client.apps.googleusercontent.com","client_secret":"secret","refresh_token":"refresh-token"}`
+	got, err := env.Eval(prg, map[string]string{"secret": adc}, nil)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+
+	m, err := got.ConvertToNative(mapAnyType)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	result := m.(map[string]any)
+	if result["result"] != "invalid" {
+		t.Fatalf("expected invalid, got %v", result["result"])
+	}
+	if result["error_code"] != "invalid_grant" {
+		t.Errorf("unexpected error_code: %v", result["error_code"])
+	}
+}
+
+func TestValidateGCPCredential_DisallowsNonGoogleTokenEndpoint(t *testing.T) {
+	result := validateGCPCredential(&ValidationEnvironment{client: DefaultHTTPClient()}, testGCPServiceAccountJSON(t, "http://127.0.0.1/token"))
+
+	if result["status"] != int64(0) {
+		t.Fatalf("expected status 0, got %v", result["status"])
+	}
+	if result["error_code"] != "unsupported_token_uri" {
+		t.Errorf("unexpected error_code: %v", result["error_code"])
+	}
+}
+
+func testGCPServiceAccountJSON(t *testing.T, tokenURI string) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPEM := string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: keyBytes,
+	}))
+
+	b, err := json.Marshal(map[string]string{
+		"type":                        "service_account",
+		"project_id":                  "test-project",
+		"private_key_id":              "key-id",
+		"private_key":                 keyPEM,
+		"client_email":                "svc@test-project.iam.gserviceaccount.com",
+		"client_id":                   "1234567890",
+		"auth_uri":                    "https://accounts.google.com/o/oauth2/auth",
+		"token_uri":                   tokenURI,
+		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+		"client_x509_cert_url":        "https://www.googleapis.com/robot/v1/metadata/x509/svc%40test-project.iam.gserviceaccount.com",
+	})
+	if err != nil {
+		t.Fatalf("Marshal credential: %v", err)
+	}
+	return string(b)
+}

--- a/internal/celenv/validation.go
+++ b/internal/celenv/validation.go
@@ -40,6 +40,9 @@ type ValidationEnvironment struct {
 	// STSEndpoint overrides the default AWS STS endpoint (for testing).
 	STSEndpoint string
 
+	// GCPTokenEndpoint overrides the GCP OAuth token endpoint (for testing).
+	GCPTokenEndpoint string
+
 	// AllowedEnv is the set of environment variable names the env(...) CEL
 	// binding may read (via os.Getenv). Names not in this set produce a CEL
 	// error. Nil or empty disables env(...) entirely. Populated from
@@ -114,6 +117,7 @@ func validationBindingSets(e *ValidationEnvironment) []cel.EnvOption {
 	opts = append(opts, hexBindings()...)
 	opts = append(opts, timeBindings()...)
 	opts = append(opts, awsBindings(e)...)
+	opts = append(opts, gcpBindings(e)...)
 	return opts
 }
 


### PR DESCRIPTION
This PR:
- enables, tweaks, and adds validation to the gcp service cred rule
- adds a [ADC](https://docs.cloud.google.com/docs/authentication/application-default-credentials) rule w/ validation 
- adds `validate.gcp` binding