### PR TITLE
fix(detect): composite findings across depths

### DIFF
--- a/detect/composite_encoded_test.go
+++ b/detect/composite_encoded_test.go
@@ -1,0 +1,228 @@
+package detect
+
+import (
+	"testing"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/report"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+// compositeTestConfig defines a composite rule "foo" that requires "bar".
+const compositeTestConfig = `
+[[rules]]
+id = "bar"
+description = "bar dependency"
+regex = '''bar-[a-z0-9]{8}'''
+keywords = ["bar-"]
+
+[[rules]]
+id = "foo"
+description = "foo composite"
+regex = '''foo-[a-z0-9]{8}'''
+keywords = ["foo-"]
+[[rules.required]]
+id = "bar"
+`
+
+// TestCompositeEncodedDependency verifies that a composite rule is reported when
+// its primary and its required dependency surface at different decode depths.
+// This is a regression test for composite rules being dropped when the
+// dependency (or primary) only appears in encoded form — the failure mode that
+// made slack-session-token (requires slack-session-cookie) invisible whenever
+// the cookie was URL/base64-encoded.
+func TestCompositeEncodedDependency(t *testing.T) {
+	cfg, err := config.ParseTOMLString(compositeTestConfig, "composite.toml")
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		raw  string
+		// wantFoo asserts the composite "foo" is reported.
+		wantFoo bool
+		// wantComponent asserts the decoded dependency secret attached to "foo".
+		wantComponent string
+	}{
+		{
+			name:          "plaintext dependency (control)",
+			raw:           "token = \"foo-abcd1234\"\ncookie = \"bar-cookie01\"\n",
+			wantFoo:       true,
+			wantComponent: "bar-cookie01",
+		},
+		{
+			// "YmFyLWNvb2tpZTAx" == base64("bar-cookie01")
+			name:          "base64-encoded dependency",
+			raw:           "token = \"foo-abcd1234\"\ncookie = \"YmFyLWNvb2tpZTAx\"\n",
+			wantFoo:       true,
+			wantComponent: "bar-cookie01",
+		},
+		{
+			// "Zm9vLWFiY2QxMjM0" == base64("foo-abcd1234"): the primary is encoded,
+			// the dependency is plaintext (mirror of the above).
+			name:          "base64-encoded primary",
+			raw:           "token = \"Zm9vLWFiY2QxMjM0\"\ncookie = \"bar-cookie01\"\n",
+			wantFoo:       true,
+			wantComponent: "bar-cookie01",
+		},
+		{
+			// "WW1GeUxXTnZiMnRwWlRBeA==" == base64(base64("bar-cookie01")): the
+			// dependency only resolves after two decode passes.
+			name:          "double-base64-encoded dependency",
+			raw:           "token = \"foo-abcd1234\"\ncookie = \"WW1GeUxXTnZiMnRwWlRBeA==\"\n",
+			wantFoo:       true,
+			wantComponent: "bar-cookie01",
+		},
+		{
+			name:    "dependency absent (negative control)",
+			raw:     "token = \"foo-abcd1234\"\ncookie = \"nothing-here-at-all\"\n",
+			wantFoo: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDetector(cfg)
+			d.MaxDecodeDepth = 3
+
+			findings := d.Detect(sources.Fragment{Raw: tt.raw})
+
+			var foo *report.Finding
+			for i := range findings {
+				if findings[i].RuleID == "foo" {
+					foo = &findings[i]
+				}
+			}
+
+			if !tt.wantFoo {
+				if foo != nil {
+					t.Fatalf("expected no composite finding, got: %+v", *foo)
+				}
+				return
+			}
+
+			if foo == nil {
+				t.Fatalf("expected composite rule \"foo\" to be reported; findings: %+v", findings)
+			}
+			if got := componentSecret(foo, "bar"); got != tt.wantComponent {
+				t.Fatalf("expected \"bar\" component secret %q, got %q (finding: %+v)",
+					tt.wantComponent, got, *foo)
+			}
+		})
+	}
+}
+
+// compositeMultiDepConfig defines a composite "foo" that requires BOTH "bar"
+// and "baz".
+const compositeMultiDepConfig = `
+[[rules]]
+id = "bar"
+description = "bar dependency"
+regex = '''bar-[a-z0-9]{8}'''
+keywords = ["bar-"]
+
+[[rules]]
+id = "baz"
+description = "baz dependency"
+regex = '''baz-[a-z0-9]{8}'''
+keywords = ["baz-"]
+
+[[rules]]
+id = "foo"
+description = "foo composite"
+regex = '''foo-[a-z0-9]{8}'''
+keywords = ["foo-"]
+[[rules.required]]
+id = "bar"
+[[rules.required]]
+id = "baz"
+`
+
+// TestCompositeMultipleDependenciesAcrossLayers verifies that a composite rule
+// requiring multiple dependencies is reported when those dependencies surface
+// at different decode depths (e.g. one plaintext, one base64, one double-base64).
+func TestCompositeMultipleDependenciesAcrossLayers(t *testing.T) {
+	cfg, err := config.ParseTOMLString(compositeMultiDepConfig, "composite-multidep.toml")
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantFoo bool
+	}{
+		{
+			name:    "both dependencies plaintext",
+			raw:     "t=\"foo-abcd1234\"\na=\"bar-cookie01\"\nb=\"baz-cookie02\"\n",
+			wantFoo: true,
+		},
+		{
+			// bar plaintext (depth 0), baz base64 (depth 1).
+			name:    "deps split across depth 0 and 1",
+			raw:     "t=\"foo-abcd1234\"\na=\"bar-cookie01\"\nb=\"YmF6LWNvb2tpZTAy\"\n",
+			wantFoo: true,
+		},
+		{
+			// bar base64 (depth 1), baz double-base64 (depth 2): both deps AND the
+			// plaintext primary live at three different layers.
+			name:    "deps split across depth 1 and 2",
+			raw:     "t=\"foo-abcd1234\"\na=\"YmFyLWNvb2tpZTAx\"\nb=\"WW1GNkxXTnZiMnRwWlRBeQ==\"\n",
+			wantFoo: true,
+		},
+		{
+			// Only one of the two required deps is present -> composite must not fire.
+			name:    "one dependency missing",
+			raw:     "t=\"foo-abcd1234\"\na=\"bar-cookie01\"\nb=\"nothing-here-at-all\"\n",
+			wantFoo: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDetector(cfg)
+			d.MaxDecodeDepth = 3
+
+			findings := d.Detect(sources.Fragment{Raw: tt.raw})
+
+			var foo *report.Finding
+			for i := range findings {
+				if findings[i].RuleID == "foo" {
+					foo = &findings[i]
+				}
+			}
+
+			if !tt.wantFoo {
+				if foo != nil {
+					t.Fatalf("expected no composite finding, got: %+v", *foo)
+				}
+				return
+			}
+
+			if foo == nil {
+				t.Fatalf("expected composite \"foo\" to be reported; findings: %+v", findings)
+			}
+			// Both required dependencies must be attached, decoded.
+			if got := componentSecret(foo, "bar"); got != "bar-cookie01" {
+				t.Fatalf("expected bar component \"bar-cookie01\", got %q (finding: %+v)", got, *foo)
+			}
+			if got := componentSecret(foo, "baz"); got != "baz-cookie02" {
+				t.Fatalf("expected baz component \"baz-cookie02\", got %q (finding: %+v)", got, *foo)
+			}
+		})
+	}
+}
+
+// componentSecret returns the secret of the first required component with the
+// given rule ID across all of the finding's required sets, or "".
+func componentSecret(f *report.Finding, ruleID string) string {
+	for _, set := range f.RequiredSets {
+		for _, comp := range set.Components {
+			if comp.RuleID == ruleID {
+				return comp.Secret
+			}
+		}
+	}
+	return ""
+}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -132,6 +132,11 @@ type Detector struct {
 	filterPrograms     map[string]exprruntime.Program
 	rulesBySpecificity []string
 
+	// requiredRuleIDs is the set of rule IDs referenced by some rule's
+	// RequiredRules. It is empty when the config has no composite rules, which
+	// lets detectFragment skip all composite bookkeeping on the hot path.
+	requiredRuleIDs map[string]struct{}
+
 	// TODO remove this in v2
 	// SkipFindingAppend skips populating the deprecated detector-level findings
 	// slice while consuming results from Run.
@@ -241,6 +246,7 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		ValidationExtractEmpty: valOpts.ExtractEmpty,
 	}
 	d.rulesBySpecificity = orderedRulesBySpecificity(cfg)
