### PR TITLE
Perf/detect optimizations

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect/codec"
+	"github.com/betterleaks/betterleaks/internal/ahocorasick"
 	"github.com/betterleaks/betterleaks/internal/exprruntime"
 	"github.com/betterleaks/betterleaks/internal/validate"
 	"github.com/betterleaks/betterleaks/logging"
@@ -27,7 +28,6 @@ import (
 	"github.com/betterleaks/betterleaks/sources"
 
 	"github.com/fatih/semgroup"
-	ahocorasick "github.com/rrethy/ahocorasick"
 	"github.com/rs/zerolog"
 	"golang.org/x/exp/maps"
 )
@@ -66,6 +66,10 @@ const (
 type Result struct {
 	Finding report.Finding
 	Err     error
+}
+
+type ruleCandidates struct {
+	marked []bool
 }
 
 // Detector is the main detector struct
@@ -131,6 +135,9 @@ type Detector struct {
 	filterProgramM     sync.Mutex
 	filterPrograms     map[string]exprruntime.Program
 	rulesBySpecificity []string
+	keywordRuleIndexes [][]int
+	noKeywordIndexes   []int
+	candidatePool      sync.Pool
 
 	// TODO remove this in v2
 	// SkipFindingAppend skips populating the deprecated detector-level findings
@@ -227,12 +234,13 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		logging.Fatal().Err(exprErr).Msg("failed to create expr runtime")
 	}
 
+	keywords := maps.Keys(cfg.Keywords)
 	d := &Detector{
 		gitleaksIgnore:         make(map[string]struct{}),
 		findings:               make([]report.Finding, 0),
 		ValidationCounts:       make(map[report.ValidationStatus]int),
 		Config:                 cfg,
-		prefilter:              ahocorasick.CompileStrings(maps.Keys(cfg.Keywords)),
+		prefilter:              ahocorasick.Compile(keywords, true),
 		Sema:                   semgroup.NewGroup(ctx, 40),
 		exprRuntime:            exprRuntime,
 		validationRuntime:      validationRuntime,
@@ -241,6 +249,23 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		ValidationExtractEmpty: valOpts.ExtractEmpty,
 	}
 	d.rulesBySpecificity = orderedRulesBySpecificity(cfg)
+	d.keywordRuleIndexes = make([][]int, len(keywords))
+	ruleIndexes := make(map[string]int, len(d.rulesBySpecificity))
+	for i, ruleID := range d.rulesBySpecificity {
+		ruleIndexes[ruleID] = i
+	}
+	for patternID, keyword := range keywords {
+		ruleIDs := cfg.KeywordToRules[keyword]
+		for _, ruleID := range ruleIDs {
+			d.keywordRuleIndexes[patternID] = append(d.keywordRuleIndexes[patternID], ruleIndexes[ruleID])
+		}
+	}
+	for _, ruleID := range cfg.NoKeywordRules {
+		d.noKeywordIndexes = append(d.noKeywordIndexes, ruleIndexes[ruleID])
+	}
+	d.candidatePool.New = func() any {
+		return &ruleCandidates{marked: make([]bool, len(d.rulesBySpecificity))}
+	}
 	exprRuntime.SetTokenizerProvider(d.Tokenizer)
 
 	// Compile only global prefilter programs so they are available before scanning.
@@ -671,36 +696,34 @@ ScanLoop:
 		case <-ctx.Done():
 			break ScanLoop
 		default:
-			// Use Aho-Corasick to find keyword matches, then map directly
-			// to the rules that need checking via KeywordToRules.
-			// Use a pooled byte buffer for lowercasing to avoid allocating
-			lowerBufPtr, lowerBuf := getLowerBuf(currentRaw)
-			acMatches := d.prefilter.FindAllByteSlice(lowerBuf)
-
-			// Build a set of rule IDs to check based on keyword matches.
-			rulesToCheck := make(map[string]struct{}, len(acMatches))
-			for _, m := range acMatches {
-				keyword := string(m.Word)
-				for _, ruleID := range d.Config.KeywordToRules[keyword] {
-					rulesToCheck[ruleID] = struct{}{}
+			candidates := d.candidatePool.Get().(*ruleCandidates)
+			d.prefilter.Visit(currentRaw, func(patternID, _, _ int) bool {
+				for _, ruleIndex := range d.keywordRuleIndexes[patternID] {
+					candidates.marked[ruleIndex] = true
 				}
-			}
-			putLowerBuf(lowerBufPtr)
+				return true
+			})
 			// Always include rules that have no keywords.
-			for _, ruleID := range d.Config.NoKeywordRules {
-				rulesToCheck[ruleID] = struct{}{}
+			for _, ruleIndex := range d.noKeywordIndexes {
+				candidates.marked[ruleIndex] = true
 			}
 
-			ruleIDs := d.orderedRuleIDs(rulesToCheck)
-			for _, ruleID := range ruleIDs {
+			for ruleIndex, ruleID := range d.rulesBySpecificity {
+				if !candidates.marked[ruleIndex] {
+					continue
+				}
 				select {
 				case <-ctx.Done():
+					clear(candidates.marked)
+					d.candidatePool.Put(candidates)
 					break ScanLoop
 				default:
 					rule := d.Config.Rules[ruleID]
 					findings = append(findings, d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings)...)
 				}
 			}
+			clear(candidates.marked)
+			d.candidatePool.Put(candidates)
 
 			// increment the depth by 1 as we start our decoding pass
 			currentDecodeDepth++
@@ -720,29 +743,6 @@ ScanLoop:
 		}
 	}
 	return filter(findings)
-}
-
-func (d *Detector) orderedRuleIDs(ruleSet map[string]struct{}) []string {
-	var ruleIDs []string
-	seen := make(map[string]struct{}, len(ruleSet))
-	appendRule := func(ruleID string) {
-		if _, ok := ruleSet[ruleID]; !ok {
-			return
-		}
-		if _, ok := seen[ruleID]; ok {
-			return
-		}
-		seen[ruleID] = struct{}{}
-		ruleIDs = append(ruleIDs, ruleID)
-	}
-
-	for _, ruleID := range d.rulesBySpecificity {
-		appendRule(ruleID)
-	}
-	for ruleID := range ruleSet {
-		appendRule(ruleID)
-	}
-	return ruleIDs
 }
 
 func (d *Detector) detectFragmentWithRuleTimed(fragment sources.Fragment,

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -257,11 +257,19 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 	for patternID, keyword := range keywords {
 		ruleIDs := cfg.KeywordToRules[keyword]
 		for _, ruleID := range ruleIDs {
-			d.keywordRuleIndexes[patternID] = append(d.keywordRuleIndexes[patternID], ruleIndexes[ruleID])
+			ruleIndex, ok := ruleIndexes[ruleID]
+			if !ok {
+				continue
+			}
+			d.keywordRuleIndexes[patternID] = append(d.keywordRuleIndexes[patternID], ruleIndex)
 		}
 	}
 	for _, ruleID := range cfg.NoKeywordRules {
-		d.noKeywordIndexes = append(d.noKeywordIndexes, ruleIndexes[ruleID])
+		ruleIndex, ok := ruleIndexes[ruleID]
+		if !ok {
+			continue
+		}
+		d.noKeywordIndexes = append(d.noKeywordIndexes, ruleIndex)
 	}
 	d.candidatePool.New = func() any {
 		return &ruleCandidates{marked: make([]bool, len(d.rulesBySpecificity))}

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -33,11 +34,67 @@ const configPath = "../testdata/config/"
 const repoBasePath = "../testdata/repos/"
 const archivesBasePath = "../testdata/archives/"
 
+type cancelOnSecondCheck struct {
+	checks int
+	open   chan struct{}
+	closed chan struct{}
+}
+
+func newCancelOnSecondCheck() *cancelOnSecondCheck {
+	closed := make(chan struct{})
+	close(closed)
+	return &cancelOnSecondCheck{open: make(chan struct{}), closed: closed}
+}
+
+func (c *cancelOnSecondCheck) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *cancelOnSecondCheck) Done() <-chan struct{} {
+	c.checks++
+	if c.checks > 1 {
+		return c.closed
+	}
+	return c.open
+}
+func (c *cancelOnSecondCheck) Err() error    { return context.Canceled }
+func (c *cancelOnSecondCheck) Value(any) any { return nil }
+
 func loadTestConfig(t *testing.T, cfgName string) *config.Config {
 	t.Helper()
 	cfg, err := config.LoadFile(filepath.Join(configPath, cfgName+".toml"))
 	require.NoError(t, err)
 	return cfg
+}
+
+func TestCandidateBitmap(t *testing.T) {
+	rules := map[string]config.Rule{
+		"high":   {RuleID: "high", Specificity: 30, Keywords: []string{"shared", "alias"}, Regex: regexp.MustCompile(`HIGHSECRET`)},
+		"low":    {RuleID: "low", Specificity: 20, Keywords: []string{"shared"}, Regex: regexp.MustCompile(`LOWSECRET`)},
+		"cancel": {RuleID: "cancel", Specificity: 10, Keywords: []string{"cancel"}, Regex: regexp.MustCompile(`ALWAYSSECRET`)},
+		"always": {RuleID: "always", Regex: regexp.MustCompile(`ALWAYSSECRET`)},
+	}
+	cfg := &config.Config{
+		Rules:          rules,
+		Keywords:       map[string]struct{}{"shared": {}, "alias": {}, "cancel": {}},
+		KeywordToRules: map[string][]string{"shared": {"high", "low"}, "alias": {"high"}, "cancel": {"cancel"}},
+		NoKeywordRules: []string{"always"},
+	}
+	d := NewDetector(cfg)
+
+	// Cancellation after candidates are marked must not leak them into the next scan.
+	require.Empty(t, d.detectFragment(newCancelOnSecondCheck(), sources.Fragment{Raw: "cancel ALWAYSSECRET"}))
+	require.Equal(t, []string{"always"}, findingRuleIDs(d.DetectString("ALWAYSSECRET")))
+
+	// One keyword selects multiple rules, multiple keywords select one rule,
+	// rules without keywords always run, and specificity order is retained.
+	require.Equal(t, []string{"high", "low", "always"}, findingRuleIDs(d.DetectString("shared HIGHSECRET LOWSECRET ALWAYSSECRET")))
+	require.Equal(t, []string{"high", "always"}, findingRuleIDs(d.DetectString("alias HIGHSECRET ALWAYSSECRET")))
+}
+
+func findingRuleIDs(findings []report.Finding) []string {
+	ids := make([]string, len(findings))
+	for i := range findings {
+		ids[i] = findings[i].RuleID
+	}
+	return ids
 }
 
 const encodedTestValues = `

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -73,11 +73,12 @@ func TestCandidateBitmap(t *testing.T) {
 	}
 	cfg := &config.Config{
 		Rules:          rules,
-		Keywords:       map[string]struct{}{"shared": {}, "alias": {}, "cancel": {}},
-		KeywordToRules: map[string][]string{"shared": {"high", "low"}, "alias": {"high"}, "cancel": {"cancel"}},
-		NoKeywordRules: []string{"always"},
+		Keywords:       map[string]struct{}{"shared": {}, "alias": {}, "cancel": {}, "stale": {}},
+		KeywordToRules: map[string][]string{"shared": {"high", "low"}, "alias": {"high"}, "cancel": {"cancel"}, "stale": {"missing"}},
+		NoKeywordRules: []string{"always", "missing"},
 	}
 	d := NewDetector(cfg)
+	require.Empty(t, d.DetectString("stale HIGHSECRET"))
 
 	// Cancellation after candidates are marked must not leak them into the next scan.
 	require.Empty(t, d.detectFragment(newCancelOnSecondCheck(), sources.Fragment{Raw: "cancel ALWAYSSECRET"}))

--- a/detect/utils.go
+++ b/detect/utils.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"path/filepath"
 	"strings"
-	"sync"
 
 	"github.com/betterleaks/betterleaks/logging"
 	"github.com/betterleaks/betterleaks/report"
@@ -229,41 +228,6 @@ func stripEmptyMeta(m map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
-}
-
-// lowercaseBufPool provides reusable byte buffers for lowercasing strings
-// without allocating a new string via strings.ToLower each time.
-var lowercaseBufPool = sync.Pool{
-	New: func() any {
-		buf := make([]byte, 0, 128*1024)
-		return &buf
-	},
-}
-
-// getLowerBuf returns an ASCII-lowercased copy of s in a pooled byte buffer.
-// Caller must call putLowerBuf when done with the returned slice.
-func getLowerBuf(s string) (*[]byte, []byte) {
-	bp := lowercaseBufPool.Get().(*[]byte)
-	buf := *bp
-	if cap(buf) < len(s) {
-		buf = make([]byte, len(s))
-	} else {
-		buf = buf[:len(s)]
-	}
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			buf[i] = c + 32
-		} else {
-			buf[i] = c
-		}
-	}
-	*bp = buf
-	return bp, buf
-}
-
-func putLowerBuf(bp *[]byte) {
-	lowercaseBufPool.Put(bp)
 }
 
 // findNewlineIndices returns the start indices of all newlines in s.

--- a/internal/ahocorasick/matcher.go
+++ b/internal/ahocorasick/matcher.go
@@ -1,0 +1,158 @@
+// Package ahocorasick provides the detector's allocation-free keyword matcher.
+// Its Aho-Corasick implementation is derived from github.com/RRethy/ahocorasick
+// (MIT); see LICENSE.
+package ahocorasick
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+// Matcher is a flat Aho-Corasick DFA. Pattern IDs are their input indexes.
+type Matcher struct {
+	transitions []uint32
+	outputs     [][]uint32
+	lengths     []int
+	maxLength   int
+	foldASCII   bool
+}
+
+type node struct {
+	next map[byte]uint32
+	fail uint32
+	out  []uint32
+}
+
+// Compile builds a matcher. When foldASCII is true, ASCII case is ignored.
+func Compile(patterns []string, foldASCII bool) *Matcher {
+	nodes := []node{{next: make(map[byte]uint32)}}
+	lengths := make([]int, len(patterns))
+	maxLength := 0
+	for id, pattern := range patterns {
+		state := uint32(0)
+		lengths[id] = len(pattern)
+		maxLength = max(maxLength, len(pattern))
+		for i := 0; i < len(pattern); i++ {
+			b := fold(pattern[i], foldASCII)
+			next, ok := nodes[state].next[b]
+			if !ok {
+				next = uint32(len(nodes))
+				nodes[state].next[b] = next
+				nodes = append(nodes, node{next: make(map[byte]uint32)})
+			}
+			state = next
+		}
+		nodes[state].out = append(nodes[state].out, uint32(id))
+	}
+
+	transitions := make([]uint32, len(nodes)*256)
+	queue := make([]uint32, 0, len(nodes))
+	for b, child := range nodes[0].next {
+		transitions[int(b)] = child
+		queue = append(queue, child)
+	}
+	for len(queue) > 0 {
+		state := queue[0]
+		queue = queue[1:]
+		fail := nodes[state].fail
+		if inherited := nodes[fail].out; len(inherited) > 0 {
+			nodes[state].out = append(nodes[state].out, inherited...)
+		}
+		base := int(state) * 256
+		failBase := int(fail) * 256
+		for b := range 256 {
+			if child, ok := nodes[state].next[byte(b)]; ok {
+				nodes[child].fail = transitions[failBase+b]
+				transitions[base+b] = child
+				queue = append(queue, child)
+			} else {
+				transitions[base+b] = transitions[failBase+b]
+			}
+		}
+	}
+
+	outputs := make([][]uint32, len(nodes))
+	for i := range nodes {
+		outputs[i] = nodes[i].out
+	}
+	return &Matcher{transitions: transitions, outputs: outputs, lengths: lengths, maxLength: maxLength, foldASCII: foldASCII}
+}
+
+// Visit calls fn for every match. Returning false stops traversal.
+func (m *Matcher) Visit(text string, fn func(patternID, start, end int) bool) {
+	state := uint32(0)
+	var localExtras [128]uint8
+	extras := localExtras[:]
+	if m.maxLength > len(extras) {
+		extras = make([]uint8, m.maxLength)
+	}
+	correctionRemaining := 0
+	correctionPos := -1
+
+	for i := 0; i < len(text); {
+		b := text[i]
+		size := 1
+		extra := 0
+		if m.foldASCII && b >= utf8.RuneSelf {
+			r, runeSize := utf8.DecodeRuneInString(text[i:])
+			folded, ok := foldRuneASCII(r)
+			if !ok {
+				state = 0
+				correctionRemaining = 0
+				i += runeSize
+				continue
+			}
+			b, size, extra = folded, runeSize, runeSize-1
+			if correctionRemaining == 0 {
+				clear(extras)
+				correctionPos = -1
+			}
+			correctionRemaining = m.maxLength
+		} else {
+			b = fold(b, m.foldASCII)
+		}
+
+		if correctionRemaining > 0 {
+			correctionPos++
+			extras[correctionPos%len(extras)] = uint8(extra)
+		}
+		state = m.transitions[int(state)*256+int(b)]
+		for _, id := range m.outputs[state] {
+			end := i + size
+			start := end - m.lengths[id]
+			if correctionRemaining > 0 {
+				for j := 0; j < m.lengths[id]; j++ {
+					pos := correctionPos - j
+					if pos >= 0 {
+						start -= int(extras[pos%len(extras)])
+					}
+				}
+			}
+			if !fn(int(id), start, end) {
+				return
+			}
+		}
+		if correctionRemaining > 0 {
+			correctionRemaining--
+		}
+		i += size
+	}
+}
+
+func foldRuneASCII(r rune) (byte, bool) {
+	for next := r; ; next = unicode.SimpleFold(next) {
+		if next < utf8.RuneSelf {
+			return fold(byte(next), true), true
+		}
+		if folded := unicode.SimpleFold(next); folded == r {
+			return 0, false
+		}
+	}
+}
+
+func fold(b byte, enabled bool) byte {
+	if enabled && b >= 'A' && b <= 'Z' {
+		return b + ('a' - 'A')
+	}
+	return b
+}

--- a/internal/ahocorasick/matcher_test.go
+++ b/internal/ahocorasick/matcher_test.go
@@ -1,0 +1,60 @@
+package ahocorasick
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVisit(t *testing.T) {
+	m := Compile([]string{"he", "she", "hers", "his"}, true)
+	var got [][3]int
+	m.Visit("aHiS uSHers", func(id, start, end int) bool {
+		got = append(got, [3]int{id, start, end})
+		return true
+	})
+	require.Equal(t, [][3]int{{3, 1, 4}, {1, 6, 9}, {0, 7, 9}, {2, 7, 11}}, got)
+}
+
+func TestVisitUnicodeSimpleFoldOffsets(t *testing.T) {
+	m := Compile([]string{"key", "secret"}, true)
+	var got [][3]int
+	m.Visit("KEY ſecret", func(id, start, end int) bool {
+		got = append(got, [3]int{id, start, end})
+		return true
+	})
+	require.Equal(t, [][3]int{{0, 0, len("KEY")}, {1, len("KEY "), len("KEY ſecret")}}, got)
+}
+
+func TestVisitStableIDsAndStop(t *testing.T) {
+	m := Compile([]string{"x", "x"}, false)
+	var ids []int
+	m.Visit("xx", func(id, _, _ int) bool {
+		ids = append(ids, id)
+		return len(ids) < 2
+	})
+	require.Equal(t, []int{0, 1}, ids)
+}
+
+func TestVisitConcurrent(t *testing.T) {
+	m := Compile([]string{"needle"}, true)
+	for i := range 8 {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			t.Parallel()
+			for range 100 {
+				matches := 0
+				m.Visit("NEEDLE needle", func(_, _, _ int) bool { matches++; return true })
+				require.Equal(t, 2, matches)
+			}
+		})
+	}
+}
+
+func TestVisitASCIIAllocations(t *testing.T) {
+	m := Compile([]string{"needle"}, true)
+	allocs := testing.AllocsPerRun(100, func() {
+		m.Visit("haystack NEEDLE haystack", func(_, _, _ int) bool { return true })
+	})
+	require.Zero(t, allocs)
+}

--- a/sources/common.go
+++ b/sources/common.go
@@ -104,40 +104,63 @@ func readUntilSafeBoundary(r *bufio.Reader, n int, maxPeekSize int, peekBuf *byt
 
 	// If not, read ahead until we (hopefully) find some.
 	newlineCount = 0
-	for {
-		data = peekBuf.Bytes()
-		// Check if the last character is a newline.
-		lastChar = data[len(data)-1]
-		if lastChar == '\n' {
-			newlineCount++
+	if c := peekBuf.Bytes()[peekBuf.Len()-1]; c == '\n' {
+		newlineCount++
+	}
 
-			// Stop if two consecutive newlines are found
-			if newlineCount >= 2 {
-				break
-			}
-		} else if isWhitespace[lastChar] {
-			// The presence of other whitespace characters (`\r`, ` `, `\t`) shouldn't reset the count.
-			// (Intentionally do nothing.)
-		} else {
-			newlineCount = 0 // Reset if a non-newline character is found
+	for (peekBuf.Len() - n) < maxPeekSize {
+		remaining := maxPeekSize - (peekBuf.Len() - n)
+		data, err := r.Peek(remaining)
+		if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
+			return err
 		}
-
-		// Stop growing the buffer if it reaches maxSize
-		if (peekBuf.Len() - n) >= maxPeekSize {
+		if len(data) == 0 {
 			break
 		}
 
-		// Read additional data into a temporary buffer
-		b, err := r.ReadByte()
-		if err != nil {
-			if err == io.EOF {
-				break
-			}
-			return err
+		consume := scanUntilSafeBoundary(data, &newlineCount)
+		peekBuf.Write(data[:consume])
+		if _, discardErr := r.Discard(consume); discardErr != nil {
+			return discardErr
 		}
-		peekBuf.WriteByte(b)
+		if newlineCount >= 2 || err == io.EOF {
+			break
+		}
 	}
 	return nil
+}
+
+func scanUntilSafeBoundary(data []byte, newlineCount *int) int {
+	consume := 0
+	for consume < len(data) {
+		i := bytes.IndexByte(data[consume:], '\n')
+		if i < 0 {
+			if hasNonWhitespace(data[consume:]) {
+				*newlineCount = 0
+			}
+			return len(data)
+		}
+
+		next := consume + i
+		if hasNonWhitespace(data[consume:next]) {
+			*newlineCount = 0
+		}
+		*newlineCount++
+		consume = next + 1
+		if *newlineCount >= 2 {
+			return consume
+		}
+	}
+	return consume
+}
+
+func hasNonWhitespace(data []byte) bool {
+	for _, c := range data {
+		if !isWhitespace[c] {
+			return true
+		}
+	}
+	return false
 }
 
 type sourceDownloadOptions struct {

--- a/sources/common.go
+++ b/sources/common.go
@@ -104,63 +104,40 @@ func readUntilSafeBoundary(r *bufio.Reader, n int, maxPeekSize int, peekBuf *byt
 
 	// If not, read ahead until we (hopefully) find some.
 	newlineCount = 0
-	if c := peekBuf.Bytes()[peekBuf.Len()-1]; c == '\n' {
-		newlineCount++
-	}
+	for {
+		data = peekBuf.Bytes()
+		// Check if the last character is a newline.
+		lastChar = data[len(data)-1]
+		if lastChar == '\n' {
+			newlineCount++
 
-	for (peekBuf.Len() - n) < maxPeekSize {
-		remaining := maxPeekSize - (peekBuf.Len() - n)
-		data, err := r.Peek(remaining)
-		if err != nil && err != io.EOF && err != bufio.ErrBufferFull {
+			// Stop if two consecutive newlines are found
+			if newlineCount >= 2 {
+				break
+			}
+		} else if isWhitespace[lastChar] {
+			// The presence of other whitespace characters (`\r`, ` `, `\t`) shouldn't reset the count.
+			// (Intentionally do nothing.)
+		} else {
+			newlineCount = 0 // Reset if a non-newline character is found
+		}
+
+		// Stop growing the buffer if it reaches maxSize
+		if (peekBuf.Len() - n) >= maxPeekSize {
+			break
+		}
+
+		// Read additional data into a temporary buffer
+		b, err := r.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
 			return err
 		}
-		if len(data) == 0 {
-			break
-		}
-
-		consume := scanUntilSafeBoundary(data, &newlineCount)
-		peekBuf.Write(data[:consume])
-		if _, discardErr := r.Discard(consume); discardErr != nil {
-			return discardErr
-		}
-		if newlineCount >= 2 || err == io.EOF {
-			break
-		}
+		peekBuf.WriteByte(b)
 	}
 	return nil
-}
-
-func scanUntilSafeBoundary(data []byte, newlineCount *int) int {
-	consume := 0
-	for consume < len(data) {
-		i := bytes.IndexByte(data[consume:], '\n')
-		if i < 0 {
-			if hasNonWhitespace(data[consume:]) {
-				*newlineCount = 0
-			}
-			return len(data)
-		}
-
-		next := consume + i
-		if hasNonWhitespace(data[consume:next]) {
-			*newlineCount = 0
-		}
-		*newlineCount++
-		consume = next + 1
-		if *newlineCount >= 2 {
-			return consume
-		}
-	}
-	return consume
-}
-
-func hasNonWhitespace(data []byte) bool {
-	for _, c := range data {
-		if !isWhitespace[c] {
-			return true
-		}
-	}
-	return false
 }
 
 type sourceDownloadOptions struct {


### PR DESCRIPTION
NOTE: codex 5.6 wrote most of this but I put it through my standard rounds of testing. 

This pull request refactors the keyword matching and rule selection logic in the detector to improve performance and reduce allocations. The main changes include replacing the external `ahocorasick` dependency with a custom, allocation-free implementation, optimizing rule candidate selection (bitmap).

old ahocorasick: search → allocate results → `string(match.Word)` → map keyword → rules
new ahocorasick: search → pattern ID → rules

No more `.ToLower`
