### PR TITLE
docs: add Go installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ sudo dnf install betterleaks
 # Containers
 docker pull ghcr.io/betterleaks/betterleaks:latest
 
+# Go
+go install github.com/betterleaks/betterleaks@latest
+
 # Source
 git clone https://github.com/betterleaks/betterleaks
 cd betterleaks


### PR DESCRIPTION
## what and why

- Add additional Go install method to documentation
- Provide other ways to install betterleaks