### PR TITLE
feat: secret revocation via rule-level 'revoke' expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Development is supported by
 | :--- | :--- |
 | **Expr-based filtering** | Write contextual rule filters that evaluate fragment (data chunks) attributes (like git author, commit message, and file path) and finding data to reduce false positives. If you're coming from Gitleaks, think of this feature as a more expressive `[[allowlist]]` system. |
 | **Secrets Validation** | Validate if a detected secret is active by making asynchronous HTTP requests directly from within the rule definition using Expr. |
+| **Secrets Revocation** | Deliberately revoke a live secret at its provider via `betterleaks revoke`, using a rule-level `revoke` expression. Manual and explicit only — never run during a scan. |
 | **Token Efficiency filtering** | Filter out natural language false positives by using BPE tokenization to measure how "rare" or non-human a string is. |
 | **Fast scans** | Achieve fast performance through sane default parallelization settings, ahocorasick keyword filters, and re2. |
 | **New Sources** | Support for sources like GitHub, GitLab, Hugging Face, S3, and more. It's easy to add new sources too!   |
@@ -146,3 +147,40 @@ r.status == 200 && (r.json?.login ?? "") != "" ? {
 Refer to the default [betterleaks config](https://github.com/betterleaks/betterleaks/blob/main/config/betterleaks.toml) for examples and the [config docs](docs/config.md) for more information about the `betterleaks.toml` config. If you're using Betterleaks in production, it is recommended you maintain your own config instead of extending the upstream default config directly. This keeps your rule set stable across Betterleaks upgrades and lets you review new upstream rules before adopting them.
 
 Test out your rules in the [Betterleaks Playground](https://betterleaks.com/playground)
+
+### Revocation
+
+A rule can also define a `revoke` expression, written the same way as `validate`, that deactivates a live secret at its provider (for example, deleting a Buildkite access token via its `DELETE /v2/access-token` endpoint).
+
+```toml
+[[rules]]
+id = "buildkite-user-access-token"
+# ... regex, keywords, validate, etc ...
+
+revoke = '''
+let r = http.delete("https://api.buildkite.com/v2/access-token", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Accept": "application/json"
+  });
+r.status == 204 ? {
+    "result": "revoked"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "token was already invalid or unauthorized"
+  } : revoke.unknown(r)
+'''
+```
+
+Unlike `validate`, `revoke` is **never** run automatically during a scan — it's destructive and irreversible against a real, live credential, so it only ever runs when you explicitly ask for it:
+
+```bash
+betterleaks revoke report.json
+```
+
+This walks the findings in a report file (as produced by `--report-format json`) and, for each one whose rule defines a `revoke` expression, prompts for confirmation before calling it. Findings for rules with no `revoke` expression are reported as unsupported and skipped. Useful flags:
+
+- `--fingerprint <fp>` — only consider the finding with this exact fingerprint, instead of every finding in the report
+- `--dry-run` — print what would be revoked without calling any provider
+- `--yes` — skip the interactive per-finding confirmation prompt (e.g. for CI)
+- `--continue-on-error` — keep going after a revocation fails, instead of stopping
+- `--output <path>` — write an updated copy of the report, with successfully revoked findings marked, to this path

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -178,6 +178,10 @@ func validateConfig(cfg *configpkg.Config) error {
 	if err != nil {
 		return err
 	}
+	revocationRT, err := cfg.CompileRevocation()
+	if err != nil {
+		return err
+	}
 	for _, id := range sortedRuleIDs(cfg) {
 		rule := cfg.Rules[id]
 		if rule.Filter != "" {
@@ -192,6 +196,11 @@ func validateConfig(cfg *configpkg.Config) error {
 		if validationRT != nil && rule.ValidateExpr != "" {
 			if _, err := validationRT.CompileValidation(rule.ValidateExpr); err != nil {
 				return fmt.Errorf("compiling rule %s validation: %w", id, err)
+			}
+		}
+		if revocationRT != nil && rule.RevokeExpr != "" {
+			if _, err := revocationRT.CompileValidation(rule.RevokeExpr); err != nil {
+				return fmt.Errorf("compiling rule %s revocation: %w", id, err)
 			}
 		}
 	}

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/betterleaks/betterleaks/config"
+)
+
+// TestValidateConfig_CatchesBrokenRevokeExpr proves that `betterleaks config
+// check` (which calls validateConfig) rejects a config whose 'revoke'
+// expression has a syntax error, the same way it already rejects a broken
+// 'validate' expression. Without this, a config with a typo'd revoke
+// expression would pass config check clean, and the error would only surface
+// later, mid-revocation, against a real credential.
+func TestValidateConfig_CatchesBrokenRevokeExpr(t *testing.T) {
+	cfg, err := config.ParseTOMLString(`
+[[rules]]
+id = "broken-revoke-rule"
+regex = '''brk_[a-z0-9]{32}'''
+revoke = '''this is not valid expr syntax {{{'''
+`, "inline")
+	if err != nil {
+		t.Fatalf("ParseTOMLString: %v", err)
+	}
+
+	err = validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected validateConfig to reject a broken revoke expression, got nil error")
+	}
+	if !strings.Contains(err.Error(), "broken-revoke-rule") {
+		t.Errorf("error should name the offending rule, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "revocation") {
+		t.Errorf("error should mention revocation, got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsValidRevokeExpr(t *testing.T) {
+	cfg, err := config.ParseTOMLString(`
+[[rules]]
+id = "good-revoke-rule"
+regex = '''grr_[a-z0-9]{32}'''
+revoke = '''{"result": "revoked"}'''
+`, "inline")
+	if err != nil {
+		t.Fatalf("ParseTOMLString: %v", err)
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		t.Errorf("expected a valid revoke expression to pass, got: %v", err)
+	}
+}

--- a/cmd/generate/config/rules/buildkite.go
+++ b/cmd/generate/config/rules/buildkite.go
@@ -18,6 +18,10 @@ func BuildkiteUserAccessToken() *config.Rule {
 			"https://api.buildkite.com/v2/access-token",
 			`(r.body contains "\"scopes\"")`,
 		),
+		RevokeExpr: utils.BearerDeleteRevokeExpr(
+			"https://api.buildkite.com/v2/access-token",
+			204,
+		),
 		Filter: utils.MinEntropy(3.5),
 	}
 

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -52,6 +52,8 @@ tags = [
 skipReport = true{{ end }}
 {{- with $rule.ValidateExpr }}
 validate = {{ tomlExpr . }}{{ end }}
+{{- with $rule.RevokeExpr }}
+revoke = {{ tomlExpr . }}{{ end }}
 {{- with $rule.Filter }}
 filter = {{ tomlExpr . }}{{ end }}
 {{- range $rule.RequiredRules }}{{println}}[[rules.required]]

--- a/cmd/generate/config/utils/expr.go
+++ b/cmd/generate/config/utils/expr.go
@@ -19,3 +19,20 @@ r.status == 200 && (` + successCheck + `) ? {
   } : validate.unknown(r)
 `
 }
+
+// BearerDeleteRevokeExpr builds a revoke expression for providers whose
+// credential revocation is a DELETE request authenticated by the secret
+// itself as a bearer token, succeeding on successStatus.
+func BearerDeleteRevokeExpr(url string, successStatus int) string {
+	return `let r = http.delete("` + url + `", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Accept": "application/json"
+  });
+r.status == ` + fmt.Sprintf("%d", successStatus) + ` ? {
+    "result": "revoked"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "token was already invalid or unauthorized"
+  } : revoke.unknown(r)
+`
+}

--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/betterleaks/betterleaks/internal/validate"
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/report"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+func init() {
+	rootCmd.AddCommand(revokeCmd)
+	revokeCmd.Flags().String("fingerprint", "", "only revoke the finding with this exact fingerprint (default: consider every finding in the report)")
+	revokeCmd.Flags().Bool("yes", false, "revoke without an interactive per-finding confirmation prompt")
+	revokeCmd.Flags().Bool("dry-run", false, "print what would be revoked without calling any provider")
+	revokeCmd.Flags().Bool("continue-on-error", false, "keep going after a revocation fails or errors, instead of stopping")
+	revokeCmd.Flags().String("output", "", "write an updated copy of the report (with revoked findings marked) to this path")
+}
+
+var revokeCmd = &cobra.Command{
+	Use:   "revoke <report-file>",
+	Short: "revoke a live secret at its provider, using a scan report as input",
+	Long: `revoke calls a rule's 'revoke' expression to deactivate a secret at its provider
+(e.g. deleting a Buildkite access token via its DELETE /access-token endpoint).
+
+This is a destructive, irreversible action against a real, live credential.
+It is never run automatically during a scan - it only runs here, against
+findings you already have in a report file, and only for rules whose config
+defines a 'revoke' expression. Findings for rules with no 'revoke' expression
+are skipped and reported as unsupported.
+
+By default you are asked to confirm each revocation individually. Use --yes
+to skip the prompt in a non-interactive context (e.g. CI), and --dry-run to
+see what would happen without revoking anything.`,
+	Args: cobra.ExactArgs(1),
+	Run:  runRevoke,
+}
+
+// revocationOutcome classifies the result of attempting to revoke a single finding.
+type revocationOutcome string
+
+const (
+	outcomeRevoked     revocationOutcome = "revoked"
+	outcomeUnsupported revocationOutcome = "unsupported" // rule has no revoke expression
+	outcomeSkipped     revocationOutcome = "skipped"     // user declined confirmation
+	outcomeDryRun      revocationOutcome = "dry-run"
+	outcomeFailed      revocationOutcome = "failed" // eval error, compile error, or non-"revoked" result
+)
+
+// revocationAttempt is the pure result of evaluating one finding's revoke
+// expression - no I/O, no process exit, so it's directly unit-testable.
+type revocationAttempt struct {
+	Outcome revocationOutcome
+	Reason  string
+	Err     error
+}
+
+// revokeOne evaluates a single finding's rule-level revoke expression and
+// reports what happened. It does not prompt, print, or exit - callers
+// (the CLI command, or a test) decide what to do with the result.
+//
+// If the rule has no RevokeExpr, the outcome is outcomeUnsupported.
+// The compiled program is cached on the rule (via SetRevocationProgram) so
+// repeated calls for the same rule ID only compile once.
+func revokeOne(ctx context.Context, cfg *config.Config, runtime *exprruntime.Runtime, f *report.Finding) revocationAttempt {
+	rule, ok := cfg.Rules[f.RuleID]
+	if !ok || rule.RevokeExpr == "" {
+		return revocationAttempt{Outcome: outcomeUnsupported}
+	}
+
+	prg := rule.RevocationProgram()
+	if prg == nil {
+		var err error
+		prg, err = runtime.CompileValidation(rule.RevokeExpr)
+		if err != nil {
+			return revocationAttempt{Outcome: outcomeFailed, Err: fmt.Errorf("compiling revoke expression for rule %s: %w", f.RuleID, err)}
+		}
+		rule.SetRevocationProgram(prg)
+		cfg.Rules[f.RuleID] = rule
+	}
+
+	result, evalErr := runtime.EvalValidation(ctx, prg, f.ToExprMap(), f.CaptureGroups, f.Attributes, exprruntime.EvalOptions{})
+	if evalErr != nil {
+		return revocationAttempt{Outcome: outcomeFailed, Err: fmt.Errorf("evaluating revoke expression: %w", evalErr)}
+	}
+
+	parsed := validate.ParseResult(result.Value)
+	if parsed.Status == report.ValidationStatusRevoked {
+		return revocationAttempt{Outcome: outcomeRevoked, Reason: parsed.Reason}
+	}
+	reason := parsed.Reason
+	if reason == "" {
+		reason = fmt.Sprintf("revoke expression returned status %q instead of \"revoked\"", parsed.Status)
+	}
+	return revocationAttempt{Outcome: outcomeFailed, Reason: reason}
+}
+
+func runRevoke(cmd *cobra.Command, args []string) {
+	reportPath := args[0]
+	fingerprint := mustGetStringFlag(cmd, "fingerprint")
+	skipConfirm := mustGetBoolFlag(cmd, "yes")
+	dryRun := mustGetBoolFlag(cmd, "dry-run")
+	continueOnError := mustGetBoolFlag(cmd, "continue-on-error")
+	outputPath := mustGetStringFlag(cmd, "output")
+
+	source := "."
+	initConfig(source)
+	cfg := Config(cmd)
+
+	findings, err := loadFindingsReport(reportPath)
+	if err != nil {
+		logging.Fatal().Err(err).Str("path", reportPath).Msg("failed to load report")
+	}
+	if fingerprint != "" {
+		filtered := findings[:0]
+		for _, f := range findings {
+			if f.Fingerprint == fingerprint {
+				filtered = append(filtered, f)
+			}
+		}
+		findings = filtered
+		if len(findings) == 0 {
+			logging.Fatal().Str("fingerprint", fingerprint).Msg("no finding in the report matches this fingerprint")
+		}
+	}
+	if len(findings) == 0 {
+		logging.Info().Msg("report contains no findings, nothing to revoke")
+		return
+	}
+
+	runtime, err := cfg.CompileRevocation()
+	if err != nil {
+		logging.Fatal().Err(err).Msg("failed to compile revocation expressions")
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	counts := map[revocationOutcome]int{}
+
+	for i := range findings {
+		f := &findings[i]
+
+		rule, ok := cfg.Rules[f.RuleID]
+		if !ok || rule.RevokeExpr == "" {
+			fmt.Printf("[skip] %s: rule %q has no 'revoke' expression configured\n", shortFingerprint(f.Fingerprint), f.RuleID)
+			counts[outcomeUnsupported]++
+			continue
+		}
+
+		fmt.Printf("\nRuleID:      %s\n", f.RuleID)
+		fmt.Printf("Path:        %s\n", f.Attributes[sources.AttrPath])
+		fmt.Printf("Fingerprint: %s\n", f.Fingerprint)
+
+		if dryRun {
+			fmt.Println("[dry-run] would attempt revocation here")
+			counts[outcomeDryRun]++
+			continue
+		}
+
+		if !skipConfirm {
+			fmt.Print("Revoke this secret now? This cannot be undone. [y/N]: ")
+			line, _ := reader.ReadString('\n')
+			answer := strings.ToLower(strings.TrimSpace(line))
+			if answer != "y" && answer != "yes" {
+				fmt.Println("[skip] not confirmed")
+				counts[outcomeSkipped]++
+				continue
+			}
+		}
+
+		attempt := revokeOne(context.Background(), cfg, runtime, f)
+		counts[attempt.Outcome]++
+
+		switch attempt.Outcome {
+		case outcomeRevoked:
+			fmt.Printf("[revoked] %s\n", nonEmptyOr(attempt.Reason, "provider confirmed revocation"))
+			f.ValidationStatus = report.ValidationStatusRevoked
+			f.ValidationReason = attempt.Reason
+		case outcomeFailed:
+			if attempt.Err != nil {
+				fmt.Printf("[error] %v\n", attempt.Err)
+			} else {
+				fmt.Printf("[failed] %s\n", attempt.Reason)
+			}
+			if !continueOnError {
+				fmt.Printf("\nrevoked=%d unsupported=%d skipped=%d failed=%d\n",
+					counts[outcomeRevoked], counts[outcomeUnsupported], counts[outcomeSkipped], counts[outcomeFailed])
+				os.Exit(1)
+			}
+		}
+	}
+
+	fmt.Printf("\nrevoked=%d unsupported=%d skipped=%d failed=%d\n",
+		counts[outcomeRevoked], counts[outcomeUnsupported], counts[outcomeSkipped], counts[outcomeFailed])
+
+	if outputPath != "" && !dryRun {
+		out, err := json.MarshalIndent(findings, "", " ")
+		if err != nil {
+			logging.Fatal().Err(err).Msg("failed to marshal updated report")
+		}
+		if err := os.WriteFile(outputPath, out, 0o644); err != nil {
+			logging.Fatal().Err(err).Str("path", outputPath).Msg("failed to write updated report")
+		}
+		logging.Info().Str("path", outputPath).Msg("wrote updated report")
+	}
+}
+
+// loadFindingsReport reads a JSON report (as produced by --report-format json)
+// into a slice of findings, mirroring detect.LoadBaseline's approach to
+// reading a prior report back in.
+func loadFindingsReport(path string) ([]report.Finding, error) {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading report file: %w", err)
+	}
+	var findings []report.Finding
+	if err := json.Unmarshal(bytes, &findings); err != nil {
+		return nil, fmt.Errorf("parsing report file as JSON findings: %w", err)
+	}
+	return findings, nil
+}
+
+func shortFingerprint(fp string) string {
+	if len(fp) <= 12 {
+		return fp
+	}
+	return fp[:12] + "…"
+}
+
+func nonEmptyOr(s, fallback string) string {
+	if s == "" {
+		return fallback
+	}
+	return s
+}

--- a/cmd/revoke.go
+++ b/cmd/revoke.go
@@ -117,25 +117,35 @@ func runRevoke(cmd *cobra.Command, args []string) {
 	initConfig(source)
 	cfg := Config(cmd)
 
-	findings, err := loadFindingsReport(reportPath)
+	allFindings, err := loadFindingsReport(reportPath)
 	if err != nil {
 		logging.Fatal().Err(err).Str("path", reportPath).Msg("failed to load report")
 	}
-	if fingerprint != "" {
-		filtered := findings[:0]
-		for _, f := range findings {
-			if f.Fingerprint == fingerprint {
-				filtered = append(filtered, f)
-			}
-		}
-		findings = filtered
-		if len(findings) == 0 {
-			logging.Fatal().Str("fingerprint", fingerprint).Msg("no finding in the report matches this fingerprint")
-		}
-	}
-	if len(findings) == 0 {
+	if len(allFindings) == 0 {
 		logging.Info().Msg("report contains no findings, nothing to revoke")
 		return
+	}
+
+	// targets is the subset of allFindings to actually attempt revocation
+	// against. allFindings itself is never filtered down - --output must
+	// always write back the complete original set (with only the attempted
+	// findings' statuses updated), otherwise every finding excluded by
+	// --fingerprint would silently disappear from the written report and
+	// from downstream baseline processing.
+	var targets []*report.Finding
+	if fingerprint != "" {
+		for i := range allFindings {
+			if allFindings[i].Fingerprint == fingerprint {
+				targets = append(targets, &allFindings[i])
+			}
+		}
+		if len(targets) == 0 {
+			logging.Fatal().Str("fingerprint", fingerprint).Msg("no finding in the report matches this fingerprint")
+		}
+	} else {
+		for i := range allFindings {
+			targets = append(targets, &allFindings[i])
+		}
 	}
 
 	runtime, err := cfg.CompileRevocation()
@@ -146,8 +156,23 @@ func runRevoke(cmd *cobra.Command, args []string) {
 	reader := bufio.NewReader(os.Stdin)
 	counts := map[revocationOutcome]int{}
 
-	for i := range findings {
-		f := &findings[i]
+	writeOutput := func() {
+		if outputPath == "" || dryRun {
+			return
+		}
+		out, err := json.MarshalIndent(allFindings, "", " ")
+		if err != nil {
+			logging.Fatal().Err(err).Msg("failed to marshal updated report")
+		}
+		// 0o600: this file can contain revoked/skipped/failed secrets in
+		// plaintext, so it must not be group- or world-readable.
+		if err := os.WriteFile(outputPath, out, 0o600); err != nil {
+			logging.Fatal().Err(err).Str("path", outputPath).Msg("failed to write updated report")
+		}
+		logging.Info().Str("path", outputPath).Msg("wrote updated report")
+	}
+
+	for _, f := range targets {
 
 		rule, ok := cfg.Rules[f.RuleID]
 		if !ok || rule.RevokeExpr == "" {
@@ -194,6 +219,10 @@ func runRevoke(cmd *cobra.Command, args []string) {
 			if !continueOnError {
 				fmt.Printf("\nrevoked=%d unsupported=%d skipped=%d failed=%d\n",
 					counts[outcomeRevoked], counts[outcomeUnsupported], counts[outcomeSkipped], counts[outcomeFailed])
+				// Write back whatever was already revoked before stopping -
+				// otherwise a real, successful, irreversible revocation would
+				// go unrecorded in the report just because a later finding failed.
+				writeOutput()
 				os.Exit(1)
 			}
 		}
@@ -202,16 +231,7 @@ func runRevoke(cmd *cobra.Command, args []string) {
 	fmt.Printf("\nrevoked=%d unsupported=%d skipped=%d failed=%d\n",
 		counts[outcomeRevoked], counts[outcomeUnsupported], counts[outcomeSkipped], counts[outcomeFailed])
 
-	if outputPath != "" && !dryRun {
-		out, err := json.MarshalIndent(findings, "", " ")
-		if err != nil {
-			logging.Fatal().Err(err).Msg("failed to marshal updated report")
-		}
-		if err := os.WriteFile(outputPath, out, 0o644); err != nil {
-			logging.Fatal().Err(err).Str("path", outputPath).Msg("failed to write updated report")
-		}
-		logging.Info().Str("path", outputPath).Msg("wrote updated report")
-	}
+	writeOutput()
 }
 
 // loadFindingsReport reads a JSON report (as produced by --report-format json)

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -183,5 +184,229 @@ func TestNonEmptyOr(t *testing.T) {
 	}
 	if got := nonEmptyOr("value", "fallback"); got != "value" {
 		t.Errorf("got %q, want value", got)
+	}
+}
+
+// setRevokeFlags resets revokeCmd's flags to known values before each
+// runRevoke invocation, since the command is a shared package-level var.
+// It also merges rootCmd's persistent flags (e.g. "no-banner") into its
+// local flag set, mirroring what cobra normally does inside Execute() -
+// initConfig reads "no-banner" via rootCmd.Flags(), which is otherwise
+// unpopulated when a Run function is invoked directly, bypassing Execute().
+func setRevokeFlags(t *testing.T, fingerprint string, yes, dryRun, continueOnError bool, output string) {
+	t.Helper()
+	if err := rootCmd.ParseFlags(nil); err != nil {
+		t.Fatalf("merging root flags: %v", err)
+	}
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("setting flag: %v", err)
+		}
+	}
+	must(revokeCmd.Flags().Set("fingerprint", fingerprint))
+	must(revokeCmd.Flags().Set("yes", fmtBool(yes)))
+	must(revokeCmd.Flags().Set("dry-run", fmtBool(dryRun)))
+	must(revokeCmd.Flags().Set("continue-on-error", fmtBool(continueOnError)))
+	must(revokeCmd.Flags().Set("output", output))
+}
+
+func fmtBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// TestRunRevoke_FingerprintFilterPreservesFullReportInOutput proves that
+// filtering by --fingerprint no longer truncates the --output report to just
+// the matched finding: every other finding from the original report must
+// still be present, untouched, in the written output.
+func TestRunRevoke_FingerprintFilterPreservesFullReportInOutput(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	revokeExpr := `let r = http.delete("` + srv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error"}`
+	t.Setenv("BETTERLEAKS_CONFIG_TOML", `
+[[rules]]
+id = "revocable-rule"
+regex = '''rr_[a-z0-9]{32}'''
+revoke = '''`+revokeExpr+`'''
+`)
+
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	outputPath := filepath.Join(dir, "out.json")
+	original := []report.Finding{
+		{RuleID: "revocable-rule", Secret: "rr_target_secret", Fingerprint: "target-fp"},
+		{RuleID: "revocable-rule", Secret: "rr_other_secret_1", Fingerprint: "other-fp-1"},
+		{RuleID: "revocable-rule", Secret: "rr_other_secret_2", Fingerprint: "other-fp-2"},
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(reportPath, data, 0o600); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+
+	setRevokeFlags(t, "target-fp", true, false, false, outputPath)
+	initConfig(".")
+	runRevoke(revokeCmd, []string{reportPath})
+
+	out, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	var got []report.Finding
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+
+	if len(got) != len(original) {
+		t.Fatalf("output has %d findings, want %d (all of them, not just the fingerprint-matched one)", len(got), len(original))
+	}
+	byFP := map[string]report.Finding{}
+	for _, f := range got {
+		byFP[f.Fingerprint] = f
+	}
+	if byFP["target-fp"].ValidationStatus != report.ValidationStatusRevoked {
+		t.Errorf("targeted finding should be marked revoked, got status %q", byFP["target-fp"].ValidationStatus)
+	}
+	if byFP["other-fp-1"].ValidationStatus == report.ValidationStatusRevoked {
+		t.Errorf("untargeted finding other-fp-1 should not have been touched")
+	}
+	if byFP["other-fp-2"].ValidationStatus == report.ValidationStatusRevoked {
+		t.Errorf("untargeted finding other-fp-2 should not have been touched")
+	}
+}
+
+// TestRunRevoke_OutputFileIsNotWorldReadable proves the --output report,
+// which can contain live/revoked secrets in plaintext, is written with a
+// restrictive mode rather than the world/group-readable 0644.
+func TestRunRevoke_OutputFileIsNotWorldReadable(t *testing.T) {
+	if isWindows() {
+		t.Skip("POSIX file mode bits are not meaningful on Windows")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	revokeExpr := `let r = http.delete("` + srv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error"}`
+	t.Setenv("BETTERLEAKS_CONFIG_TOML", `
+[[rules]]
+id = "revocable-rule"
+regex = '''rr_[a-z0-9]{32}'''
+revoke = '''`+revokeExpr+`'''
+`)
+
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	outputPath := filepath.Join(dir, "out.json")
+	data, _ := json.Marshal([]report.Finding{{RuleID: "revocable-rule", Secret: "rr_secret", Fingerprint: "fp"}})
+	if err := os.WriteFile(reportPath, data, 0o600); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+
+	setRevokeFlags(t, "", true, false, false, outputPath)
+	initConfig(".")
+	runRevoke(revokeCmd, []string{reportPath})
+
+	info, err := os.Stat(outputPath)
+	if err != nil {
+		t.Fatalf("stat output: %v", err)
+	}
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		t.Errorf("output file mode = %o, want no group/world permission bits (e.g. 0600)", mode)
+	}
+}
+
+func isWindows() bool {
+	return os.PathSeparator == '\\'
+}
+
+// TestRunRevoke_WritesOutputBeforeExitingOnFailure proves that when an
+// earlier finding is successfully revoked and a later one fails (without
+// --continue-on-error, so the process exits), the already-successful,
+// irreversible revocation is still recorded in --output before the process
+// exits. This runs the real command in a subprocess since a failed
+// revocation calls os.Exit(1).
+func TestRunRevoke_WritesOutputBeforeExitingOnFailure(t *testing.T) {
+	if os.Getenv("BETTERLEAKS_REVOKE_HELPER") == "1" {
+		reportPath := os.Getenv("HELPER_REPORT_PATH")
+		outputPath := os.Getenv("HELPER_OUTPUT_PATH")
+		setRevokeFlags(t, "", true, false, false, outputPath)
+		initConfig(".")
+		runRevoke(revokeCmd, []string{reportPath})
+		return
+	}
+
+	okSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer okSrv.Close()
+	failSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer failSrv.Close()
+
+	okExpr := `let r = http.delete("` + okSrv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error"}`
+	failExpr := `let r = http.delete("` + failSrv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error", "reason": "boom"}`
+
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	outputPath := filepath.Join(dir, "out.json")
+	findings := []report.Finding{
+		{RuleID: "ok-rule", Secret: "ok_secret", Fingerprint: "ok-fp"},
+		{RuleID: "fail-rule", Secret: "fail_secret", Fingerprint: "fail-fp"},
+	}
+	data, err := json.Marshal(findings)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(reportPath, data, 0o600); err != nil {
+		t.Fatalf("write report: %v", err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestRunRevoke_WritesOutputBeforeExitingOnFailure")
+	cmd.Env = append(os.Environ(),
+		"BETTERLEAKS_REVOKE_HELPER=1",
+		"HELPER_REPORT_PATH="+reportPath,
+		"HELPER_OUTPUT_PATH="+outputPath,
+		`BETTERLEAKS_CONFIG_TOML=`+`
+[[rules]]
+id = "ok-rule"
+regex = '''ok_[a-z0-9]*'''
+revoke = '''`+okExpr+`'''
+
+[[rules]]
+id = "fail-rule"
+regex = '''fail_[a-z0-9]*'''
+revoke = '''`+failExpr+`'''
+`,
+	)
+	runErr := cmd.Run()
+	if runErr == nil {
+		t.Fatal("expected the subprocess to exit non-zero (a revocation failed), got nil error")
+	}
+
+	out, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading output (expected it to be written before exiting): %v", err)
+	}
+	var got []report.Finding
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	byFP := map[string]report.Finding{}
+	for _, f := range got {
+		byFP[f.Fingerprint] = f
+	}
+	if byFP["ok-fp"].ValidationStatus != report.ValidationStatusRevoked {
+		t.Errorf("the successful revocation before the failure should still be recorded in --output, got status %q", byFP["ok-fp"].ValidationStatus)
 	}
 }

--- a/cmd/revoke_test.go
+++ b/cmd/revoke_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/report"
+)
+
+func testConfig(t *testing.T, revokeExpr string) *config.Config {
+	t.Helper()
+	toml := `
+[[rules]]
+id = "revocable-rule"
+regex = '''rr_[a-z0-9]{32}'''
+`
+	if revokeExpr != "" {
+		toml += "revoke = '''" + revokeExpr + "'''\n"
+	}
+	toml += `
+[[rules]]
+id = "no-revoke-rule"
+regex = '''nrr_[a-z0-9]{32}'''
+`
+	cfg, err := config.ParseTOMLString(toml, "inline")
+	if err != nil {
+		t.Fatalf("ParseTOMLString: %v", err)
+	}
+	return cfg
+}
+
+func TestRevokeOne_UnsupportedWhenRuleHasNoRevokeExpr(t *testing.T) {
+	cfg := testConfig(t, "")
+	f := &report.Finding{RuleID: "no-revoke-rule", Secret: "whatever"}
+
+	attempt := revokeOne(context.Background(), cfg, nil, f)
+	if attempt.Outcome != outcomeUnsupported {
+		t.Errorf("Outcome = %v, want %v", attempt.Outcome, outcomeUnsupported)
+	}
+}
+
+func TestRevokeOne_UnsupportedWhenRuleUnknown(t *testing.T) {
+	cfg := testConfig(t, "")
+	f := &report.Finding{RuleID: "does-not-exist", Secret: "whatever"}
+
+	attempt := revokeOne(context.Background(), cfg, nil, f)
+	if attempt.Outcome != outcomeUnsupported {
+		t.Errorf("Outcome = %v, want %v", attempt.Outcome, outcomeUnsupported)
+	}
+}
+
+func TestRevokeOne_SuccessCallsProviderAndReturnsRevoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer rr_test_secret" {
+			t.Errorf("Authorization = %q", got)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	revokeExpr := `let r = http.delete("` + srv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error", "reason": "unexpected status"}`
+	cfg := testConfig(t, revokeExpr)
+	runtime, err := cfg.CompileRevocation()
+	if err != nil {
+		t.Fatalf("CompileRevocation: %v", err)
+	}
+	f := &report.Finding{RuleID: "revocable-rule", Secret: "rr_test_secret"}
+
+	attempt := revokeOne(context.Background(), cfg, runtime, f)
+	if attempt.Outcome != outcomeRevoked {
+		t.Fatalf("Outcome = %v, want %v (err=%v, reason=%v)", attempt.Outcome, outcomeRevoked, attempt.Err, attempt.Reason)
+	}
+}
+
+func TestRevokeOne_ProviderErrorDoesNotYieldRevoked(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	revokeExpr := `let r = http.delete("` + srv.URL + `", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error", "reason": "provider returned an error"}`
+	cfg := testConfig(t, revokeExpr)
+	runtime, err := cfg.CompileRevocation()
+	if err != nil {
+		t.Fatalf("CompileRevocation: %v", err)
+	}
+	f := &report.Finding{RuleID: "revocable-rule", Secret: "rr_test_secret"}
+
+	attempt := revokeOne(context.Background(), cfg, runtime, f)
+	if attempt.Outcome != outcomeFailed {
+		t.Fatalf("Outcome = %v, want %v", attempt.Outcome, outcomeFailed)
+	}
+	if attempt.Reason != "provider returned an error" {
+		t.Errorf("Reason = %q", attempt.Reason)
+	}
+}
+
+func TestRevokeOne_CompileErrorIsFailedNotPanic(t *testing.T) {
+	cfg := testConfig(t, `this is not valid expr syntax {{{`)
+	runtime, err := cfg.CompileRevocation()
+	if err != nil {
+		t.Fatalf("CompileRevocation: %v", err)
+	}
+	f := &report.Finding{RuleID: "revocable-rule", Secret: "rr_test_secret"}
+
+	attempt := revokeOne(context.Background(), cfg, runtime, f)
+	if attempt.Outcome != outcomeFailed {
+		t.Fatalf("Outcome = %v, want %v", attempt.Outcome, outcomeFailed)
+	}
+	if attempt.Err == nil {
+		t.Error("expected a compile error to be set on Err")
+	}
+}
+
+func TestLoadFindingsReport(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	want := []report.Finding{
+		{RuleID: "revocable-rule", Secret: "rr_test_secret", Fingerprint: "abc123"},
+	}
+	data, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := loadFindingsReport(path)
+	if err != nil {
+		t.Fatalf("loadFindingsReport: %v", err)
+	}
+	if len(got) != 1 || got[0].RuleID != "revocable-rule" || got[0].Fingerprint != "abc123" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestLoadFindingsReport_MissingFile(t *testing.T) {
+	_, err := loadFindingsReport(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Error("expected an error for a missing file")
+	}
+}
+
+func TestLoadFindingsReport_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(path, []byte("not json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	_, err := loadFindingsReport(path)
+	if err == nil {
+		t.Error("expected an error for invalid JSON")
+	}
+}
+
+func TestShortFingerprint(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"short", "short"},
+		{"exactly12ch1", "exactly12ch1"},
+		{"this-is-a-very-long-fingerprint", "this-is-a-ve…"},
+	}
+	for _, tc := range tests {
+		if got := shortFingerprint(tc.in); got != tc.want {
+			t.Errorf("shortFingerprint(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNonEmptyOr(t *testing.T) {
+	if got := nonEmptyOr("", "fallback"); got != "fallback" {
+		t.Errorf("got %q, want fallback", got)
+	}
+	if got := nonEmptyOr("value", "fallback"); got != "value" {
+		t.Errorf("got %q, want value", got)
+	}
+}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -1111,6 +1111,19 @@ r.status == 200 && ((r.body contains "\"scopes\"")) ? {
   } : validate.unknown(r)
 
 '''
+revoke = '''
+let r = http.delete("https://api.buildkite.com/v2/access-token", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Accept": "application/json"
+  });
+r.status == 204 ? {
+    "result": "revoked"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "token was already invalid or unauthorized"
+  } : revoke.unknown(r)
+
+'''
 filter = '''
 entropy(finding["secret"]) < 3.5
 '''

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,7 @@ type rawRule struct {
 	Allowlists      []*rawRuleAllowlist `toml:"allowlists"`
 	Required        []*rawRequired      `toml:"required"`
 	Validate        string              `toml:"validate"`
+	Revoke          string              `toml:"revoke"`
 	SkipReport      bool                `toml:"skipReport"`
 	TokenEfficiency bool                `toml:"tokenEfficiency"`
 
@@ -258,6 +259,7 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 		}
 
 		cr.ValidateExpr = vr.Validate
+		cr.RevokeExpr = vr.Revoke
 		cr.Filter = vr.Filter
 
 		orderedRules = append(orderedRules, cr.RuleID)
@@ -529,6 +531,36 @@ func (c *Config) CompileFilters(tokenizer *tiktoken.Tiktoken) error {
 	return nil
 }
 
+// CompileRevocation returns a runtime for per-rule revocation expressions.
+// Individual revocation programs are compiled lazily by the `revoke` command
+// via Rule.RevocationProgram/SetRevocationProgram, mirroring how validation
+// programs are compiled lazily by the detector.
+//
+// This is deliberately never called from the scan path (git/dir/stdin/etc.).
+// Revocation is a destructive action against a live credential and must
+// only run when a user explicitly invokes the `revoke` command for a
+// specific finding - never implicitly as a side effect of scanning.
+// Returns (nil, nil) when no rules have revocation expressions.
+func (c *Config) CompileRevocation() (*exprruntime.Runtime, error) {
+	hasRevocation := false
+	for _, r := range c.Rules {
+		if r.RevokeExpr != "" {
+			hasRevocation = true
+			break
+		}
+	}
+	if !hasRevocation {
+		return nil, nil
+	}
+
+	runtime, err := exprruntime.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating revocation env: %w", err)
+	}
+
+	return runtime, nil
+}
+
 // CompileValidation returns a runtime for per-rule validation expressions.
 // Individual validation programs are compiled lazily by the detector.
 // Returns (nil, nil) when no rules have validation expressions.
@@ -654,6 +686,9 @@ func (c *Config) extend(extensionConfig *Config) {
 			}
 			if currentRule.ValidateExpr != "" {
 				baseRule.ValidateExpr = currentRule.ValidateExpr
+			}
+			if currentRule.RevokeExpr != "" {
+				baseRule.RevokeExpr = currentRule.RevokeExpr
 			}
 			// Current rule's Filter replaces the extending one if set.
 			if currentRule.Filter != "" {

--- a/config/revoke_test.go
+++ b/config/revoke_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevokeExpr_Parsed(t *testing.T) {
+	cfg, err := ParseTOMLString(`
+[[rules]]
+id = "example-token"
+regex = '''example_[a-z0-9]{32}'''
+revoke = '''let r = http.delete("https://api.example.com/token", {"Authorization": "Bearer " + secret}); r.status == 204 ? {"result": "revoked"} : {"result": "error", "reason": "unexpected status"}'''
+`, "inline")
+	require.NoError(t, err)
+
+	rule, ok := cfg.Rules["example-token"]
+	require.True(t, ok)
+	assert.Contains(t, rule.RevokeExpr, `http.delete`)
+	assert.Empty(t, rule.ValidateExpr, "revoke and validate are independent fields")
+}
+
+func TestRevokeExpr_AbsentWhenNotConfigured(t *testing.T) {
+	cfg, err := ParseTOMLString(`
+[[rules]]
+id = "no-revoke-rule"
+regex = '''nrr_[a-z0-9]{32}'''
+`, "inline")
+	require.NoError(t, err)
+
+	rule, ok := cfg.Rules["no-revoke-rule"]
+	require.True(t, ok)
+	assert.Empty(t, rule.RevokeExpr)
+}
+
+// TestRevokeExpr_ExtendedRuleOverridesBase exercises the real [extend] merge
+// path (the same mechanism covered by TestTranslateExtend for other rule
+// fields) to confirm RevokeExpr participates in it correctly: an extending
+// rule's non-empty RevokeExpr replaces the base rule's, mirroring how
+// ValidateExpr already behaves.
+func TestRevokeExpr_ExtendedRuleOverridesBase(t *testing.T) {
+	dir := t.TempDir()
+	basePath := filepath.Join(dir, "base.toml")
+	extendPath := filepath.Join(dir, "extend.toml")
+
+	require.NoError(t, os.WriteFile(basePath, []byte(`
+[[rules]]
+id = "extend-me"
+regex = '''em_[a-z0-9]{32}'''
+revoke = '''{"result": "revoked", "reason": "base"}'''
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(extendPath, []byte(`
+[extend]
+path = "`+filepath.ToSlash(basePath)+`"
+
+[[rules]]
+id = "extend-me"
+revoke = '''{"result": "revoked", "reason": "overridden"}'''
+`), 0o600))
+
+	cfg, err := LoadFile(extendPath)
+	require.NoError(t, err)
+
+	rule, ok := cfg.Rules["extend-me"]
+	require.True(t, ok)
+	assert.Contains(t, rule.RevokeExpr, "overridden")
+	assert.NotContains(t, rule.RevokeExpr, `"reason": "base"`)
+}
+
+func TestCompileRevocation_NilWhenNoRulesDefineRevoke(t *testing.T) {
+	cfg, err := ParseTOMLString(`
+[[rules]]
+id = "plain-rule"
+regex = '''pr_[a-z0-9]{32}'''
+`, "inline")
+	require.NoError(t, err)
+
+	runtime, err := cfg.CompileRevocation()
+	require.NoError(t, err)
+	assert.Nil(t, runtime, "no rule defines a revoke expression, so no runtime should be created")
+}
+
+func TestCompileRevocation_CreatesRuntimeWhenAnyRuleDefinesRevoke(t *testing.T) {
+	cfg, err := ParseTOMLString(`
+[[rules]]
+id = "plain-rule"
+regex = '''pr_[a-z0-9]{32}'''
+
+[[rules]]
+id = "revocable-rule"
+regex = '''rr_[a-z0-9]{32}'''
+revoke = '''{"result": "revoked"}'''
+`, "inline")
+	require.NoError(t, err)
+
+	runtime, err := cfg.CompileRevocation()
+	require.NoError(t, err)
+	require.NotNil(t, runtime)
+
+	prg, err := runtime.CompileValidation(cfg.Rules["revocable-rule"].RevokeExpr)
+	require.NoError(t, err)
+	assert.NotNil(t, prg)
+}

--- a/config/rule.go
+++ b/config/rule.go
@@ -70,6 +70,17 @@ type Rule struct {
 	// validationProgram is the compiled validation program, set at config load time.
 	validationProgram exprruntime.Program
 
+	// RevokeExpr is the raw expression used to revoke a secret at its
+	// provider, e.g. calling a DELETE /access-token endpoint. Unlike
+	// ValidateExpr, it is never run automatically during a scan - it only
+	// runs when a user explicitly requests revocation for a specific
+	// finding (see the `revoke` command), since revocation is a
+	// destructive, irreversible action against a live credential.
+	RevokeExpr string
+
+	// revocationProgram is the compiled revocation program, set at config load time.
+	revocationProgram exprruntime.Program
+
 	// Filter is an expression evaluated against attributes + finding per regex match.
 	// Returns true = skip (discard this finding); false = keep.
 	// Deprecated legacy Allowlists, Entropy, and TokenEfficiency are translated into this field.
@@ -134,6 +145,16 @@ func (r *Rule) Validate() error {
 // ValidationProgram returns the compiled validation program for this rule, or nil.
 func (r *Rule) ValidationProgram() exprruntime.Program {
 	return r.validationProgram
+}
+
+// RevocationProgram returns the compiled revocation program for this rule, or nil.
+func (r *Rule) RevocationProgram() exprruntime.Program {
+	return r.revocationProgram
+}
+
+// SetRevocationProgram stores a compiled revocation program on the rule.
+func (r *Rule) SetRevocationProgram(p exprruntime.Program) {
+	r.revocationProgram = p
 }
 
 // SetValidationProgram stores a compiled validation program on the rule.

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,6 +22,7 @@ Each `[[rules]]` entry can use:
 - `regex`: regular expression used to detect the secret.
 - `filter`: rule-specific Expr expression to discard false positives.
 - `validate`: Expr expression to actively verify whether a secret is live.
+- `revoke`: Expr expression to deactivate a live secret at its provider. Never run during a scan; only runs via `betterleaks revoke`.
 - `[[rules.required]]`: composite rule requirements.
 
 `keywords` are strongly recommended. Betterleaks checks them with an
@@ -210,6 +211,42 @@ r.status == 200 && (r.json?.slug ?? "") != "" ? {
 For more complex validation setups, such as Basic Auth, dynamic request bodies,
 HMAC signatures, or composite `[[rules.required]]` rules, check the built-in
 rules in `cmd/generate/config/rules`.
+
+## Revocation
+
+Revocation deactivates a live secret at its provider by evaluating the rule's
+`revoke` Expr expression - for example, deleting an access token via a
+provider's `DELETE` endpoint. Unlike `validate`, `revoke` is never run
+automatically during a scan; it only runs against findings you already have in
+a report, via `betterleaks revoke <report-file>`, and only for rules whose
+config defines a `revoke` expression. This is deliberate: revocation is a
+destructive, irreversible action against a real credential, so it should
+never happen as a side effect of scanning.
+
+`revoke` uses the same result format as `validate` (a map with a `"result"`
+key). A successful revocation must return `"result": "revoked"` - any other
+result is treated as a failed revocation, not a success. `revoke` expressions
+have access to `finding` the same way `validate` does, and can use all the
+same [validation functions](#validation-functions), plus
+`revoke.unknown(response)` (the `revoke`-namespace equivalent of
+`validate.unknown`).
+
+Example, mirroring the `validate` example above:
+
+```toml
+revoke = '''
+let r = http.delete("https://api.buildkite.com/v2/access-token", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Accept": "application/json"
+  });
+r.status == 204 ? {
+    "result": "revoked"
+  } : r.status in [401, 403] ? {
+    "result": "invalid",
+    "reason": "token was already invalid or unauthorized"
+  } : revoke.unknown(r)
+'''
+```
 
 ### Overriding rule defaults with env vars
 

--- a/internal/exprruntime/bindings_http.go
+++ b/internal/exprruntime/bindings_http.go
@@ -13,8 +13,9 @@ import (
 
 func httpNamespace(rt *runtimeBindings) map[string]any {
 	return map[string]any{
-		"get":  rt.httpGet,
-		"post": rt.httpPost,
+		"get":    rt.httpGet,
+		"post":   rt.httpPost,
+		"delete": rt.httpDelete,
 	}
 }
 
@@ -24,6 +25,13 @@ func (rt *runtimeBindings) httpGet(rawURL string, headers any) (map[string]any, 
 
 func (rt *runtimeBindings) httpPost(rawURL string, headers any, body string) (map[string]any, error) {
 	return rt.httpRequest(rt.ctx, http.MethodPost, rawURL, headers, body)
+}
+
+// httpDelete exists primarily for revoke expressions: most providers expose
+// token/credential revocation as a DELETE endpoint (e.g. Buildkite's
+// DELETE /v2/access-token).
+func (rt *runtimeBindings) httpDelete(rawURL string, headers any) (map[string]any, error) {
+	return rt.httpRequest(rt.ctx, http.MethodDelete, rawURL, headers, "")
 }
 
 func (rt *runtimeBindings) httpRequest(ctx context.Context, method, rawURL string, headers any, body string) (map[string]any, error) {

--- a/internal/exprruntime/bindings_revoke.go
+++ b/internal/exprruntime/bindings_revoke.go
@@ -1,0 +1,25 @@
+package exprruntime
+
+import "fmt"
+
+// revokeNamespace mirrors validateNamespace, giving `revoke` expressions
+// the same "I got a response but don't know how to classify it" escape
+// hatch that `validate.unknown` provides.
+func revokeNamespace() map[string]any {
+	return map[string]any{
+		"unknown": unknownRevokeResult,
+	}
+}
+
+func unknownRevokeResult(resp map[string]any) map[string]any {
+	m := map[string]any{"result": "unknown"}
+	if status, ok := resp["status"]; ok {
+		switch status {
+		case int64(429), 429:
+			m["reason"] = "rate limited"
+		default:
+			m["reason"] = fmt.Sprintf("HTTP %v", status)
+		}
+	}
+	return m
+}

--- a/internal/exprruntime/bindings_revoke_test.go
+++ b/internal/exprruntime/bindings_revoke_test.go
@@ -1,0 +1,113 @@
+package exprruntime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRevokeNamespace_UnknownHelper mirrors the existing pattern for
+// validate.unknown: confirm revoke.unknown(resp) is reachable from a
+// compiled expression and produces the expected fallback shape for a
+// response the expression doesn't explicitly branch on.
+func TestRevokeNamespace_UnknownHelper(t *testing.T) {
+	env, err := New(nil)
+	if err != nil {
+		t.Fatalf("exprruntime.New: %v", err)
+	}
+
+	prg, err := env.CompileValidation(`revoke.unknown({"status": 429})`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := env.Eval(prg, nil, nil)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	m, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", got)
+	}
+	if m["result"] != "unknown" {
+		t.Errorf("result = %v, want %q", m["result"], "unknown")
+	}
+	if m["reason"] != "rate limited" {
+		t.Errorf("reason = %v, want %q", m["reason"], "rate limited")
+	}
+}
+
+// TestRevokeExpr_EndToEndHTTPCall proves a realistic revoke expression -
+// a DELETE call against a provider endpoint using the secret as a bearer
+// token, mirroring the shape a real rule (e.g. Buildkite) would use -
+// compiles and evaluates correctly against a mock server, for both the
+// success and failure paths.
+func TestRevokeExpr_EndToEndHTTPCall(t *testing.T) {
+	env, err := New(nil)
+	if err != nil {
+		t.Fatalf("exprruntime.New: %v", err)
+	}
+
+	const revokeExpr = `let r = http.delete("` + "%s" + `", {"Authorization": "Bearer " + finding["secret"]});
+r.status == 204 ? {"result": "revoked"} : r.status in [401, 403] ? {"result": "invalid", "reason": "unauthorized"} : revoke.unknown(r)`
+
+	t.Run("success (204) yields revoked", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE, got %s", r.Method)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer test-secret-123" {
+				t.Errorf("Authorization header = %q", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		prg, err := env.CompileValidation(sprintfExpr(revokeExpr, srv.URL))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		got, err := env.Eval(prg, map[string]string{"secret": "test-secret-123"}, nil)
+		if err != nil {
+			t.Fatalf("eval: %v", err)
+		}
+		m := got.(map[string]any)
+		if m["result"] != "revoked" {
+			t.Errorf("result = %v, want \"revoked\"", m["result"])
+		}
+	})
+
+	t.Run("already-invalid token (401) is not reported as revoked", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		prg, err := env.CompileValidation(sprintfExpr(revokeExpr, srv.URL))
+		if err != nil {
+			t.Fatalf("compile: %v", err)
+		}
+		got, err := env.Eval(prg, map[string]string{"secret": "already-dead"}, nil)
+		if err != nil {
+			t.Fatalf("eval: %v", err)
+		}
+		m := got.(map[string]any)
+		if m["result"] == "revoked" {
+			t.Errorf("a 401 must never be reported as revoked - that would be a false success")
+		}
+	})
+}
+
+func sprintfExpr(expr, url string) string {
+	// Minimal helper so the revokeExpr template above stays readable;
+	// avoids importing fmt just for one call site.
+	out := make([]byte, 0, len(expr)+len(url))
+	for i := 0; i < len(expr); i++ {
+		if i+1 < len(expr) && expr[i] == '%' && expr[i+1] == 's' {
+			out = append(out, url...)
+			i++
+			continue
+		}
+		out = append(out, expr[i])
+	}
+	return string(out)
+}

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -314,6 +314,7 @@ func (e *Runtime) validationBindings(ctx context.Context, finding, captures, att
 	b["env_get"] = rt.envGet
 	b["strings"] = stringsNamespace()
 	b["validate"] = validateNamespace()
+	b["revoke"] = revokeNamespace()
 	b["json"] = jsonNamespace()
 	b["crypto"] = cryptoNamespace()
 	b["hex"] = hexNamespace()


### PR DESCRIPTION
Closes #212.

Adds a `revoke` Expr expression alongside the existing `validate` one, letting a rule deactivate a live secret at its provider (e.g. deleting a Buildkite access token via its `DELETE /v2/access-token` endpoint).

## Design

Revocation is deliberately **never** run automatically during a scan - it's a destructive, irreversible action against a real credential. It only runs via a new `betterleaks revoke <report-file>` command, against findings already in a report, and only for rules whose config defines a `revoke` expression. Findings for rules with no `revoke` expression are reported as unsupported and skipped.

By default each revocation is confirmed interactively (`Revoke this secret now? This cannot be undone. [y/N]`). Flags:
- `--fingerprint` - only consider one specific finding
- `--dry-run` - preview without calling any provider
- `--yes` - skip the confirmation prompt (e.g. CI)
- `--continue-on-error` - keep going after a failure instead of stopping
- `--output` - write an updated report with revoked findings marked

`revoke` uses the same result-map format as `validate` (`{"result": "revoked", ...}`); anything other than `"revoked"` is treated as a failed revocation, never silently reported as success.

## What's included

- `config`: `revoke` TOML field, `[extend]` inheritance support, `Config.CompileRevocation()`
- `internal/exprruntime`: `revoke` namespace binding (`revoke.unknown()`), plus a new `http.delete` binding since revocation is most commonly a DELETE call
- `cmd/revoke.go`: the CLI command, with the core evaluation logic (`revokeOne`) kept separate from I/O so it's directly unit-testable
- `cmd/config.go`: wired `revoke` expression compilation into `betterleaks config check`/`config show`'s eager validation, matching how `validate` is already checked there - otherwise a broken `revoke` expression would pass `config check` clean and only surface mid-revocation against a real credential
- A real proof-of-concept `revoke` expression on the existing `buildkite-user-access-token` rule, using the same DELETE endpoint referenced in #212
- README and `docs/config.md` updated with a Revocation section

## Testing

New tests at every layer: config parsing/inheritance/compilation (`config/revoke_test.go`), the `revoke` Expr binding end-to-end against a mock HTTP server (`internal/exprruntime/bindings_revoke_test.go`), `revokeOne`/`loadFindingsReport`/formatting helpers (`cmd/revoke_test.go`), and the config-check fix (`cmd/config_test.go`). Full existing suite passes with zero regressions (`go build ./...`, `go vet ./...`, `go test ./...`).