### PR TITLE
validation check for existing gcp-api-key rule, create new gemini rules

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -209,6 +209,7 @@ func main() {
 		rules.GCPApplicationDefaultCredentials(),
 		rules.GCPServiceAccount(),
 		rules.GCPAPIKey(),
+		rules.GCPGeminiAPIKey(),
 		rules.GiteaAccessToken(),
 		rules.GitHubPat(),
 		rules.GitHubFineGrainedPat(),

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -11,7 +11,9 @@ const gcpAPIKeyValidationExpr = `let k = http.get("https://www.googleapis.com/id
     "result": "invalid",
     "reason": "Unauthorized"
   } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
-    "result": "valid"
+    "result": "valid",
+    "active_google_key": true,
+    "gemini_access": true
   } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
     "result": "needs_validation",
     "reason": "Active Google API key blocked by HTTP referrer restriction",
@@ -38,7 +40,7 @@ const gcpAPIKeyValidationExpr = `let k = http.get("https://www.googleapis.com/id
     "restriction": "android_app"
   } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key blocked from Gemini API",
     "active_google_key": true,
     "gemini_access": false
   } : r.status == 403 ? {
@@ -48,9 +50,12 @@ const gcpAPIKeyValidationExpr = `let k = http.get("https://www.googleapis.com/id
     "gemini_access": "unknown"
   } : r.status == 400 && k.status in [200, 403] ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key not accepted by Gemini API",
     "active_google_key": true,
     "gemini_access": false
+  } : r.status == 400 && (r.body contains "API_KEY_INVALID") ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
   } : r.status == 400 ? {
     "result": "invalid",
     "reason": "Unauthorized"

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -68,7 +68,18 @@ func GCPAPIKey() *config.Rule {
 		Description: "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches.",
 		Regex:       utils.GenerateUniqueTokenRegex(`AIza[\w-]{35}`, false),
 		Keywords:    []string{"AIza"},
-		Filter:      "entropy(finding[\"secret\"]) <= 4.0\n|| matchesAny(finding[\"secret\"], [\n  `AIzaSyabcdefghijklmnopqrstuvwxyz1234567`,\n  `AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`,\n  `AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`,\n  `AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`,\n  `AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`,\n  `AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`,\n  `AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`,\n  `AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`,\n  `AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`,\n  `AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`,\n  `AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`,\n  `AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`,\n  `AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`,\n  `AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,\n  `AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,\n  `AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`\n])",
+		ValidateExpr: `let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+    "result": "valid"
+  } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)`,
+		Filter: "entropy(finding[\"secret\"]) <= 4.0\n|| matchesAny(finding[\"secret\"], [\n  `AIzaSyabcdefghijklmnopqrstuvwxyz1234567`,\n  `AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`,\n  `AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`,\n  `AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`,\n  `AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`,\n  `AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`,\n  `AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`,\n  `AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`,\n  `AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`,\n  `AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`,\n  `AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`,\n  `AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`,\n  `AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`,\n  `AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,\n  `AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,\n  `AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`\n])",
 	}
 
 	// validate
@@ -99,6 +110,36 @@ func GCPAPIKey() *config.Rule {
 		`AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,
 		`AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,
 		`AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`,
+	}
+	return utils.Validate(r, tps, fps)
+}
+
+func GCPGeminiAPIKey() *config.Rule {
+	r := config.Rule{
+		RuleID:      "gcp-gemini-api",
+		Description: "Detected a Google Gemini API key, which may expose Gemini model access and usage to unauthorized parties.",
+		Regex:       utils.GenerateUniqueTokenRegex(`AQ\.Ab8RN6[A-Za-z0-9_-]{44}`, false),
+		Keywords:    []string{"AQ.Ab8RN6"},
+		ValidateExpr: `let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+    "result": "valid"
+  } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)`,
+		Filter: `entropy(finding["secret"]) <= 4.0`,
+	}
+
+	tps := utils.GenerateSampleSecrets("gemini", "AQ.Ab8RN6"+secrets.NewSecretWithEntropy(`[A-Za-z0-9_-]{44}`, 4))
+	fps := []string{
+		// Wrong prefix.
+		`gemini_api_key = "AQ.Ab8RN5AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-AB"`,
+		// Too short.
+		`gemini_api_key = "AQ.Ab8RN6AbCdEfGhIjKlMnOpQrStUvWxYz0123456789_-"`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/gcp.go
+++ b/cmd/generate/config/rules/gcp.go
@@ -7,6 +7,55 @@ import (
 	"github.com/betterleaks/betterleaks/regexp"
 )
 
+const gcpAPIKeyValidationExpr = `let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/getProjectConfig?key=" + finding["secret"], {}); k.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+    "result": "valid"
+  } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by HTTP referrer restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "http_referrer"
+  } : r.status == 403 && (r.body contains "API_KEY_IP_ADDRESS_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by IP address restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ip_address"
+  } : r.status == 403 && (r.body contains "API_KEY_IOS_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by iOS app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ios_app"
+  } : r.status == 403 && (r.body contains "API_KEY_ANDROID_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by Android app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "android_app"
+  } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key with unknown Gemini access",
+    "active_google_key": true,
+    "gemini_access": "unknown"
+  } : r.status == 400 && k.status in [200, 403] ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r))`
+
 func GCPApplicationDefaultCredentials() *config.Rule {
 	r := config.Rule{
 		Description: "Google (GCP) Application Default Credentials",
@@ -64,22 +113,12 @@ func GCPServiceAccount() *config.Rule {
 func GCPAPIKey() *config.Rule {
 	// define rule
 	r := config.Rule{
-		RuleID:      "gcp-api-key",
-		Description: "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches.",
-		Regex:       utils.GenerateUniqueTokenRegex(`AIza[\w-]{35}`, false),
-		Keywords:    []string{"AIza"},
-		ValidateExpr: `let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
-    "result": "valid"
-  } : r.status == 403 ? {
-    "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
-    "active_google_key": true,
-    "gemini_access": false
-  } : r.status == 400 ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : validate.unknown(r)`,
-		Filter: "entropy(finding[\"secret\"]) <= 4.0\n|| matchesAny(finding[\"secret\"], [\n  `AIzaSyabcdefghijklmnopqrstuvwxyz1234567`,\n  `AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`,\n  `AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`,\n  `AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`,\n  `AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`,\n  `AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`,\n  `AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`,\n  `AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`,\n  `AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`,\n  `AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`,\n  `AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`,\n  `AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`,\n  `AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`,\n  `AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,\n  `AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,\n  `AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`\n])",
+		RuleID:       "gcp-api-key",
+		Description:  "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches.",
+		Regex:        utils.GenerateUniqueTokenRegex(`AIza[\w-]{35}`, false),
+		Keywords:     []string{"AIza"},
+		ValidateExpr: gcpAPIKeyValidationExpr,
+		Filter:       "entropy(finding[\"secret\"]) <= 4.0\n|| matchesAny(finding[\"secret\"], [\n  `AIzaSyabcdefghijklmnopqrstuvwxyz1234567`,\n  `AIzaSyAnLA7NfeLquW1tJFpx_eQCxoX-oo6YyIs`,\n  `AIzaSyCkEhVjf3pduRDt6d1yKOMitrUEke8agEM`,\n  `AIzaSyDMAScliyLx7F0NPDEJi1QmyCgHIAODrlU`,\n  `AIzaSyD3asb-2pEZVqMkmL6M9N6nHZRR_znhrh0`,\n  `AIzayDNSXIbFmlXbIE6mCzDLQAqITYefhixbX4A`,\n  `AIzaSyAdOS2zB6NCsk1pCdZ4-P6GBdi_UUPwX7c`,\n  `AIzaSyASWm6HmTMdYWpgMnjRBjxcQ9CKctWmLd4`,\n  `AIzaSyANUvH9H9BsUccjsu2pCmEkOPjjaXeDQgY`,\n  `AIzaSyA5_iVawFQ8ABuTZNUdcwERLJv_a_p4wtM`,\n  `AIzaSyA4UrcGxgwQFTfaI3no3t7Lt1sjmdnP5sQ`,\n  `AIzaSyDSb51JiIcB6OJpwwMicseKRhhrOq1cS7g`,\n  `AIzaSyBF2RrAIm4a0mO64EShQfqfd2AFnzAvvuU`,\n  `AIzaSyBcE-OOIbhjyR83gm4r2MFCu4MJmprNXsw`,\n  `AIzaSyB8qGxt4ec15vitgn44duC5ucxaOi4FmqE`,\n  `AIzaSyA8vmApnrHNFE0bApF4hoZ11srVL_n0nvY`\n])",
 	}
 
 	// validate
@@ -116,22 +155,12 @@ func GCPAPIKey() *config.Rule {
 
 func GCPGeminiAPIKey() *config.Rule {
 	r := config.Rule{
-		RuleID:      "gcp-gemini-api",
-		Description: "Detected a Google Gemini API key, which may expose Gemini model access and usage to unauthorized parties.",
-		Regex:       utils.GenerateUniqueTokenRegex(`AQ\.Ab8RN6[A-Za-z0-9_-]{44}`, false),
-		Keywords:    []string{"AQ.Ab8RN6"},
-		ValidateExpr: `let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
-    "result": "valid"
-  } : r.status == 403 ? {
-    "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
-    "active_google_key": true,
-    "gemini_access": false
-  } : r.status == 400 ? {
-    "result": "invalid",
-    "reason": "Unauthorized"
-  } : validate.unknown(r)`,
-		Filter: `entropy(finding["secret"]) <= 4.0`,
+		RuleID:       "gcp-gemini-api",
+		Description:  "Detected a Google Gemini API key, which may expose Gemini model access and usage to unauthorized parties.",
+		Regex:        utils.GenerateUniqueTokenRegex(`AQ\.Ab8RN6[A-Za-z0-9_-]{44}`, false),
+		Keywords:     []string{"AQ.Ab8RN6"},
+		ValidateExpr: gcpAPIKeyValidationExpr,
+		Filter:       `entropy(finding["secret"]) <= 4.0`,
 	}
 
 	tps := utils.GenerateSampleSecrets("gemini", "AQ.Ab8RN6"+secrets.NewSecretWithEntropy(`[A-Za-z0-9_-]{44}`, 4))

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2305,7 +2305,9 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "result": "invalid",
     "reason": "Unauthorized"
   } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
-    "result": "valid"
+    "result": "valid",
+    "active_google_key": true,
+    "gemini_access": true
   } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
     "result": "needs_validation",
     "reason": "Active Google API key blocked by HTTP referrer restriction",
@@ -2332,7 +2334,7 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "restriction": "android_app"
   } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key blocked from Gemini API",
     "active_google_key": true,
     "gemini_access": false
   } : r.status == 403 ? {
@@ -2342,9 +2344,12 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "gemini_access": "unknown"
   } : r.status == 400 && k.status in [200, 403] ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key not accepted by Gemini API",
     "active_google_key": true,
     "gemini_access": false
+  } : r.status == 400 && (r.body contains "API_KEY_INVALID") ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
   } : r.status == 400 ? {
     "result": "invalid",
     "reason": "Unauthorized"
@@ -2406,7 +2411,9 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "result": "invalid",
     "reason": "Unauthorized"
   } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
-    "result": "valid"
+    "result": "valid",
+    "active_google_key": true,
+    "gemini_access": true
   } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
     "result": "needs_validation",
     "reason": "Active Google API key blocked by HTTP referrer restriction",
@@ -2433,7 +2440,7 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "restriction": "android_app"
   } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key blocked from Gemini API",
     "active_google_key": true,
     "gemini_access": false
   } : r.status == 403 ? {
@@ -2443,9 +2450,12 @@ let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/get
     "gemini_access": "unknown"
   } : r.status == 400 && k.status in [200, 403] ? {
     "result": "needs_validation",
-    "reason": "Active Google API key without Gemini access",
+    "reason": "Active Google API key not accepted by Gemini API",
     "active_google_key": true,
     "gemini_access": false
+  } : r.status == 400 && (r.body contains "API_KEY_INVALID") ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
   } : r.status == 400 ? {
     "result": "invalid",
     "reason": "Unauthorized"

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2300,6 +2300,19 @@ id = "gcp-api-key"
 description = "Uncovered a GCP API key, which could lead to unauthorized access to Google Cloud services and data breaches."
 regex = '''\b(AIza[\w-]{35})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["aiza"]
+validate = '''
+let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+    "result": "valid"
+  } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)
+'''
 filter = '''
 entropy(finding["secret"]) <= 4.0
 || matchesAny(finding["secret"], [
@@ -2341,6 +2354,31 @@ let r = gcp.validate(finding["secret"]); r.status == 200 ? {
     "error_message": r.error_message
   } : validate.unknown(r)
 
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
+# gcp-gemini-api
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "gcp-gemini-api"
+description = "Detected a Google Gemini API key, which may expose Gemini model access and usage to unauthorized parties."
+regex = '''\b(AQ\.Ab8RN6[A-Za-z0-9_-]{44})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+keywords = ["aq.ab8rn6"]
+validate = '''
+let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+    "result": "valid"
+  } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
+  } : r.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)
+'''
+filter = '''
+entropy(finding["secret"]) <= 4.0
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2301,9 +2301,46 @@ description = "Uncovered a GCP API key, which could lead to unauthorized access 
 regex = '''\b(AIza[\w-]{35})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["aiza"]
 validate = '''
-let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/getProjectConfig?key=" + finding["secret"], {}); k.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
     "result": "valid"
+  } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by HTTP referrer restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "http_referrer"
+  } : r.status == 403 && (r.body contains "API_KEY_IP_ADDRESS_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by IP address restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ip_address"
+  } : r.status == 403 && (r.body contains "API_KEY_IOS_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by iOS app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ios_app"
+  } : r.status == 403 && (r.body contains "API_KEY_ANDROID_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by Android app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "android_app"
+  } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
   } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key with unknown Gemini access",
+    "active_google_key": true,
+    "gemini_access": "unknown"
+  } : r.status == 400 && k.status in [200, 403] ? {
     "result": "needs_validation",
     "reason": "Active Google API key without Gemini access",
     "active_google_key": true,
@@ -2311,7 +2348,7 @@ let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" 
   } : r.status == 400 ? {
     "result": "invalid",
     "reason": "Unauthorized"
-  } : validate.unknown(r)
+  } : validate.unknown(r))
 '''
 filter = '''
 entropy(finding["secret"]) <= 4.0
@@ -2365,9 +2402,46 @@ description = "Detected a Google Gemini API key, which may expose Gemini model a
 regex = '''\b(AQ\.Ab8RN6[A-Za-z0-9_-]{44})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["aq.ab8rn6"]
 validate = '''
-let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
+let k = http.get("https://www.googleapis.com/identitytoolkit/v3/relyingparty/getProjectConfig?key=" + finding["secret"], {}); k.status == 400 ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : (let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" + finding["secret"], {}); r.status == 200 && (r.body contains '"models"') ? {
     "result": "valid"
+  } : r.status == 403 && (r.body contains "API_KEY_HTTP_REFERRER_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by HTTP referrer restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "http_referrer"
+  } : r.status == 403 && (r.body contains "API_KEY_IP_ADDRESS_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by IP address restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ip_address"
+  } : r.status == 403 && (r.body contains "API_KEY_IOS_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by iOS app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "ios_app"
+  } : r.status == 403 && (r.body contains "API_KEY_ANDROID_APP_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key blocked by Android app restriction",
+    "active_google_key": true,
+    "gemini_access": "unknown",
+    "restriction": "android_app"
+  } : r.status == 403 && (r.body contains "API_KEY_SERVICE_BLOCKED") ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key without Gemini access",
+    "active_google_key": true,
+    "gemini_access": false
   } : r.status == 403 ? {
+    "result": "needs_validation",
+    "reason": "Active Google API key with unknown Gemini access",
+    "active_google_key": true,
+    "gemini_access": "unknown"
+  } : r.status == 400 && k.status in [200, 403] ? {
     "result": "needs_validation",
     "reason": "Active Google API key without Gemini access",
     "active_google_key": true,
@@ -2375,7 +2449,7 @@ let r = http.get("https://generativelanguage.googleapis.com/v1beta/models?key=" 
   } : r.status == 400 ? {
     "result": "invalid",
     "reason": "Unauthorized"
-  } : validate.unknown(r)
+  } : validate.unknown(r))
 '''
 filter = '''
 entropy(finding["secret"]) <= 4.0


### PR DESCRIPTION
This pull request adds support for detecting and validating Google Gemini API keys and validating existing GCP API keys (originally designed to be public) against the gemini api

relevant https://trufflesecurity.com/blog/google-api-keys-werent-secrets-but-then-gemini-changed-the-rules

---
Conditions:

- **identitytoolkit invalid** -> `invalid`; key is not a valid Google API key.
- **Gemini 200 with models** -> `valid`; active Google key with Gemini access.
- **Gemini API_KEY_SERVICE_BLOCKED** -> `needs_validation`; active Google key, but Gemini is
  blocked.
- **Gemini referrer/IP/iOS/Android restriction** -> `needs_validation`; Gemini access unknown
  because another caller context may work.
- **identitytoolkit active/blocked + Gemini 400/API_KEY_INVALID** -> `needs_validation`;
  active Google key, but Gemini does not accept it and other Google APIs may still work.
- **Other Gemini 403** -> `needs_validation`; active Google key with unknown Gemini access.