### PR TITLE
fix(detect): log filter-skipped findings

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -820,6 +820,9 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			if err != nil {
 				logger.Warn().Err(err).Msg("global filter eval error")
 			} else if skip {
+				logger.Trace().
+					Str("finding", finding.Secret).
+					Msg("skipping finding: global filter")
 				continue
 			}
 		}
@@ -830,6 +833,9 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			if err != nil {
 				logger.Warn().Err(err).Msg("rule filter eval error")
 			} else if skip {
+				logger.Trace().
+					Str("finding", finding.Secret).
+					Msg("skipping finding: rule filter")
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary

Adds trace-level logging when a candidate finding is suppressed by a global or rule-level CEL filter.

Previously, candidates skipped by translated allowlists, entropy checks, token-efficiency checks, or other CEL filters disappeared without indicating why. This made debugging custom rules difficult even with `--log-level trace`.

The new messages follow the existing skip-log format:

- `skipping finding: global filter`
- `skipping finding: rule filter`

Logs include the existing source metadata, `rule_id`, and candidate finding context.

Fixes #162