### PR TITLE
Log why a finding is dropped by a filter at trace level

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -826,6 +826,10 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			if err != nil {
 				logger.Warn().Err(err).Msg("global filter eval error")
 			} else if skip {
+				logger.Trace().
+					Str("finding", finding.Secret).
+					Float64("entropy", entropy).
+					Msg("skipping finding: dropped by the global [extend] filter/allowlist")
 				continue
 			}
 		}
@@ -836,6 +840,10 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			if err != nil {
 				logger.Warn().Err(err).Msg("rule filter eval error")
 			} else if skip {
+				logger.Trace().
+					Str("finding", finding.Secret).
+					Float64("entropy", entropy).
+					Msg("skipping finding: dropped by the rule filter (entropy threshold, allowlist, or token efficiency)")
 				continue
 			}
 		}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -827,7 +827,6 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 				logger.Warn().Err(err).Msg("global filter eval error")
 			} else if skip {
 				logger.Trace().
-					Str("finding", finding.Secret).
 					Float64("entropy", entropy).
 					Msg("skipping finding: dropped by the global [extend] filter/allowlist")
 				continue
@@ -841,7 +840,6 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 				logger.Warn().Err(err).Msg("rule filter eval error")
 			} else if skip {
 				logger.Trace().
-					Str("finding", finding.Secret).
 					Float64("entropy", entropy).
 					Msg("skipping finding: dropped by the rule filter (entropy threshold, allowlist, or token efficiency)")
 				continue

--- a/detect/filter_trace_test.go
+++ b/detect/filter_trace_test.go
@@ -1,0 +1,38 @@
+package detect
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/betterleaks/betterleaks/logging"
+)
+
+// TestRuleFilterSkipEmitsTrace verifies that when a candidate matches a rule's
+// regex but is then dropped by the rule's filter, a trace-level log explains
+// the reason instead of the finding silently disappearing (issue #162).
+func TestRuleFilterSkipEmitsTrace(t *testing.T) {
+	d, err := NewDetectorDefaultConfig()
+	if err != nil {
+		t.Fatalf("NewDetectorDefaultConfig: %v", err)
+	}
+
+	var buf bytes.Buffer
+	orig := logging.Logger
+	logging.Logger = zerolog.New(&buf).Level(zerolog.TraceLevel)
+	t.Cleanup(func() { logging.Logger = orig })
+
+	// "ghp_" + 36 chars matches the github-pat regex, but an all-"a" token has
+	// ~0 entropy and is dropped by that rule's `entropy(secret) <= 3.0` filter.
+	token := "ghp_" + strings.Repeat("a", 36)
+	findings := d.DetectString(`token = "` + token + `"`)
+	if len(findings) != 0 {
+		t.Fatalf("expected the low-entropy token to be filtered out, got %d finding(s)", len(findings))
+	}
+
+	if out := buf.String(); !strings.Contains(out, "dropped by the rule filter") {
+		t.Fatalf("expected a trace log explaining the rule-filter skip, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
When a candidate matched a rule's regex but was then dropped by the global or rule filter (entropy threshold, allowlist, or token efficiency) it just disappeared — `-l trace` gave no hint as to why, which makes tuning rules frustrating.

This emits a trace log at each filter skip point that names which filter dropped the finding and includes the computed entropy, so `-l trace` actually explains the outcome. For example:

    TRC skipping finding: dropped by the rule filter (entropy threshold, allowlist, or token efficiency) entropy=0.66 rule_id=github-pat

Added a test.

Closes #162
