### PR TITLE
Fix/exprruntime data race

### DIFF
--- a/internal/exprruntime/bindings_filter.go
+++ b/internal/exprruntime/bindings_filter.go
@@ -119,16 +119,21 @@ func shannonEntropy(s string) float64 {
 var newlineReplacer = strings.NewReplacer("\n", "", "\r", "")
 
 func (rt *runtimeBindings) failsTokenEfficiency(secret string) bool {
-	if rt.tokenizer == nil {
+	// rt is shared across concurrent evals; never write it here. Caching the
+	// resolved tokenizer into rt.tokenizer would be a data race. The provider
+	// memoizes via sync.Once, so re-resolving every eval recomputes nothing
+	// and costs one indirect call.
+	tke := rt.tokenizer
+	if tke == nil {
 		if rt.tokenizerProvider == nil {
 			return false
 		}
-		rt.tokenizer = rt.tokenizerProvider()
-		if rt.tokenizer == nil {
+		tke = rt.tokenizerProvider()
+		if tke == nil {
 			return false
 		}
 	}
-	return failsTokenEfficiency(rt.tokenizer, secret)
+	return failsTokenEfficiency(tke, secret)
 }
 
 func failsTokenEfficiency(tke *tiktoken.Tiktoken, secret string) bool {

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -154,6 +154,14 @@ func (e *Runtime) compile(mode compileMode, expression string, tokenizer *tiktok
 		tokenizerProvider: e.tokenizerProvider,
 		bindings:          programBindings(mode, b),
 	}
+	// The failsTokenEfficiency and filter-namespace closures capture this
+	// *runtimeBindings; concurrent evals then read its tokenizer fields
+	// without synchronization. Resolve them now, before the program is
+	// cached and shared, because any write once evals begin is a data race.
+	if rt, ok := prg.bindings["__runtime"].(*runtimeBindings); ok {
+		rt.tokenizer = tokenizer
+		rt.tokenizerProvider = e.tokenizerProvider
+	}
 
 	e.mu.Lock()
 	e.cache[cacheKey] = prg
@@ -208,17 +216,12 @@ func (e *Runtime) EvalPrefilter(prg Program, attributes map[string]string) (bool
 
 func (prg Program) evalBindings() bindings {
 	if prg.bindings != nil {
-		b := cloneBindings(prg.bindings)
-		if rt, ok := b["__runtime"].(*runtimeBindings); ok {
-			rtCopy := *rt
-			rt = &rtCopy
-			rt.tokenizer = prg.tokenizer
-			rt.tokenizerProvider = prg.tokenizerProvider
-			b["__runtime"] = rt
-			b["filter"] = filterNamespace(rt)
-			b["failsTokenEfficiency"] = rt.failsTokenEfficiency
-		}
-		return b
+		// cloneBindings is shallow: the returned map is per-eval, but its
+		// __runtime entry still aliases the program's shared
+		// *runtimeBindings. Concurrent evals share that struct, so no eval
+		// may write through __runtime; compile time already resolved its
+		// tokenizer fields.
+		return cloneBindings(prg.bindings)
 	}
 	return bindings{}
 }

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -29,11 +29,9 @@ const (
 )
 
 type compiledProgram struct {
-	vm                *vm.Program
-	mode              compileMode
-	tokenizer         *tiktoken.Tiktoken
-	tokenizerProvider func() *tiktoken.Tiktoken
-	bindings          bindings
+	vm       *vm.Program
+	mode     compileMode
+	bindings bindings
 }
 
 var emptyStringMap = map[string]string{}
@@ -148,11 +146,9 @@ func (e *Runtime) compile(mode compileMode, expression string, tokenizer *tiktok
 		return nil, fmt.Errorf("%s expr compile error: %w", mode, err)
 	}
 	prg := &compiledProgram{
-		vm:                vmPrg,
-		mode:              mode,
-		tokenizer:         tokenizer,
-		tokenizerProvider: e.tokenizerProvider,
-		bindings:          programBindings(mode, b),
+		vm:       vmPrg,
+		mode:     mode,
+		bindings: programBindings(mode, b),
 	}
 	// The failsTokenEfficiency and filter-namespace closures capture this
 	// *runtimeBindings; concurrent evals then read its tokenizer fields

--- a/internal/exprruntime/runtime_race_test.go
+++ b/internal/exprruntime/runtime_race_test.go
@@ -1,0 +1,112 @@
+package exprruntime
+
+import (
+	"sync"
+	"testing"
+
+	tiktoken "github.com/pkoukk/tiktoken-go"
+)
+
+// The Runtime caches compiled filter/prefilter programs and shares each
+// Program across scan workers, so EvalFilter and EvalPrefilter run
+// concurrently on one Program value. These tests reproduce that access
+// pattern. They fail under -race if any eval writes the shared
+// *runtimeBindings, and fail functionally if a racing write leaves the
+// tokenizer unresolved, which flips failsTokenEfficiency verdicts and makes
+// findings nondeterministic.
+
+func testTokenizer(t *testing.T) *tiktoken.Tiktoken {
+	t.Helper()
+	tke, err := tiktoken.GetEncoding("cl100k_base")
+	if err != nil {
+		t.Skipf("tokenizer unavailable: %v", err)
+	}
+	return tke
+}
+
+func TestEvalFilterConcurrentSharedProgram(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tke := testTokenizer(t)
+
+	// Lazy provider mirrors Detector.Tokenizer: rule filters compile with a
+	// nil tokenizer and resolve it through the provider at eval time.
+	rt.SetTokenizerProvider(func() *tiktoken.Tiktoken { return tke })
+
+	prg, err := rt.CompileFilter(`filter.failsTokenEfficiency(finding["secret"])`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// cl100k_base encodes "sk-test" to 2 tokens over 7 characters; the 3.5
+	// ratio clears the token-efficiency threshold, so failsTokenEfficiency
+	// returns true under every interleaving. A false result then signals a
+	// race, not a borderline input.
+	finding := map[string]string{"secret": "sk-test"}
+
+	const workers = 32
+	const evals = 200
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < evals; i++ {
+				got, err := rt.EvalFilter(prg, finding, nil)
+				if err != nil {
+					t.Errorf("EvalFilter: %v", err)
+					return
+				}
+				if !got {
+					// The verdict is deterministically true; a false result
+					// means a concurrent write left the shared tokenizer
+					// unresolved, forcing failsTokenEfficiency to return false.
+					t.Error("EvalFilter verdict flipped under concurrency")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestEvalPrefilterConcurrentSharedProgram(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prg, err := rt.CompilePrefilter(`matchesAny(get(attributes, "path", ""), ["\\.png$"])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const workers = 32
+	const evals = 500
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			attrs := map[string]string{"path": "img/logo.png"}
+			if w%2 == 1 {
+				attrs["path"] = "src/main.go"
+			}
+			want := w%2 == 0
+			for i := 0; i < evals; i++ {
+				got, err := rt.EvalPrefilter(prg, attrs)
+				if err != nil {
+					t.Errorf("EvalPrefilter: %v", err)
+					return
+				}
+				if got != want {
+					t.Errorf("EvalPrefilter = %v, want %v", got, want)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Filter expressions are compiled once and shared across worker threads. The problem was that each evaluation still wrote shared state back to the compiled program, creating a race that could cause the token-efficiency filter to be skipped. As a result, the same file _could_ produce different results across runs.

This moves that setup to compile time, before the program is shared, so evaluation is read-only and safe to run concurrently. Filter behavior is unchanged, just deterministic. Regression tests exercise a single shared program from many goroutines and reproduce the race on the old code while passing on the fix.

When run with `go test -race`
```
--- FAIL: TestEvalFilterConcurrentSharedProgram (0.70s)
--- FAIL: TestEvalPrefilterConcurrentSharedProgram (0.99s)
WARNING: DATA RACE  (x14)  →  concurrent writes to the shared rt.tokenizer
FAIL	github.com/betterleaks/betterleaks/internal/exprruntime
```

EDIT: Looks like Zach got to this before me :)

Both fixes address the race. The approach in #231 creates fresh runtime bindings on each evaluation, while this one resolves the tokenizer at compile time and keeps evaluation read-only, avoiding the ~3 extra allocations per evaluation.