### PR TITLE
fix(sources): don't crash the process on archive/decompress panics

### DIFF
--- a/sources/file.go
+++ b/sources/file.go
@@ -205,6 +205,15 @@ func (s *File) extractorFragments(ctx context.Context, extractor archives.Extrac
 
 // decompressorFragments recursively crawls archives and yields fragments
 func (s *File) decompressorFragments(ctx context.Context, decompressor archives.Decompressor, reader io.Reader, yield FragmentsFunc) {
+	defer func() {
+		if r := recover(); r != nil {
+			logging.Warn().
+				Str("path", s.FullPath()).
+				Str("panic", fmt.Sprint(r)).
+				Msg("skipping compressed file: panic during decompression")
+		}
+	}()
+
 	innerReader, err := decompressor.OpenReader(reader)
 	if err != nil {
 		logging.Warn().Err(err).Str("path", s.FullPath()).Msg("could not read compressed file")

--- a/sources/file.go
+++ b/sources/file.go
@@ -205,7 +205,13 @@ func (s *File) extractorFragments(ctx context.Context, extractor archives.Extrac
 
 // decompressorFragments recursively crawls archives and yields fragments
 func (s *File) decompressorFragments(ctx context.Context, decompressor archives.Decompressor, reader io.Reader, yield FragmentsFunc) {
+	// Declared upfront so that the deferred func can release it even if
+	// decompression panics on malformed content.
+	var innerReader io.ReadCloser
 	defer func() {
+		if innerReader != nil {
+			_ = innerReader.Close()
+		}
 		if r := recover(); r != nil {
 			logging.Warn().
 				Str("path", s.FullPath()).
@@ -225,9 +231,6 @@ func (s *File) decompressorFragments(ctx context.Context, decompressor archives.
 	if err := s.fileFragments(ctx, br, true, yield); err != nil {
 		logging.Warn().Err(err).Str("path", s.FullPath()).Msg("error reading compressed file")
 	}
-
-	_ = innerReader.Close()
-	return
 }
 
 // fileFragments reads the file into fragments to yield.

--- a/sources/file_test.go
+++ b/sources/file_test.go
@@ -1,0 +1,69 @@
+package sources
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// panicReader panics on the first Read, emulating a decompressor that blows up
+// on malformed content after OpenReader already succeeded.
+type panicReader struct {
+	closed bool
+}
+
+func (p *panicReader) Read([]byte) (int, error) {
+	panic("boom during read")
+}
+
+func (p *panicReader) Close() error {
+	p.closed = true
+	return nil
+}
+
+// panicDecompressor is an archives.Decompressor whose reader panics. When
+// panicOnOpen is set, OpenReader itself panics instead.
+type panicDecompressor struct {
+	reader      *panicReader
+	panicOnOpen bool
+}
+
+func (d *panicDecompressor) OpenReader(_ io.Reader) (io.ReadCloser, error) {
+	if d.panicOnOpen {
+		panic("boom during open")
+	}
+	return d.reader, nil
+}
+
+func TestFile_decompressorFragments_recoversAndClosesReader(t *testing.T) {
+	t.Run("panic while reading closes the inner reader", func(t *testing.T) {
+		pr := &panicReader{}
+		s := &File{Path: "evil.lz"}
+
+		require.NotPanics(t, func() {
+			s.decompressorFragments(
+				t.Context(),
+				&panicDecompressor{reader: pr},
+				strings.NewReader("irrelevant"),
+				func(Fragment, error) error { return nil },
+			)
+		})
+
+		require.True(t, pr.closed, "inner reader should be closed after a recovered panic")
+	})
+
+	t.Run("panic inside OpenReader is recovered", func(t *testing.T) {
+		s := &File{Path: "evil.lz"}
+
+		require.NotPanics(t, func() {
+			s.decompressorFragments(
+				t.Context(),
+				&panicDecompressor{panicOnOpen: true},
+				strings.NewReader("irrelevant"),
+				func(Fragment, error) error { return nil },
+			)
+		})
+	})
+}


### PR DESCRIPTION
Fixes #265 

## Summary
- Recover from panics in `extractorFragments` / `decompressorFragments` so one malformed archive or compressed file cannot abort the scan.
- Motivated by truncated `.lz` input that panics in `sorairolake/lzip-go` (`slice bounds out of range`) via `mholt/archives`.

## Test plan
- [x] `betterleaks dir poc` with a 14-byte truncated `evil.lz` warns and exits 0 instead of panicking (exit 2)
- [x] Sibling files in the same directory still get scanned
- [x] Normal archives (e.g. existing `testdata/archives` cases) still behave as before