### PR TITLE
Fix nil-pointer panic when a symlink target can't be stat'd

### DIFF
--- a/sources/files.go
+++ b/sources/files.go
@@ -82,7 +82,12 @@ func (s *Files) scanTargets(ctx context.Context, yield func(ScanTarget, error) e
 				logger.Error().Err(err).Msg("skipping symlink: could not evaluate")
 				return nil
 			}
-			if realPathFileInfo, _ := os.Stat(realPath); realPathFileInfo.IsDir() {
+			realPathFileInfo, err := os.Stat(realPath)
+			if err != nil {
+				logger.Error().Err(err).Str("target", realPath).Msg("skipping symlink: could not stat target")
+				return nil
+			}
+			if realPathFileInfo.IsDir() {
 				logger.Debug().Str("target", realPath).Msgf("skipping symlink: target is directory")
 				return nil
 			}


### PR DESCRIPTION
When scanning with `--follow-symlinks`, the symlink branch discarded the `os.Stat` error and immediately called `realPathFileInfo.IsDir()`. If `Stat` fails — the target is removed between `EvalSymlinks` and `Stat`, permission is denied, or it's a special file — `realPathFileInfo` is nil and the directory walk panics, aborting the whole scan.

Handle the error and skip the symlink instead.
