### PR TITLE
fix(kubernetes): expand Secret detection range

### DIFF
--- a/cmd/generate/config/rules/kubernetes.go
+++ b/cmd/generate/config/rules/kubernetes.go
@@ -25,7 +25,7 @@ func KubernetesSecret() *config.Rule {
 		Description: "Possible Kubernetes Secret detected, posing a risk of leaking credentials/tokens from your deployments",
 		Regex: regexp.MustCompile(fmt.Sprintf(
 			//language=regexp
-			`(?i)(?:%s(?s:.){0,200}?%s|%s(?s:.){0,200}?%s)`, kindPat, dataPat, dataPat, kindPat)),
+			`(?i)(?:%s(?s:.){0,1000}?%s|%s(?s:.){0,1000}?%s)`, kindPat, dataPat, dataPat, kindPat)),
 		Keywords: []string{
 			"secret",
 		},
@@ -50,6 +50,19 @@ metadata:
 data:
   # base64 encoded password. E.g.: echo -n "mypassword" | base64
   key: bXlwYXNzd29yZA==`,
+		"annotations.yaml": `apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: "testk8smain-vault-secrets"
+  labels:
+    app.k8s.veepee.tech/mutate: mutate
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    vault.security.banzaicloud.io/vault-role: "corporate-sre_community_shared"
+data:
+  MINIO_ROOT_PASSWORD: dmF1bHQ6cHJvZHVjdHMvZGF0YS9pbnQvemF6ZXIvdGVzdGs4c21haW4vY29tbXVuaXR5L3NoYXJlZC9taW5pbyNNSU5JT19ST09UX1BBU1NXT1JE
+  MINIO_ROOT_USER: dmF1bHQ6cHJvZHVjdHMvZGF0YS9pbnQvemF6ZXIvdGVzdGs4c21haW4vY29tbXVuaXR5L3NoYXJlZC9taW5pbyNNSU5JT19ST09UX1VTRVI=`,
 		// The "data"-key is before the identifier "kind: Secret"
 		"before-kubernetes.yaml": `apiVersion: v1
  data:

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -5032,7 +5032,7 @@ keywords = ["kraken"]
 [[rules]]
 id = "kubernetes-secret-yaml"
 description = "Possible Kubernetes Secret detected, posing a risk of leaking credentials/tokens from your deployments"
-regex = '''(?i)(?:\bkind:[ \t]*["']?\bsecret\b["']?(?s:.){0,200}?\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))|\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))(?s:.){0,200}?\bkind:[ \t]*["']?\bsecret\b["']?)'''
+regex = '''(?i)(?:\bkind:[ \t]*["']?\bsecret\b["']?(?s:.){0,1000}?\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))|\bdata:(?s:.){0,100}?\s+([\w.-]+:(?:[ \t]*(?:\||>[-+]?)\s+)?[ \t]*(?:["']?[a-z0-9+/]{10,}={0,3}["']?|\{\{[ \t\w"|$:=,.-]+}}|""|''))(?s:.){0,1000}?\bkind:[ \t]*["']?\bsecret\b["']?)'''
 path = '''(?i)\.ya?ml$'''
 keywords = ["secret"]
 filter = '''


### PR DESCRIPTION
## what and why

- The Kubernetes Secret rule now allows up to 1000 characters between `kind: Secret` and `data:`
- Secrets with larger metadata blocks like labels and annotations are correctly classified as kubernetes-secret-yaml
- Default config was updated to match the generator
- Fixture was added for the annotation-heavy Secret case

## references

- Closes #216 