### PR TITLE
Add --exclude-attributes and --max-attribute-length for verbose output

### DIFF
--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -39,8 +39,6 @@ func runDirectory(cmd *cobra.Command, args []string) {
 	followSymlinks := mustGetBoolFlag(cmd, "follow-symlinks")
 	maxArchiveDepth := mustGetIntFlag(cmd, "max-archive-depth")
 	maxTargetMegaBytes := mustGetIntFlag(cmd, "max-target-megabytes")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 	exitCode := mustGetIntFlag(cmd, "exit-code")
 
@@ -77,11 +75,7 @@ func runDirectory(cmd *cobra.Command, args []string) {
 
 			findings = append(findings, result.Finding)
 			if verbose {
-				if detector.LegacyPrint {
-					result.Finding.PrintLegacy(noColor, uint(redact))
-				} else {
-					result.Finding.Print(noColor, uint(redact))
-				}
+				detector.PrintFinding(result.Finding)
 			}
 		}
 

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -66,8 +66,6 @@ func runGit(cmd *cobra.Command, args []string) {
 	staged := mustGetBoolFlag(cmd, "staged")
 	preCommit := mustGetBoolFlag(cmd, "pre-commit")
 	gitWorkers := mustGetIntFlag(cmd, "git-workers")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 
 	var (
@@ -135,11 +133,7 @@ func runGit(cmd *cobra.Command, args []string) {
 
 		findings = append(findings, result.Finding)
 		if verbose {
-			if detector.LegacyPrint {
-				result.Finding.PrintLegacy(noColor, redact)
-			} else {
-				result.Finding.Print(noColor, redact)
-			}
+			detector.PrintFinding(result.Finding)
 		}
 	}
 

--- a/cmd/github.go
+++ b/cmd/github.go
@@ -118,8 +118,6 @@ func runGitHub(cmd *cobra.Command, args []string) {
 	}
 
 	exitCode := mustGetIntFlag(cmd, "exit-code")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 
 	detector.SkipFindingAppend = true
@@ -133,11 +131,7 @@ func runGitHub(cmd *cobra.Command, args []string) {
 		}
 		findings = append(findings, result.Finding)
 		if verbose {
-			if detector.LegacyPrint {
-				result.Finding.PrintLegacy(noColor, redact)
-			} else {
-				result.Finding.Print(noColor, redact)
-			}
+			detector.PrintFinding(result.Finding)
 		}
 	}
 

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -113,8 +113,6 @@ func runGitLab(cmd *cobra.Command, args []string) {
 	}
 
 	exitCode := mustGetIntFlag(cmd, "exit-code")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 
 	detector.SkipFindingAppend = true
@@ -128,11 +126,7 @@ func runGitLab(cmd *cobra.Command, args []string) {
 		}
 		findings = append(findings, result.Finding)
 		if verbose {
-			if detector.LegacyPrint {
-				result.Finding.PrintLegacy(noColor, redact)
-			} else {
-				result.Finding.Print(noColor, redact)
-			}
+			detector.PrintFinding(result.Finding)
 		}
 	}
 

--- a/cmd/huggingface.go
+++ b/cmd/huggingface.go
@@ -91,8 +91,6 @@ func runHuggingFace(cmd *cobra.Command, args []string) {
 	}
 
 	exitCode := mustGetIntFlag(cmd, "exit-code")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 
 	detector.SkipFindingAppend = true
@@ -106,11 +104,7 @@ func runHuggingFace(cmd *cobra.Command, args []string) {
 		}
 		findings = append(findings, result.Finding)
 		if verbose {
-			if detector.LegacyPrint {
-				result.Finding.PrintLegacy(noColor, redact)
-			} else {
-				result.Finding.Print(noColor, redact)
-			}
+			detector.PrintFinding(result.Finding)
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,7 +84,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("legacy-print", false, "use legacy key/value verbose finding format (requires --verbose)")
 	rootCmd.PersistentFlags().BoolP("no-color", "", false, "turn off color for verbose output")
 	rootCmd.PersistentFlags().StringSlice("exclude-attributes", []string{}, "attribute keys to omit from verbose output (repeat flag or comma-separate to add more)")
-	rootCmd.PersistentFlags().Int("max-attribute-length", 0, "truncate attribute values in verbose output to this many characters (default \"0\", no limit)")
+	rootCmd.PersistentFlags().Int("max-attribute-length", 0, "truncate attribute values in verbose output to this many characters/runes (default \"0\", no limit)")
 	rootCmd.PersistentFlags().Int("max-target-megabytes", 0, "files larger than this will be skipped")
 	rootCmd.PersistentFlags().BoolP("ignore-gitleaks-allow", "", false, "ignore gitleaks:allow and betterleaks:allow comments")
 	rootCmd.PersistentFlags().Uint("redact", 0, "redact secrets from logs and stdout. To redact only parts of the secret just apply a percent value from 0..100. For example --redact=20 (default 100%)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "show verbose output from scan")
 	rootCmd.PersistentFlags().Bool("legacy-print", false, "use legacy key/value verbose finding format (requires --verbose)")
 	rootCmd.PersistentFlags().BoolP("no-color", "", false, "turn off color for verbose output")
+	rootCmd.PersistentFlags().StringSlice("exclude-attributes", []string{}, "attribute keys to omit from verbose output (repeat flag or comma-separate to add more)")
+	rootCmd.PersistentFlags().Int("max-attribute-length", 0, "truncate attribute values in verbose output to this many characters (default \"0\", no limit)")
 	rootCmd.PersistentFlags().Int("max-target-megabytes", 0, "files larger than this will be skipped")
 	rootCmd.PersistentFlags().BoolP("ignore-gitleaks-allow", "", false, "ignore gitleaks:allow and betterleaks:allow comments")
 	rootCmd.PersistentFlags().Uint("redact", 0, "redact secrets from logs and stdout. To redact only parts of the secret just apply a percent value from 0..100. For example --redact=20 (default 100%)")
@@ -391,6 +393,18 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 		logging.Fatal().Err(err).Send()
 	}
 	if detector.LegacyPrint, err = cmd.Flags().GetBool("legacy-print"); err != nil {
+		logging.Fatal().Err(err).Send()
+	}
+	// limit which attributes are shown in verbose output (does not affect reports)
+	if excludeAttrs, attrErr := cmd.Flags().GetStringSlice("exclude-attributes"); attrErr != nil {
+		logging.Fatal().Err(attrErr).Send()
+	} else if len(excludeAttrs) > 0 {
+		detector.ExcludeAttributes = make(map[string]struct{}, len(excludeAttrs))
+		for _, attr := range excludeAttrs {
+			detector.ExcludeAttributes[strings.TrimSpace(attr)] = struct{}{}
+		}
+	}
+	if detector.MaxAttributeLength, err = cmd.Flags().GetInt("max-attribute-length"); err != nil {
 		logging.Fatal().Err(err).Send()
 	}
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -83,8 +83,6 @@ func runS3(cmd *cobra.Command, args []string) {
 	}
 
 	exitCode := mustGetIntFlag(cmd, "exit-code")
-	noColor := mustGetBoolFlag(cmd, "no-color")
-	redact := mustGetUIntFlag(cmd, "redact")
 	verbose := mustGetBoolFlag(cmd, "verbose")
 
 	detector.SkipFindingAppend = true
@@ -98,11 +96,7 @@ func runS3(cmd *cobra.Command, args []string) {
 		}
 		findings = append(findings, result.Finding)
 		if verbose {
-			if detector.LegacyPrint {
-				result.Finding.PrintLegacy(noColor, redact)
-			} else {
-				result.Finding.Print(noColor, redact)
-			}
+			detector.PrintFinding(result.Finding)
 		}
 	}
 

--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -48,7 +48,7 @@ func (d *Detector) DetectSource(ctx context.Context, source sources.Source) ([]r
 				d.ValidationCounts[f.ValidationStatus]++
 			}
 			if d.shouldVerbosePrint(f) {
-				printFinding(f, d.NoColor, d.Redact, d.LegacyPrint)
+				d.PrintFinding(f)
 			}
 		}
 	}()

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -177,6 +177,14 @@ type Detector struct {
 	// LegacyPrint uses the legacy key/value verbose format (typically with Verbose=true).
 	LegacyPrint bool
 
+	// ExcludeAttributes is the set of attribute keys to omit from verbose
+	// output. It does not affect findings written to reports.
+	ExcludeAttributes map[string]struct{}
+
+	// MaxAttributeLength truncates attribute values in verbose output to this
+	// many runes. Zero means no limit. It does not affect reports.
+	MaxAttributeLength int
+
 	// commitMutex is to prevent concurrent access to the
 	// commit map when adding commits
 	// Deprecated: this is only used for logging in git scans and can be removed when the legacy git scan is removed in v2.

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -180,12 +180,17 @@ func filter(findings []report.Finding) []report.Finding {
 	return retFindings
 }
 
-func printFinding(f report.Finding, noColor bool, redact uint, legacyPrint bool) {
-	if legacyPrint {
-		f.PrintLegacy(noColor, redact)
+// PrintFinding writes a single finding to stdout in verbose mode using the
+// detector's display settings, honoring --exclude-attributes and
+// --max-attribute-length. Attribute filtering is applied to a copy, so the
+// finding written to any report keeps its full attribute set.
+func (d *Detector) PrintFinding(f report.Finding) {
+	f = f.FilterAttributes(d.ExcludeAttributes, d.MaxAttributeLength)
+	if d.LegacyPrint {
+		f.PrintLegacy(d.NoColor, d.Redact)
 		return
 	}
-	f.Print(noColor, redact)
+	f.Print(d.NoColor, d.Redact)
 }
 
 // stripEmptyMeta removes keys whose value is an empty string or nil.

--- a/report/filter_attributes_test.go
+++ b/report/filter_attributes_test.go
@@ -1,0 +1,65 @@
+package report
+
+import "testing"
+
+func TestFilterAttributesNoop(t *testing.T) {
+	f := Finding{Attributes: map[string]string{"file": "main.go"}}
+	got := f.FilterAttributes(nil, 0)
+	if len(got.Attributes) != 1 || got.Attributes["file"] != "main.go" {
+		t.Fatalf("expected attributes unchanged, got %v", got.Attributes)
+	}
+}
+
+func TestFilterAttributesExcludeDoesNotMutateOriginal(t *testing.T) {
+	f := Finding{Attributes: map[string]string{
+		"file":   "main.go",
+		"commit": "abc123",
+		"email":  "a@b.com",
+	}}
+	exclude := map[string]struct{}{"commit": {}, "email": {}}
+
+	got := f.FilterAttributes(exclude, 0)
+	if _, ok := got.Attributes["commit"]; ok {
+		t.Error("commit should have been excluded")
+	}
+	if _, ok := got.Attributes["email"]; ok {
+		t.Error("email should have been excluded")
+	}
+	if got.Attributes["file"] != "main.go" {
+		t.Errorf("file should remain, got %q", got.Attributes["file"])
+	}
+	// The original finding (and its map) must be untouched so reports are unaffected.
+	if len(f.Attributes) != 3 {
+		t.Errorf("original finding was mutated: %v", f.Attributes)
+	}
+}
+
+func TestFilterAttributesMaxLen(t *testing.T) {
+	f := Finding{Attributes: map[string]string{
+		"short": "abc",
+		"long":  "abcdefghij",
+	}}
+	got := f.FilterAttributes(nil, 5)
+	if got.Attributes["short"] != "abc" {
+		t.Errorf("value within the limit should be untouched, got %q", got.Attributes["short"])
+	}
+	if want := "abcde" + windowEllipsis; got.Attributes["long"] != want {
+		t.Errorf("long value: got %q want %q", got.Attributes["long"], want)
+	}
+}
+
+func TestFilterAttributesMaxLenCountsRunes(t *testing.T) {
+	f := Finding{Attributes: map[string]string{"multi": "日本語テスト"}} // 6 runes, 18 bytes
+	got := f.FilterAttributes(nil, 3)
+	if want := "日本語" + windowEllipsis; got.Attributes["multi"] != want {
+		t.Errorf("rune-aware truncation: got %q want %q", got.Attributes["multi"], want)
+	}
+}
+
+func TestFilterAttributesNoAttributes(t *testing.T) {
+	f := Finding{}
+	got := f.FilterAttributes(map[string]struct{}{"x": {}}, 5)
+	if got.Attributes != nil {
+		t.Errorf("expected nil attributes, got %v", got.Attributes)
+	}
+}

--- a/report/finding.go
+++ b/report/finding.go
@@ -214,6 +214,32 @@ func (f Finding) Print(noColor bool, redact uint) {
 	f.printPretty(noColor, redact)
 }
 
+// FilterAttributes returns a copy of the finding whose Attributes have been
+// reduced for verbose display: keys present in exclude are dropped, and when
+// maxLen > 0 each remaining value is truncated to maxLen runes with a trailing
+// ellipsis. The receiver and its underlying Attributes map are left untouched,
+// so report output is unaffected. The finding is returned unchanged when there
+// is nothing to do.
+func (f Finding) FilterAttributes(exclude map[string]struct{}, maxLen int) Finding {
+	if len(f.Attributes) == 0 || (len(exclude) == 0 && maxLen <= 0) {
+		return f
+	}
+	filtered := make(map[string]string, len(f.Attributes))
+	for k, v := range f.Attributes {
+		if _, skip := exclude[k]; skip {
+			continue
+		}
+		if maxLen > 0 {
+			if t, truncated := truncateRunes(v, maxLen); truncated {
+				v = t + windowEllipsis
+			}
+		}
+		filtered[k] = v
+	}
+	f.Attributes = filtered
+	return f
+}
+
 // locateMatch returns the byte index of match within rawLine, using startCol
 // (1-indexed byte offset) to disambiguate duplicate occurrences. When the
 // exact position doesn't match, it searches forward then backward from the


### PR DESCRIPTION
Verbose output prints every attribute at full length, which gets noisy when attributes hold long values (paths, commit messages) or ones you don't care about.

Adds two flags:

- `--exclude-attributes` — attribute keys to omit from verbose output
- `--max-attribute-length` — truncate attribute values to N characters

Filtering happens on a copy of the finding inside a new `Detector.PrintFinding` helper, so findings written to reports (json/sarif/csv/…) keep their full attribute set — only the verbose console output is trimmed. While I was in there I collapsed the duplicated legacy-vs-pretty print branches in the dir/git/github/gitlab/huggingface/s3 commands into that one helper.

Verified in both pretty and legacy output, and confirmed JSON reports are unchanged. Added tests for the attribute filtering.

Closes #151