+	d.requiredRuleIDs = collectRequiredRuleIDs(cfg)
 	exprRuntime.SetTokenizerProvider(d.Tokenizer)
 
 	// Compile only global prefilter programs so they are available before scanning.
@@ -659,6 +665,23 @@ func (d *Detector) detectFragment(ctx context.Context, fragment sources.Fragment
 
 	findings := []report.Finding{}
 
+	// Composite rules (those with RequiredRules) may have their primary match and
+	// their dependency surface at different decode depths — e.g. a plaintext token
+	// whose required cookie only appears base64-encoded. Resolving dependencies at
+	// each individual depth misses these pairings, so we defer composite handling:
+	// primary findings are accumulated in pendingPrimaries, every decode pass is
+	// recorded in passes, and after the loop the dependencies are detected across
+	// all passes and paired (see resolveCompositeFindings). This bookkeeping is
+	// skipped entirely when the config has no composite rules.
+	hasComposites := len(d.requiredRuleIDs) > 0 && !fragment.InheritedFromFinding
+	var (
+		pendingPrimaries map[string][]report.Finding
+		passes           []decodePass
+	)
+	if hasComposites {
+		pendingPrimaries = make(map[string][]report.Finding)
+	}
+
 	// setup variables to handle different decoding passes
 	currentRaw := fragment.Raw
 	encodedSegments := []*codec.EncodedSegment{}
@@ -671,6 +694,14 @@ ScanLoop:
 		case <-ctx.Done():
 			break ScanLoop
 		default:
+			// Record this pass so composite dependencies can later be detected
+			// against the exact raw/segments the primaries were scanned against.
+			// decoder.Decode allocates a fresh string and segment slice each pass,
+			// so retaining these references is cheap (no copy).
+			if hasComposites {
+				passes = append(passes, decodePass{raw: currentRaw, segments: encodedSegments})
+			}
+
 			// Use Aho-Corasick to find keyword matches, then map directly
 			// to the rules that need checking via KeywordToRules.
 			// Use a pooled byte buffer for lowercasing to avoid allocating
@@ -698,7 +729,13 @@ ScanLoop:
 					break ScanLoop
 				default:
 					rule := d.Config.Rules[ruleID]
-					findings = append(findings, d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings)...)
+					ruleFindings := d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings)
+					// Defer composite primaries; emit everything else immediately.
+					if hasComposites && len(rule.RequiredRules) > 0 {
+						pendingPrimaries[ruleID] = append(pendingPrimaries[ruleID], ruleFindings...)
+					} else {
+						findings = append(findings, ruleFindings...)
+					}
 				}
 			}
 
