### PR TITLE
perf(detect): limit regex searches to inferred keyword regions

### DIFF
--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -22,7 +22,7 @@ func GenericCredential() *config.Rule {
 			"passw(?:or)?d",
 			"secret",
 			"token",
-		}, `[\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3}`, true),
+		}, `[\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,149}={0,3}`, true),
 		Keywords: []string{
 			"access",
 			"api",

--- a/cmd/generate/config/rules/generic_test.go
+++ b/cmd/generate/config/rules/generic_test.go
@@ -1,0 +1,28 @@
+package rules
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericCredentialBase64Length(t *testing.T) {
+	re := GenericCredential().Regex
+	for _, test := range []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{"149", "a" + strings.Repeat("/", 148), true},
+		{"150", "a" + strings.Repeat("/", 149), true},
+		{"151", "a" + strings.Repeat("/", 150), false},
+		{"500", "a" + strings.Repeat("/", 499), false},
+		{"three padding", "a" + strings.Repeat("/", 146) + "===", true},
+		{"four padding", "a" + strings.Repeat("/", 145) + "====", false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, re.MatchString("token = "+test.value+"\n"))
+		})
+	}
+}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -2516,7 +2516,7 @@ containsAny(finding["secret"], ["image-pulling@authenticated-image-pulling.iam.g
 [[rules]]
 id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
-regex = '''(?i)(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+regex = '''(?i)(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,149}={0,3})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 specificity = 0
 keywords = [
     "access",

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -70,6 +70,12 @@ type Result struct {
 
 type ruleCandidates struct {
 	marked []bool
+	spans  [][]searchSpan
+}
+
+type searchSpan struct {
+	start int
+	end   int
 }
 
 // Detector is the main detector struct
@@ -137,6 +143,7 @@ type Detector struct {
 	rulesBySpecificity []string
 	keywordRuleIndexes [][]int
 	noKeywordIndexes   []int
+	ruleSearchScopes   []int
 	candidatePool      sync.Pool
 
 	// TODO remove this in v2
@@ -249,10 +256,12 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		ValidationExtractEmpty: valOpts.ExtractEmpty,
 	}
 	d.rulesBySpecificity = orderedRulesBySpecificity(cfg)
+	d.ruleSearchScopes = make([]int, len(d.rulesBySpecificity))
 	d.keywordRuleIndexes = make([][]int, len(keywords))
 	ruleIndexes := make(map[string]int, len(d.rulesBySpecificity))
 	for i, ruleID := range d.rulesBySpecificity {
 		ruleIndexes[ruleID] = i
+		d.ruleSearchScopes[i] = inferKeywordScope(cfg.Rules[ruleID])
 	}
 	for patternID, keyword := range keywords {
 		ruleIDs := cfg.KeywordToRules[keyword]
@@ -272,7 +281,7 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		d.noKeywordIndexes = append(d.noKeywordIndexes, ruleIndex)
 	}
 	d.candidatePool.New = func() any {
-		return &ruleCandidates{marked: make([]bool, len(d.rulesBySpecificity))}
+		return &ruleCandidates{marked: make([]bool, len(d.rulesBySpecificity)), spans: make([][]searchSpan, len(d.rulesBySpecificity))}
 	}
 	exprRuntime.SetTokenizerProvider(d.Tokenizer)
 
@@ -705,9 +714,15 @@ ScanLoop:
 			break ScanLoop
 		default:
 			candidates := d.candidatePool.Get().(*ruleCandidates)
-			d.prefilter.Visit(currentRaw, func(patternID, _, _ int) bool {
+			d.prefilter.Visit(currentRaw, func(patternID, start, end int) bool {
 				for _, ruleIndex := range d.keywordRuleIndexes[patternID] {
 					candidates.marked[ruleIndex] = true
+					if scope := d.ruleSearchScopes[ruleIndex]; scope > 0 {
+						candidates.spans[ruleIndex] = append(candidates.spans[ruleIndex], searchSpan{
+							start: max(0, start-scope),
+							end:   min(len(currentRaw), end+scope),
+						})
+					}
 				}
 				return true
 			})
@@ -720,17 +735,21 @@ ScanLoop:
 				if !candidates.marked[ruleIndex] {
 					continue
 				}
+				candidates.marked[ruleIndex] = false
 				select {
 				case <-ctx.Done():
 					clear(candidates.marked)
+					for i := range candidates.spans {
+						candidates.spans[i] = candidates.spans[i][:0]
+					}
 					d.candidatePool.Put(candidates)
 					break ScanLoop
 				default:
 					rule := d.Config.Rules[ruleID]
-					findings = append(findings, d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings)...)
+					findings = append(findings, d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings, candidates.spans[ruleIndex])...)
+					candidates.spans[ruleIndex] = candidates.spans[ruleIndex][:0]
 				}
 			}
-			clear(candidates.marked)
 			d.candidatePool.Put(candidates)
 
 			// increment the depth by 1 as we start our decoding pass
@@ -757,13 +776,14 @@ func (d *Detector) detectFragmentWithRuleTimed(fragment sources.Fragment,
 	currentRaw string,
 	r config.Rule,
 	encodedSegments []*codec.EncodedSegment,
-	priorFindings []report.Finding) []report.Finding {
+	priorFindings []report.Finding,
+	keywordSpans []searchSpan) []report.Finding {
 	if d.RuleTimings == nil {
-		return d.detectFragmentWithRule(fragment, currentRaw, r, encodedSegments, priorFindings)
+		return d.detectFragmentWithRule(fragment, currentRaw, r, encodedSegments, priorFindings, keywordSpans)
 	}
 
 	start := time.Now()
-	findings := d.detectFragmentWithRule(fragment, currentRaw, r, encodedSegments, priorFindings)
+	findings := d.detectFragmentWithRule(fragment, currentRaw, r, encodedSegments, priorFindings, keywordSpans)
 	d.RuleTimings.Record(r.RuleID, time.Since(start))
 	return findings
 }
@@ -790,12 +810,39 @@ func orderedRulesBySpecificity(cfg *config.Config) []string {
 	return ruleIDs
 }
 
+func findRuleMatches(raw string, r config.Rule, spans []searchSpan) [][]int {
+	if spans == nil {
+		return r.Regex.FindAllStringIndex(raw, -1)
+	}
+	if len(spans) == 0 {
+		return nil
+	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+	merged := spans[:0]
+	for _, span := range spans {
+		if len(merged) > 0 && span.start <= merged[len(merged)-1].end {
+			merged[len(merged)-1].end = max(merged[len(merged)-1].end, span.end)
+			continue
+		}
+		merged = append(merged, span)
+	}
+
+	var matches [][]int
+	for _, span := range merged {
+		for _, match := range r.Regex.FindAllStringIndex(raw[span.start:span.end], -1) {
+			matches = append(matches, []int{match[0] + span.start, match[1] + span.start})
+		}
+	}
+	return matches
+}
+
 // detectFragmentWithRule scans the given fragment for the given rule and returns a list of findings
 func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 	currentRaw string,
 	r config.Rule,
 	encodedSegments []*codec.EncodedSegment,
-	priorFindings []report.Finding) []report.Finding {
+	priorFindings []report.Finding,
+	keywordSpans []searchSpan) []report.Finding {
 	var (
 		findings []report.Finding
 		logger   = fragment.Logger().With().Str("rule_id", r.RuleID).Logger()
@@ -825,7 +872,7 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		return findings
 	}
 
-	matches := r.Regex.FindAllStringIndex(currentRaw, -1)
+	matches := findRuleMatches(currentRaw, r, keywordSpans)
 	if len(matches) == 0 {
 		return findings
 	}
@@ -1055,7 +1102,7 @@ func (d *Detector) processRequiredRules(fragment sources.Fragment, currentRaw st
 		inheritedFragment.InheritedFromFinding = true
 
 		// Call detectRule once for each required rule
-		requiredFindings := d.detectFragmentWithRuleTimed(inheritedFragment, currentRaw, rule, encodedSegments, nil)
+		requiredFindings := d.detectFragmentWithRuleTimed(inheritedFragment, currentRaw, rule, encodedSegments, nil, nil)
 		allRequiredFindings[requiredRule.RuleID] = requiredFindings
 
 		logger.Debug().

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -90,6 +90,61 @@ func TestCandidateBitmap(t *testing.T) {
 	require.Equal(t, []string{"high", "always"}, findingRuleIDs(d.DetectString("alias HIGHSECRET ALWAYSSECRET")))
 }
 
+func TestInferredCandidateRegions(t *testing.T) {
+	scoped := config.Rule{
+		RuleID:      "scoped",
+		Specificity: 20,
+		Keywords:    []string{"key", "token"},
+		Regex:       regexp.MustCompile(`(?i:key)=([A-Z]{4})`),
+		SecretGroup: 1,
+	}
+	unscoped := config.Rule{
+		RuleID:      "unscoped",
+		Specificity: 10,
+		Keywords:    []string{"open"},
+		Regex:       regexp.MustCompile(`open.*(ZZZZ)`),
+		SecretGroup: 1,
+	}
+	cfg := &config.Config{
+		Rules:    map[string]config.Rule{scoped.RuleID: scoped, unscoped.RuleID: unscoped},
+		Keywords: map[string]struct{}{"key": {}, "token": {}, "open": {}},
+		KeywordToRules: map[string][]string{
+			"key": {scoped.RuleID}, "token": {scoped.RuleID}, "open": {unscoped.RuleID},
+		},
+	}
+	d := NewDetector(cfg)
+	require.Positive(t, d.ruleSearchScopes[0])
+	require.Zero(t, d.ruleSearchScopes[1])
+
+	raw := "KEY=AAAA\n" + strings.Repeat("x", 100) + " token \nkey=BBBB\nopen distant ZZZZ"
+	findings := d.DetectString(raw)
+	require.Equal(t, []string{"scoped", "scoped", "unscoped"}, findingRuleIDs(findings))
+	require.Equal(t, []string{"AAAA", "BBBB", "ZZZZ"}, []string{findings[0].Secret, findings[1].Secret, findings[2].Secret})
+	require.Equal(t, []int{0, 2, 3}, []int{findings[0].StartLine, findings[1].StartLine, findings[2].StartLine})
+}
+
+func TestFindRuleMatchesMergesAndOffsets(t *testing.T) {
+	raw := "value=0000 token=1111 value=2222"
+	rule := config.Rule{Regex: regexp.MustCompile(`(?:token|value)=\d{4}`)}
+	full := rule.Regex.FindAllStringIndex(raw, -1)
+	require.Equal(t, full, findRuleMatches(raw, rule, nil))
+	require.Equal(t, full, findRuleMatches(raw, rule, []searchSpan{{start: 0, end: 24}, {start: 12, end: len(raw)}}))
+
+	start := strings.Index(raw, "token")
+	require.Equal(t, [][]int{{start, start + len("token=1111")}}, findRuleMatches(raw, rule, []searchSpan{{start: start, end: start + len("token=1111")}}))
+}
+
+func TestFindRuleMatchesPreservesAnchorsAndBoundaries(t *testing.T) {
+	for _, pattern := range []string{`^token=1234`, `token=1234$`, `\btoken=1234\b`} {
+		rule := config.Rule{Regex: regexp.MustCompile(pattern)}
+		for _, raw := range []string{"token=1234", strings.Repeat("x", 30) + " token=1234 " + strings.Repeat("y", 30)} {
+			start := strings.Index(raw, "token")
+			span := searchSpan{start: max(0, start-10), end: min(len(raw), start+len("token")+10)}
+			require.Equal(t, rule.Regex.FindAllStringIndex(raw, -1), findRuleMatches(raw, rule, []searchSpan{span}))
+		}
+	}
+}
+
 func findingRuleIDs(findings []report.Finding) []string {
 	ids := make([]string, len(findings))
 	for i := range findings {
@@ -2674,7 +2729,7 @@ let password = 'Summer2024!';`
 			f := tc.fragment
 			f.Raw = raw
 
-			actual := d.detectFragmentWithRule(f, raw, rule, []*codec.EncodedSegment{}, nil)
+			actual := d.detectFragmentWithRule(f, raw, rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, tc.expected, actual)
 		})
 	}
@@ -2834,7 +2889,7 @@ func TestWindowsFileSeparator_RulePath(t *testing.T) {
 	require.NoError(t, err)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			actual := d.detectFragmentWithRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{}, nil)
+			actual := d.detectFragmentWithRule(test.fragment, test.fragment.Raw, test.rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, test.expected, actual)
 		})
 	}
@@ -3062,7 +3117,7 @@ func TestWindowsFileSeparator_RuleAllowlistPaths(t *testing.T) {
 			require.NoError(t, cfg.CompileFilters(nil))
 			rule := cfg.Rules[test.rule.RuleID]
 
-			actual := d.detectFragmentWithRule(test.fragment, test.fragment.Raw, rule, []*codec.EncodedSegment{}, nil)
+			actual := d.detectFragmentWithRule(test.fragment, test.fragment.Raw, rule, []*codec.EncodedSegment{}, nil, nil)
 			compare(t, test.expected, actual)
 		})
 	}

--- a/detect/search_scope.go
+++ b/detect/search_scope.go
@@ -1,0 +1,270 @@
+package detect
+
+import (
+	"math"
+	"regexp/syntax"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/betterleaks/betterleaks/config"
+)
+
+const (
+	maxExactVariants = 4096
+	maxExactBytes    = 64
+)
+
+// inferKeywordScope returns a conservative byte radius around keyword matches.
+// Zero keeps full-fragment evaluation.
+func inferKeywordScope(rule config.Rule) int {
+	if rule.Regex == nil || len(rule.Keywords) == 0 {
+		return 0
+	}
+	re, err := syntax.Parse(rule.Regex.String(), syntax.Perl)
+	if err != nil || !requiresKeyword(re, rule.Keywords) {
+		return 0
+	}
+	maxLen, finite := maxRegexBytes(re)
+	if !finite || maxLen == 0 {
+		return 0
+	}
+	return maxLen
+}
+
+func requiresKeyword(re *syntax.Regexp, keywords []string) bool {
+	switch re.Op {
+	case syntax.OpLiteral:
+		return containsKeyword(strings.ToLower(string(re.Rune)), keywords)
+	case syntax.OpCapture:
+		return requiresKeyword(re.Sub[0], keywords)
+	case syntax.OpConcat:
+		variants := []string{""}
+		for _, sub := range re.Sub {
+			if requiresKeyword(sub, keywords) {
+				return true
+			}
+			part, ok := exactStrings(sub)
+			if !ok {
+				variants = []string{""}
+				continue
+			}
+			variants, ok = combineStrings(variants, part)
+			if !ok {
+				variants = []string{""}
+				continue
+			}
+			allContain := true
+			for _, variant := range variants {
+				if !containsKeyword(strings.ToLower(variant), keywords) {
+					allContain = false
+					break
+				}
+			}
+			if allContain {
+				return true
+			}
+		}
+		return false
+	case syntax.OpAlternate:
+		for _, sub := range re.Sub {
+			if !requiresKeyword(sub, keywords) {
+				return false
+			}
+		}
+		return len(re.Sub) > 0
+	case syntax.OpPlus:
+		return requiresKeyword(re.Sub[0], keywords)
+	case syntax.OpRepeat:
+		if re.Min > 0 {
+			return requiresKeyword(re.Sub[0], keywords)
+		}
+	}
+
+	variants, ok := exactStrings(re)
+	if !ok || len(variants) == 0 {
+		return false
+	}
+	for _, variant := range variants {
+		if !containsKeyword(strings.ToLower(variant), keywords) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsKeyword(s string, keywords []string) bool {
+	for _, keyword := range keywords {
+		if strings.Contains(s, strings.ToLower(keyword)) {
+			return true
+		}
+	}
+	return false
+}
+
+func maxRegexBytes(re *syntax.Regexp) (int, bool) {
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpBeginLine, syntax.OpEndLine,
+		syntax.OpBeginText, syntax.OpEndText, syntax.OpWordBoundary,
+		syntax.OpNoWordBoundary:
+		return 0, true
+	case syntax.OpLiteral:
+		total := 0
+		for _, r := range re.Rune {
+			n := maxFoldedRuneBytes(r, re.Flags&syntax.FoldCase != 0)
+			if n > math.MaxInt-total {
+				return 0, false
+			}
+			total += n
+		}
+		return total, true
+	case syntax.OpCharClass:
+		maxLen := 1
+		for i := 1; i < len(re.Rune); i += 2 {
+			maxLen = max(maxLen, utf8.RuneLen(re.Rune[i]))
+		}
+		return maxLen, true
+	case syntax.OpAnyCharNotNL, syntax.OpAnyChar:
+		return utf8.UTFMax, true
+	case syntax.OpCapture:
+		return maxRegexBytes(re.Sub[0])
+	case syntax.OpConcat:
+		total := 0
+		for _, sub := range re.Sub {
+			n, finite := maxRegexBytes(sub)
+			if !finite || n > math.MaxInt-total {
+				return 0, false
+			}
+			total += n
+		}
+		return total, true
+	case syntax.OpAlternate:
+		longest := 0
+		for _, sub := range re.Sub {
+			n, finite := maxRegexBytes(sub)
+			if !finite {
+				return 0, false
+			}
+			longest = max(longest, n)
+		}
+		return longest, true
+	case syntax.OpQuest:
+		return maxRegexBytes(re.Sub[0])
+	case syntax.OpRepeat:
+		if re.Max < 0 {
+			return 0, false
+		}
+		n, finite := maxRegexBytes(re.Sub[0])
+		if !finite || (n > 0 && re.Max > math.MaxInt/n) {
+			return 0, false
+		}
+		return n * re.Max, true
+	case syntax.OpStar, syntax.OpPlus:
+		return 0, false
+	default:
+		return 0, false
+	}
+}
+
+func maxFoldedRuneBytes(r rune, folded bool) int {
+	maxLen := max(utf8.RuneLen(r), 1)
+	if !folded {
+		return maxLen
+	}
+	for next := unicode.SimpleFold(r); next != r; next = unicode.SimpleFold(next) {
+		maxLen = max(maxLen, utf8.RuneLen(next))
+	}
+	return maxLen
+}
+
+func exactStrings(re *syntax.Regexp) ([]string, bool) {
+	switch re.Op {
+	case syntax.OpEmptyMatch, syntax.OpBeginLine, syntax.OpEndLine,
+		syntax.OpBeginText, syntax.OpEndText, syntax.OpWordBoundary,
+		syntax.OpNoWordBoundary:
+		return []string{""}, true
+	case syntax.OpLiteral:
+		literal := string(re.Rune)
+		return []string{literal}, len(literal) <= maxExactBytes
+	case syntax.OpCharClass:
+		var out []string
+		for i := 0; i < len(re.Rune); i += 2 {
+			lo, hi := re.Rune[i], re.Rune[i+1]
+			if int64(hi)-int64(lo)+1 > int64(maxExactVariants-len(out)) {
+				return nil, false
+			}
+			for r := lo; ; r++ {
+				out = append(out, string(r))
+				if r == hi {
+					break
+				}
+			}
+		}
+		return out, true
+	case syntax.OpCapture:
+		return exactStrings(re.Sub[0])
+	case syntax.OpConcat:
+		out := []string{""}
+		for _, sub := range re.Sub {
+			part, ok := exactStrings(sub)
+			if !ok {
+				return nil, false
+			}
+			out, ok = combineStrings(out, part)
+			if !ok {
+				return nil, false
+			}
+		}
+		return out, true
+	case syntax.OpAlternate:
+		var out []string
+		for _, sub := range re.Sub {
+			part, ok := exactStrings(sub)
+			if !ok || len(out)+len(part) > maxExactVariants {
+				return nil, false
+			}
+			out = append(out, part...)
+		}
+		return out, true
+	case syntax.OpQuest:
+		part, ok := exactStrings(re.Sub[0])
+		if !ok || len(part)+1 > maxExactVariants {
+			return nil, false
+		}
+		return append([]string{""}, part...), true
+	case syntax.OpRepeat:
+		if re.Min != re.Max || re.Max < 0 {
+			return nil, false
+		}
+		part, ok := exactStrings(re.Sub[0])
+		if !ok {
+			return nil, false
+		}
+		out := []string{""}
+		for range re.Max {
+			out, ok = combineStrings(out, part)
+			if !ok {
+				return nil, false
+			}
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func combineStrings(left, right []string) ([]string, bool) {
+	if len(left) == 0 || len(right) == 0 || len(left) > maxExactVariants/len(right) {
+		return nil, false
+	}
+	out := make([]string, 0, len(left)*len(right))
+	for _, a := range left {
+		for _, b := range right {
+			if len(a)+len(b) > maxExactBytes {
+				return nil, false
+			}
+			out = append(out, a+b)
+		}
+	}
+	return out, true
+}

--- a/detect/search_scope_test.go
+++ b/detect/search_scope_test.go
@@ -1,0 +1,69 @@
+package detect
+
+import (
+	"math"
+	"regexp/syntax"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/regexp"
+)
+
+func TestInferKeywordScope(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		pattern  string
+		keywords []string
+		want     int
+	}{
+		{"bounded required keyword", `token=.{10}`, []string{"token"}, 46},
+		{"keyword assembled across nodes", `passw(?:or)?d=.{2}`, []string{"passwd", "password"}, 17},
+		{"keyword-free alternation branch", `(?:token|username)=.{10}`, []string{"token"}, 0},
+		{"optional keyword", `(?:token)?value`, []string{"token"}, 0},
+		{"unbounded expression", `token=.+`, []string{"token"}, 0},
+		{"bounded repetition", `token[0-9]{2,4}`, []string{"token"}, 9},
+		{"excessive bounded repetition", `token(?:ab){1000}`, []string{"token"}, 2005},
+		{"unicode case-folded literal", `(?i:key)`, []string{"key"}, 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			rule := config.Rule{Regex: regexp.MustCompile(test.pattern), Keywords: test.keywords}
+			require.Equal(t, test.want, inferKeywordScope(rule))
+		})
+	}
+}
+
+func TestScopeInferenceLimits(t *testing.T) {
+	choice := &syntax.Regexp{Op: syntax.OpCharClass, Rune: []rune{'a', 'b'}}
+	concat := &syntax.Regexp{Op: syntax.OpConcat, Sub: make([]*syntax.Regexp, 13)}
+	for i := range concat.Sub {
+		concat.Sub[i] = choice
+	}
+	_, exact := exactStrings(concat)
+	require.False(t, exact)
+
+	repeat := &syntax.Regexp{
+		Op:  syntax.OpRepeat,
+		Min: 1,
+		Max: math.MaxInt,
+		Sub: []*syntax.Regexp{{Op: syntax.OpLiteral, Rune: []rune("ab")}},
+	}
+	_, finite := maxRegexBytes(repeat)
+	require.False(t, finite)
+}
+
+func TestDefaultScopeInventory(t *testing.T) {
+	cfg, err := config.Default()
+	require.NoError(t, err)
+	require.Equal(t, 537, inferKeywordScope(cfg.Rules["generic-api-key"]))
+	require.Zero(t, inferKeywordScope(cfg.Rules["azure-app-configuration-connection-string"]))
+
+	inferred := 0
+	for _, rule := range cfg.Rules {
+		if inferKeywordScope(rule) > 0 {
+			inferred++
+		}
+	}
+	require.GreaterOrEqual(t, inferred, 250)
+}


### PR DESCRIPTION
This pull request introduces a new mechanism for inferring and restricting the scan region for certain secret-detection rules, improving performance and accuracy by limiting the search area to a region around detected keywords when possible. It also adjusts the generic credential regex to better cap match lengths, and adds tests to validate these behaviors.
