### PR TITLE
fix(exprruntime): data race evaluating a cached Program concurrently

### DIFF
--- a/internal/exprruntime/bindings_filter.go
+++ b/internal/exprruntime/bindings_filter.go
@@ -119,16 +119,21 @@ func shannonEntropy(s string) float64 {
 var newlineReplacer = strings.NewReplacer("\n", "", "\r", "")
 
 func (rt *runtimeBindings) failsTokenEfficiency(secret string) bool {
-	if rt.tokenizer == nil {
+	// rt is shared across concurrent evaluations of a cached program, so it must
+	// not be mutated here. Resolve the tokenizer into a local; the provider
+	// (Detector.Tokenizer) is already memoized via sync.Once, so re-resolving is
+	// cheap and there is no need to cache it back onto rt.
+	tke := rt.tokenizer
+	if tke == nil {
 		if rt.tokenizerProvider == nil {
 			return false
 		}
-		rt.tokenizer = rt.tokenizerProvider()
-		if rt.tokenizer == nil {
+		tke = rt.tokenizerProvider()
+		if tke == nil {
 			return false
 		}
 	}
-	return failsTokenEfficiency(rt.tokenizer, secret)
+	return failsTokenEfficiency(tke, secret)
 }
 
 func failsTokenEfficiency(tke *tiktoken.Tiktoken, secret string) bool {

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -154,6 +154,15 @@ func (e *Runtime) compile(mode compileMode, expression string, tokenizer *tiktok
 		tokenizerProvider: e.tokenizerProvider,
 		bindings:          programBindings(mode, b),
 	}
+	// Filter/prefilter programs are cached and evaluated concurrently, so their
+	// bindings (including the shared *runtimeBindings) must be immutable after
+	// compile. The tokenizer and provider are program-constant, so bake them in
+	// here — once, on the compiling goroutine, before the program is shared —
+	// rather than writing them on every Eval (which raced). See evalBindings.
+	if rt, ok := prg.bindings["__runtime"].(*runtimeBindings); ok {
+		rt.tokenizer = prg.tokenizer
+		rt.tokenizerProvider = prg.tokenizerProvider
+	}
 
 	e.mu.Lock()
 	e.cache[cacheKey] = prg
@@ -206,14 +215,14 @@ func (e *Runtime) EvalPrefilter(prg Program, attributes map[string]string) (bool
 	return runBool(prg, b, "prefilter")
 }
 
+// evalBindings returns a per-eval shallow copy of the program's bindings. The
+// map is cloned so callers can layer dynamic values (finding, attributes)
+// without racing, while the shared function bindings — including the immutable
+// *runtimeBindings whose tokenizer/provider were fixed at compile time — are
+// safe to share by pointer across concurrent evaluations.
 func (prg Program) evalBindings() bindings {
 	if prg.bindings != nil {
-		b := cloneBindings(prg.bindings)
-		if rt, ok := b["__runtime"].(*runtimeBindings); ok {
-			rt.tokenizer = prg.tokenizer
-			rt.tokenizerProvider = prg.tokenizerProvider
-		}
-		return b
+		return cloneBindings(prg.bindings)
 	}
 	return bindings{}
 }

--- a/internal/exprruntime/runtime_race_test.go
+++ b/internal/exprruntime/runtime_race_test.go
@@ -1,0 +1,64 @@
+package exprruntime
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestEvalFilter_ConcurrentSameProgram guards against the data race where a
+// single cached filter Program, evaluated concurrently, mutates the shared
+// *runtimeBindings stored in its bindings map. Run with -race.
+func TestEvalFilter_ConcurrentSameProgram(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	prg, err := rt.CompileFilter(`entropy(finding["secret"]) >= 0.0 && !failsTokenEfficiency(finding["secret"])`, nil)
+	if err != nil {
+		t.Fatalf("CompileFilter: %v", err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if _, err := rt.EvalFilter(prg, map[string]string{"secret": "value"}, nil); err != nil {
+					t.Errorf("EvalFilter: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestEvalPrefilter_ConcurrentSameProgram is the prefilter analogue.
+func TestEvalPrefilter_ConcurrentSameProgram(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	prg, err := rt.CompilePrefilter(`entropy(get(attributes, "path", "")) >= 0.0`)
+	if err != nil {
+		t.Fatalf("CompilePrefilter: %v", err)
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				if _, err := rt.EvalPrefilter(prg, map[string]string{"path": "x"}); err != nil {
+					t.Errorf("EvalPrefilter: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

Fixes #224 — a data race in `internal/exprruntime` when the same cached filter/prefilter `Program` is evaluated concurrently, which is the normal shape for `detect.Detector.Run`/`DetectSource` (one goroutine per file).

## Root cause

A cached filter/prefilter `Program` stores a single shared `*runtimeBindings` (the `__runtime` entry) in its bindings map. `evalBindings` shallow-clones that map but not the pointer, so every concurrent `Eval` mutated shared state:

- `evalBindings` wrote `rt.tokenizer` / `rt.tokenizerProvider` on each call (`runtime.go`, the line reported in #224)
- `failsTokenEfficiency` lazily wrote `rt.tokenizer = rt.tokenizerProvider()`

## Fix

Both values are **program-constant** (the filter cache key already includes the tokenizer pointer), so:

- Bake `tokenizer`/`tokenizerProvider` into the shared bindings **once at compile time** — on the compiling goroutine, before the `Program` is shared — and make `evalBindings` a pure clone with no mutation.
- `failsTokenEfficiency` resolves the tokenizer into a **local** instead of caching it back onto `rt`. No extra cost: the provider (`Detector.Tokenizer`) is already memoized via `sync.Once`.

No behavior change — the reads observe the same program-constant values they did before, just without the concurrent writes.

## Testing

- New `-race` regression test evaluates one cached filter/prefilter `Program` from 50 goroutines (fails on `main`, passes with this change).
- `go test -race ./internal/exprruntime/ ./detect/` — ok (`detect` exercises the real per-file fan-out).
- `go test -race ./...` — clean, no regressions.