@@ -719,6 +756,13 @@ ScanLoop:
 			}
 		}
 	}
+
+	// Resolve deferred composite rules by pairing each accumulated primary with
+	// its required-rule dependencies detected across every recorded decode pass.
+	if hasComposites && len(pendingPrimaries) > 0 {
+		findings = append(findings, d.resolveCompositeFindings(fragment, passes, pendingPrimaries)...)
+	}
+
 	return filter(findings)
 }
 
@@ -758,6 +802,19 @@ func (d *Detector) detectFragmentWithRuleTimed(fragment sources.Fragment,
 	findings := d.detectFragmentWithRule(fragment, currentRaw, r, encodedSegments, priorFindings)
 	d.RuleTimings.Record(r.RuleID, time.Since(start))
 	return findings
+}
+
+// collectRequiredRuleIDs returns the set of rule IDs referenced by any rule's
+// RequiredRules across the config. An empty result means there are no composite
+// rules, letting detectFragment skip composite bookkeeping entirely.
+func collectRequiredRuleIDs(cfg *config.Config) map[string]struct{} {
+	ids := make(map[string]struct{})
+	for _, r := range cfg.Rules {
+		for _, req := range r.RequiredRules {
+			ids[req.RuleID] = struct{}{}
+		}
+	}
+	return ids
 }
 
 func orderedRulesBySpecificity(cfg *config.Config) []string {
@@ -1014,94 +1071,126 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		findings = append(findings, finding)
 	}
 
-	// Handle required rules (multi-part rules)
-	if fragment.InheritedFromFinding || len(r.RequiredRules) == 0 {
-		return findings
-	}
-
-	// Process required rules and create findings with auxiliary findings
-	return d.processRequiredRules(fragment, currentRaw, r, encodedSegments, findings, logger)
+	return findings
 }
 
