### PR TITLE
Report a clean error for an unknown --regex-engine instead of panicking

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -157,7 +157,7 @@ func initLog() {
 	case "stdlib":
 		regexp.SetEngine(regexp.Stdlib{})
 	default:
-		panic("regexp: unknown engine: " + engineName)
+		logging.Fatal().Msgf("unknown regex engine %q (valid values: re2, stdlib)", engineName)
 	}
 }
 


### PR DESCRIPTION
Passing an unrecognized `--regex-engine` (e.g. `--regex-engine=bogus`) hit a `default:` panic in `initLog`, printing a Go stack trace and exiting 2.

Use `logging.Fatal` for a clear single-line error that lists the valid values, matching how other invalid flag values are reported in this file.

Before:

    panic: regexp: unknown engine: bogus
    goroutine 1 [running]: ...

After:

    FTL unknown regex engine "bogus" (valid values: re2, stdlib)
