### PR TITLE
limit sourcegraph regex and keywords

### DIFF
--- a/cmd/generate/config/rules/sourcegraph.go
+++ b/cmd/generate/config/rules/sourcegraph.go
@@ -12,7 +12,17 @@ func SourceGraph() *config.Rule {
 		Description: "Sourcegraph is a code search and navigation engine.",
 		Regex:       utils.GenerateUniqueTokenRegex(`sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}`, true),
 		Keywords:    []string{"sgp_"},
-		Filter:      `entropy(finding["secret"]) <= 3.0`,
+		ValidateExpr: `let r = http.post("https://sourcegraph.com/.api/graphql", {
+    "Authorization": "token " + finding["secret"],
+    "Content-Type": "application/json"
+  }, "{\"query\":\"query ValidateToken { site { id } }\"}"); r.status == 200 && (r.json?.data?.site?.id ?? "") != "" ? {
+    "result": "valid",
+    "site_id": (r.json?.data?.site?.id ?? "")
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)`,
+		Filter: `entropy(finding["secret"]) <= 3.0`,
 	}
 
 	// validate

--- a/cmd/generate/config/rules/sourcegraph.go
+++ b/cmd/generate/config/rules/sourcegraph.go
@@ -10,15 +10,14 @@ func SourceGraph() *config.Rule {
 	r := config.Rule{
 		RuleID:      "sourcegraph-access-token",
 		Description: "Sourcegraph is a code search and navigation engine.",
-		Regex:       utils.GenerateUniqueTokenRegex(`\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40})\b`, true),
-		Keywords:    []string{"sgp_", "sourcegraph"},
+		Regex:       utils.GenerateUniqueTokenRegex(`(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})`, true),
+		Keywords:    []string{"sgp_"},
 		Filter:      `entropy(finding["secret"]) <= 3.0`,
 	}
 
 	// validate
 	tps := []string{
 		`sgp_AaD80dc6E02eCAE1_d3cba16CC0F18fA14A2EFB61CbDFceEBf9fAD16b`,
-		`sourcegraph: 6d2FabeB6ADd229Bc199FabA28fD3efb57dF0bD3`,
 		`sgp_0D697F54cb24238EefB29af05Abf1b505E90950F`,
 		`sgp_local_d7dfFD43cF2503B1da673EB560aAa3e80f16FA42`,
 		`sgp_local_bcD1DA18de0d6476Be0f3BD7Ef9Da4f09b479aE5`,
@@ -28,7 +27,6 @@ func SourceGraph() *config.Rule {
 		`sgp_local_d45b6G86aBb0F2Cee943902dbaDBCFCFDD1dA089`,              // invalid case
 		`sgp_652d9a2e48FC7E!FcDbEA1BC2E2A6CE23cFe7F7D`,                    // invalid character
 		`sgp_78Ad84a5B6e8A2fE5B_4085FB0ccaDDd29DB66Fd7FE9bA2C1cdCE8400CD`, // invalid length
-		`BcAeb6640ad7DAD46AD73687946Ce85047d5C9Bb`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/sourcegraph.go
+++ b/cmd/generate/config/rules/sourcegraph.go
@@ -10,7 +10,7 @@ func SourceGraph() *config.Rule {
 	r := config.Rule{
 		RuleID:      "sourcegraph-access-token",
 		Description: "Sourcegraph is a code search and navigation engine.",
-		Regex:       utils.GenerateUniqueTokenRegex(`(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})`, true),
+		Regex:       utils.GenerateUniqueTokenRegex(`sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}`, true),
 		Keywords:    []string{"sgp_"},
 		Filter:      `entropy(finding["secret"]) <= 3.0`,
 	}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -6501,6 +6501,18 @@ id = "sourcegraph-access-token"
 description = "Sourcegraph is a code search and navigation engine."
 regex = '''(?i)\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["sgp_"]
+validate = '''
+let r = http.post("https://sourcegraph.com/.api/graphql", {
+    "Authorization": "token " + finding["secret"],
+    "Content-Type": "application/json"
+  }, "{\"query\":\"query ValidateToken { site { id } }\"}"); r.status == 200 && (r.json?.data?.site?.id ?? "") != "" ? {
+    "result": "valid",
+    "site_id": (r.json?.data?.site?.id ?? "")
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : validate.unknown(r)
+'''
 filter = '''
 entropy(finding["secret"]) <= 3.0
 '''

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -6499,11 +6499,8 @@ keywords = ["sonar"]
 [[rules]]
 id = "sourcegraph-access-token"
 description = "Sourcegraph is a code search and navigation engine."
-regex = '''(?i)\b(\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}|[a-fA-F0-9]{40})\b)(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
-keywords = [
-    "sgp_",
-    "sourcegraph",
-]
+regex = '''(?i)\b((sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}))(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+keywords = ["sgp_"]
 filter = '''
 entropy(finding["secret"]) <= 3.0
 '''

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -6499,7 +6499,7 @@ keywords = ["sonar"]
 [[rules]]
 id = "sourcegraph-access-token"
 description = "Sourcegraph is a code search and navigation engine."
-regex = '''(?i)\b((sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40}))(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+regex = '''(?i)\b(sgp_(?:[a-fA-F0-9]{16}|local)_[a-fA-F0-9]{40}|sgp_[a-fA-F0-9]{40})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 keywords = ["sgp_"]
 filter = '''
 entropy(finding["secret"]) <= 3.0


### PR DESCRIPTION
big time risk for FPs when fragments had `sourcegraph` in them