-// processRequiredRules handles the logic for multi-part rules with auxiliary findings
-func (d *Detector) processRequiredRules(fragment sources.Fragment, currentRaw string, r config.Rule, encodedSegments []*codec.EncodedSegment, primaryFindings []report.Finding, logger zerolog.Logger) []report.Finding {
-	if len(primaryFindings) == 0 {
-		logger.Debug().Msg("no primary findings to process for required rules")
-		return primaryFindings
+// decodePass captures the raw content and encoded segments scanned during a
+// single decode pass, so composite dependencies can later be detected against
+// the same input the primaries were scanned against.
+type decodePass struct {
+	raw      string
+	segments []*codec.EncodedSegment
+}
+
+// resolveCompositeFindings pairs accumulated composite-primary findings with
+// their required-rule dependencies. Dependencies are detected across every
+// recorded decode pass, so a primary and its dependency can be paired even when
+// they surface at different decode depths (e.g. a plaintext token and a
+// base64-encoded cookie). Positions on all findings are already normalized to
+// original fragment coordinates (see codec.AdjustMatchIndex), so proximity
+// comparisons are depth-agnostic.
+func (d *Detector) resolveCompositeFindings(fragment sources.Fragment, passes []decodePass, pendingPrimaries map[string][]report.Finding) []report.Finding {
+	logger := fragment.Logger()
+
+	// Determine which required rules are needed across all pending composites.
+	requiredIDs := make(map[string]struct{})
+	for primaryID := range pendingPrimaries {
+		for _, req := range d.Config.Rules[primaryID].RequiredRules {
+			requiredIDs[req.RuleID] = struct{}{}
+		}
 	}
 
-	// Pre-collect all required rule findings once
-	allRequiredFindings := make(map[string][]report.Finding)
-
-	for _, requiredRule := range r.RequiredRules {
-		rule, ok := d.Config.Rules[requiredRule.RuleID]
+	// Detect each required rule against every recorded pass, then dedupe. A
+	// dependency decoded at depth k is found when scanning that pass; a plaintext
+	// dependency is found when scanning pass 0 (which has no segments).
+	allRequiredFindings := make(map[string][]report.Finding, len(requiredIDs))
+	for reqID := range requiredIDs {
+		rule, ok := d.Config.Rules[reqID]
 		if !ok {
-			logger.Error().Str("rule-id", requiredRule.RuleID).Msg("required rule not found in config")
+			logger.Error().Str("rule-id", reqID).Msg("required rule not found in config")
 			continue
 		}
 
-		// Mark fragment as inherited to prevent infinite recursion
-		inheritedFragment := fragment
-		inheritedFragment.InheritedFromFinding = true
-
-		// Call detectRule once for each required rule
-		requiredFindings := d.detectFragmentWithRuleTimed(inheritedFragment, currentRaw, rule, encodedSegments, nil)
-		allRequiredFindings[requiredRule.RuleID] = requiredFindings
-
-		logger.Debug().
-			Str("rule-id", requiredRule.RuleID).
-			Int("findings", len(requiredFindings)).
-			Msg("collected required rule findings")
+		var collected []report.Finding
+		for _, pass := range passes {
+			// Mark fragment as inherited to prevent recursion / SkipReport gating.
+			inheritedFragment := fragment
+			inheritedFragment.InheritedFromFinding = true
+			collected = append(collected,
+				d.detectFragmentWithRuleTimed(inheritedFragment, pass.raw, rule, pass.segments, nil)...)
+		}
+		allRequiredFindings[reqID] = dedupeFindings(collected)
 	}
 
 	var finalFindings []report.Finding
 
-	// Now process each primary finding against the pre-collected required findings
-	for _, primaryFinding := range primaryFindings {
-		var requiredFindings []*report.RequiredFinding
+	// Iterate composites in specificity order for deterministic output.
+	for _, primaryID := range d.rulesBySpecificity {
+		primaries, ok := pendingPrimaries[primaryID]
+		if !ok {
+			continue
+		}
+		r := d.Config.Rules[primaryID]
 
-		for _, requiredRule := range r.RequiredRules {
-			foundRequiredFindings, exists := allRequiredFindings[requiredRule.RuleID]
-			if !exists {
-				continue // Rule wasn't found earlier, skip
-			}
+		for _, primaryFinding := range dedupeFindings(primaries) {
+			var requiredFindings []*report.RequiredFinding
 
-			// Filter findings that are within proximity of the primary finding
-			for _, requiredFinding := range foundRequiredFindings {
-				if d.withinProximity(primaryFinding, requiredFinding, requiredRule) {
-					req := &report.RequiredFinding{
-						RuleID:          requiredFinding.RuleID,
-						StartLine:       requiredFinding.StartLine,
-						EndLine:         requiredFinding.EndLine,
-						StartColumn:     requiredFinding.StartColumn,
-						EndColumn:       requiredFinding.EndColumn,
-						Line:            requiredFinding.Line,
-						Match:           requiredFinding.Match,
-						Secret:          requiredFinding.Secret,
-						CaptureGroups:   requiredFinding.CaptureGroups,
-						RuleSpecificity: requiredFinding.RuleSpecificity,
+			for _, requiredRule := range r.RequiredRules {
+				for _, requiredFinding := range allRequiredFindings[requiredRule.RuleID] {
+					if d.withinProximity(primaryFinding, requiredFinding, requiredRule) {
+						requiredFindings = append(requiredFindings, &report.RequiredFinding{
+							RuleID:          requiredFinding.RuleID,
+							StartLine:       requiredFinding.StartLine,
+							EndLine:         requiredFinding.EndLine,
+							StartColumn:     requiredFinding.StartColumn,
+							EndColumn:       requiredFinding.EndColumn,
+							Line:            requiredFinding.Line,
+							Match:           requiredFinding.Match,
+							Secret:          requiredFinding.Secret,
+							CaptureGroups:   requiredFinding.CaptureGroups,
+							RuleSpecificity: requiredFinding.RuleSpecificity,
+						})
 					}
-					requiredFindings = append(requiredFindings, req)
 				}
 			}
-		}
 
-		// Check if we have at least one auxiliary finding for each required rule
-		if len(requiredFindings) > 0 && d.hasAllRequiredRules(requiredFindings, r.RequiredRules) {
-			// Create a finding with auxiliary findings
-			newFinding := primaryFinding // Copy the primary finding
-			newFinding.BuildRequiredSets(requiredFindings, maxRequiredSets)
-			finalFindings = append(finalFindings, newFinding)
+			// Emit only when at least one dependency of every required rule is present.
+			if len(requiredFindings) > 0 && d.hasAllRequiredRules(requiredFindings, r.RequiredRules) {
+				newFinding := primaryFinding // Copy the primary finding
+				newFinding.BuildRequiredSets(requiredFindings, maxRequiredSets)
+				finalFindings = append(finalFindings, newFinding)
 
-			logger.Debug().
-				Str("primary-rule", r.RuleID).
-				Int("primary-line", primaryFinding.StartLine).
-				Int("auxiliary-count", len(requiredFindings)).
-				Msg("multi-part rule satisfied")
+				logger.Debug().
+					Str("primary-rule", r.RuleID).
+					Int("primary-line", primaryFinding.StartLine).
+					Int("auxiliary-count", len(requiredFindings)).
+					Msg("multi-part rule satisfied")
+			}
 		}
 	}
 
 	return finalFindings
+}
+
+// dedupeFindings removes findings that share the same original-coordinate
+// location and secret. Matches can repeat across decode passes when a decoded
+// segment sits adjacent to another encoded segment; deduping keeps required-set
+// combinations (and their cartesian product) from being inflated.
+func dedupeFindings(findings []report.Finding) []report.Finding {
+	if len(findings) <= 1 {
+		return findings
+	}
+	seen := make(map[string]struct{}, len(findings))
+	out := make([]report.Finding, 0, len(findings))
+	for _, f := range findings {
+		key := fmt.Sprintf("%d:%d:%d:%d:%s", f.StartLine, f.StartColumn, f.EndLine, f.EndColumn, f.Secret)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, f)
+	}
+	return out
 }
 
 // hasAllRequiredRules checks if we have at least one auxiliary finding for each required rule


### PR DESCRIPTION
**This is a speculative fix for #236 generated by Claude.** Let me know your thoughts on the reported issue, and whether you'd be happy with this approach.

```
 ┌─────────────────────────────────────────────────────────────────────────────────────────────┬───────────────────────────┐
  │                                          Scenario                                           │          Result           │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Plaintext primary + encoded dependency                                                      │ ✅                        │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Encoded primary + plaintext dependency (mirror)                                             │ ✅                        │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Single dependency two layers deep (double-base64)                                           │ ✅                        │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Two deps split across depths 0 and 1                                                        │ ✅                        │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Two deps split across depths 1 and 2 (primary at 0, deps at 1 & 2 — three different layers) │ ✅                        │
  ├─────────────────────────────────────────────────────────────────────────────────────────────┼───────────────────────────┤
  │ Any one required dep missing                                                                │ ✅ correctly not reported │
  └─────────────────────────────────────────────────────────────────────────────────────────────┴───────────────────────────┘

```