### PR TITLE
perf(git): strided work-stealing batches for parallel git workers

### DIFF
--- a/sources/parallel_git.go
+++ b/sources/parallel_git.go
@@ -17,11 +17,12 @@ import (
 	"github.com/betterleaks/betterleaks/sources/scm"
 )
 
-// ParallelGit scans a git repo by running multiple `git log -p` processes
-// in parallel, each covering a distinct set of commits. Commit SHAs are
-// enumerated once via `git rev-list` and then partitioned across workers,
-// guaranteeing deterministic, non-overlapping coverage regardless of
-// timestamp ties in the commit graph.
+// ParallelGit scans a git repo with a fixed pool of git log -p worker
+// processes. Commit SHAs are enumerated once via git rev-list, split into many
+// small batches, and drained from a shared queue by the workers. Every commit
+// belongs to exactly one batch and every batch runs on exactly one worker, so
+// coverage is complete and non-overlapping. Findings are independent of scan
+// order, so it does not matter which worker runs a given batch.
 type ParallelGit struct {
 	RepoPath        string
 	ShouldSkip      SkipFunc
@@ -40,12 +41,22 @@ func (s *ParallelGit) workers() int {
 	return min(runtime.NumCPU(), 4)
 }
 
-// Fragments implements Source by partitioning commits across
-// multiple parallel git log workers.
+// Fragments implements Source. It scans the repo's commits with a fixed pool
+// of concurrent git log workers; the first worker to error cancels the others
+// and that error is returned. It falls back to a single git log process when
+// commit enumeration fails or when only one worker would run, matching a
+// non-parallel scan.
 func (s *ParallelGit) Fragments(ctx context.Context, yield FragmentsFunc) error {
 	commits, err := listCommits(ctx, s.RepoPath, s.LogOpts)
 	if err != nil {
-		return fmt.Errorf("list commits: %w", err)
+		// Some --log-opts are valid for `git log` but not `git rev-list`
+		// (e.g. `-n 5` with no ref). Fall back to a single `git log -p`
+		// process, which preserves the exact non-partitioned behavior.
+		// A genuinely broken repo or bad revision still surfaces an error
+		// through the fallback's own git log; Warn makes the loss of
+		// parallelism visible at default verbosity.
+		logging.Warn().Err(err).Msg("git rev-list failed; falling back to a single git log process (no parallelism)")
+		return s.runSingleWorker(ctx, yield)
 	}
 
 	count := len(commits)
@@ -57,32 +68,56 @@ func (s *ParallelGit) Fragments(ctx context.Context, yield FragmentsFunc) error 
 		workers = count
 	}
 
-	// For very small repos, just run a single worker (no overhead)
+	// One effective worker (single CPU, Workers=1, or a one-commit repo) has
+	// nothing to parallelize; skip the batching machinery.
 	if workers <= 1 {
 		return s.runSingleWorker(ctx, yield)
 	}
 
-	chunkSize := (count + workers - 1) / workers
-	logging.Info().Int("commits", count).Int("workers", workers).Int("chunk_size", chunkSize).Msg("parallel git scan")
+	// Commit diff sizes are heavy-tailed, and heavy commits cluster in
+	// contiguous stretches of history (e.g. vendored-dependency churn), so a
+	// contiguous partition landing on a cluster straggles while other workers
+	// idle. Two mitigations compose: batches stride across all of history
+	// (batch b holds commits b, b+numBatches, b+2*numBatches, ...) so each
+	// samples heavy regions evenly, and workers pull from a shared queue so
+	// residual imbalance self-corrects. Aim for about 8 batches per worker:
+	// enough to smooth the tail through stealing, few enough to amortize git
+	// process startup, with a 64-commit floor so small repos do not spawn a
+	// process per handful of commits.
+	batchSize := max(count/(workers*8), 64)
+	numBatches := (count + batchSize - 1) / batchSize
+	logging.Info().Int("commits", count).Int("workers", workers).Int("batch_size", batchSize).Int("batches", numBatches).Msg("parallel git scan")
+
+	batches := make(chan []string, numBatches)
+	for b := range numBatches {
+		batch := make([]string, 0, batchSize)
+		for i := b; i < count; i += numBatches {
+			batch = append(batch, commits[i])
+		}
+		batches <- batch
+	}
+	close(batches)
 
 	g, gctx := errgroup.WithContext(ctx)
-	for i := range workers {
-		start := i * chunkSize
-		if start >= count {
-			break
-		}
-		end := min(start+chunkSize, count)
-		chunk := commits[start:end]
+	for range workers {
 		g.Go(func() error {
-			return s.runWorkerCommits(gctx, yield, chunk)
+			for batch := range batches {
+				if err := gctx.Err(); err != nil {
+					return err
+				}
+				if err := s.runWorkerCommits(gctx, yield, batch); err != nil {
+					return err
+				}
+			}
+			return nil
 		})
 	}
 
 	return g.Wait()
 }
 
-// runSingleWorker runs a full git log (no partitioning) for small repos or
-// single-worker mode.
+// runSingleWorker runs one full, unpartitioned git log, used for the
+// enumeration-failure fallback and when only one worker would run.
 func (s *ParallelGit) runSingleWorker(ctx context.Context, yield FragmentsFunc) error {
 	gitCmd, err := newGitLogCmd(ctx, s.RepoPath, s.LogOpts)
 	if err != nil {
@@ -226,10 +261,10 @@ func startGitLogCmd(ctx context.Context, repoPath string, args []string) (*GitCm
 	}, nil
 }
 
-// listCommits returns all commit SHAs matching the given log options.
-// The order is deterministic for a given repo state (reverse chronological
-// from a single rev-list invocation), which is critical for correct
-// partitioning across workers.
+// listCommits returns the commit SHAs matching logOpts from a single git
+// rev-list invocation. When batched across workers, Fragments scans every
+// returned SHA exactly once, so coverage depends only on the set being
+// complete, not on its order.
 func listCommits(ctx context.Context, source string, logOpts string) ([]string, error) {
 	sourceClean := filepath.Clean(source)
 	args := []string{"-C", sourceClean, "rev-list"}


### PR DESCRIPTION
### What we doing?

This speeds up Git history scans when using `--git-workers`.

On `gitlab-foss` (197k commits), a full scan drops from **8.5 minutes to 1 minute** with `--git-workers 32`, an **8.2x speedup**. Findings are byte-for-byte identical, and the default single-process path is unchanged.

| Repo | Commits | Before | After |
|------|---------:|-------:|------:|
| gitleaks | 1,303 | 0.46s | 0.54s |
| betterleaks | 394 | 1.90s | 1.55s |
| trufflehog | 5,570 | 1.52s | 1.72s |
| prometheus | 20,277 | 2.91s | 2.67s |
| gitlab-foss | 197,166 | 506.6s | 61.9s |

Benchmarks were run with `--git-workers 32` on a 32-core machine using native RE2. Findings digests matched before and after on every repository.

### Why do we care?

Previously, commits were split into one contiguous chunk per worker. That assumes each slice has roughly equal scan cost, but real histories often violate that. Large imports, rewrites, vendored drops, generated files, and other expensive commits tend to cluster, leaving one worker with most of the work while the others finish early.

I'm sure I could come back and put some hard numbers behind this. For now, though, I'm trusting my gut. Future me can complain about it in review.

This change breaks the history into many smaller batches spread across the commit range. Workers pull batches from a shared queue as they finish, keeping all cores busy without changing scan results. Happy cores, happy life :)

On `gitlab-foss`, the largest unit of work drops from roughly 36% of the scan to about 4%. Effective parallelism increases from about 2.8x to 26x, producing the 8.2x wall-clock speedup.

### Cool, what are the downsides?

Smaller batches mean more Git subprocesses. On large repositories, better load balancing easily outweighs that overhead. On small repositories, where work is already balanced, the extra subprocesses can make scans a few tenths of a second slower.

That's why this remains behind the opt-in `--git-workers` flag. If it were up to me, this would've been on by default. Good thing it wasn't.

### What's next?

Batch size is currently fixed at about eight batches per worker. Exposing it as a tuning flag could help users optimize for different workloads. I'll leave that decision to the aforementioned smarter people in charge of these things.

One limit remains: a single huge commit can't be split across workers, so eventually it becomes the bottleneck.

### Did this break things? (i hope not)

- Findings are byte-for-byte identical across all repositories tested.
- This only changes scheduling, not scan behavior.
- The default single-process path is unchanged. Only `--git-workers N` (`N > 0`) is affected.