### PR TITLE
fix(sources): recover from panics on the archive extractor path

### DIFF
--- a/sources/file.go
+++ b/sources/file.go
@@ -143,6 +143,21 @@ func (s *File) Fragments(ctx context.Context, yield FragmentsFunc) error {
 
 // extractorFragments recursively crawls archives and yields fragments
 func (s *File) extractorFragments(ctx context.Context, extractor archives.Extractor, reader io.Reader, yield FragmentsFunc) {
+	// Malformed archives can make the extraction library panic (e.g. a tiny
+	// .rar whose block header encodes a bogus size). Recover here so a bad
+	// archive is skipped with a warning instead of killing the process. This
+	// guard sits inside extractorFragments (rather than at the dispatch site)
+	// so it protects every nesting level: extractorFragments recurses into
+	// nested entries via file.Fragments below.
+	defer func() {
+		if r := recover(); r != nil {
+			logging.Warn().
+				Str("path", s.FullPath()).
+				Str("panic", fmt.Sprint(r)).
+				Msg("skipping archive: panic during extraction")
+		}
+	}()
+
 	if _, isSeekReaderAt := reader.(seekReaderAt); !isSeekReaderAt {
 		switch extractor.(type) {
 		case archives.SevenZip, archives.Zip:

--- a/sources/file_test.go
+++ b/sources/file_test.go
@@ -1,10 +1,12 @@
 package sources
 
 import (
+	"context"
 	"io"
 	"strings"
 	"testing"
 
+	"github.com/mholt/archives"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,5 +67,45 @@ func TestFile_decompressorFragments_recoversAndClosesReader(t *testing.T) {
 				func(Fragment, error) error { return nil },
 			)
 		})
+	})
+}
+
+// panicExtractor is an archives.Extractor whose Extract panics, emulating a
+// decoder (e.g. rardecode) that blows up on a malformed archive header.
+type panicExtractor struct{}
+
+func (panicExtractor) Extract(context.Context, io.Reader, archives.FileHandler) error {
+	panic("boom during extract")
+}
+
+func TestFile_extractorFragments_recoversPanic(t *testing.T) {
+	s := &File{Path: "evil.rar"}
+
+	require.NotPanics(t, func() {
+		s.extractorFragments(
+			t.Context(),
+			panicExtractor{},
+			strings.NewReader("irrelevant"),
+			func(Fragment, error) error { return nil },
+		)
+	})
+}
+
+// TestFile_Fragments_malformedRarDoesNotPanic drives the real 16-byte RAR5
+// payload through the public entry point. Before the extractorFragments
+// recover() guard, this panicked with "slice bounds out of range [3:1]" inside
+// rardecode and killed the process.
+func TestFile_Fragments_malformedRarDoesNotPanic(t *testing.T) {
+	// RAR5 signature followed by 8 zero bytes -> block header parses size = 0.
+	payload := "Rar!\x1a\x07\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+	s := &File{
+		Content:         strings.NewReader(payload),
+		Path:            "evil.rar",
+		MaxArchiveDepth: 5,
+	}
+
+	require.NotPanics(t, func() {
+		err := s.Fragments(t.Context(), func(Fragment, error) error { return nil })
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Fixes #269 

## Summary

Commit ca147d7 (#266) added a `recover()` to `decompressorFragments`, closing the lzip crash. But RAR (and 7z/zip/tar) flow through **`extractorFragments`**, which had no guard. A 16-byte malformed `.rar` makes `rardecode` panic with `slice bounds out of range [3:1]` and unwinds through a `semgroup` worker goroutine, killing the **whole scan process** (exit 2).

Because archives are identified by user-controlled file extension and `Extractor` is checked before `Decompressor` in `File.Fragments`, any tiny file named `*.rar` triggers a crash  on every scan mode (`dir`, `git`, `github`, `gitlab`, `s3`, `huggingface`, `stdin`).

## Fix

Add the same `recover()` guard to `extractorFragments`, mirroring the decompressor fix. Placing it *inside* `extractorFragments` (rather than at the dispatch site) protects every nesting level, since it recurses into nested archive entries via `file.Fragments`.

## Before

```
% ./betterleaks dir poc


  ○
  ○
  ●
  ○  betterleaks dev

panic: runtime error: slice bounds out of range [3:1]

goroutine 49 [running]:
github.com/nwaples/rardecode/v2.(*archive50).readBlockHeader(...)   archive50.go:503
github.com/nwaples/rardecode/v2.(*archive50).mustReadBlockHeader(...)  archive50.go:547
github.com/nwaples/rardecode/v2.(*archive50).init(...)              archive50.go:560
github.com/mholt/archives.Rar.Extract(...)                          rar.go:109
.../sources.(*File).extractorFragments(...)                         sources/file.go:169
.../sources.(*File).Fragments(...)                                  sources/file.go:128
created by github.com/fatih/semgroup.(*Group).Go in goroutine 11
exit status 2
```

## After

```
% ./betterleaks dir poc


  ○
  ○
  ●
  ○  betterleaks dev

12:13AM WRN skipping archive: panic during extraction panic="runtime error: slice bounds out of range [3:1]" path=poc/evil.rar
12:13AM WRN skipping compressed file: panic during decompression panic="runtime error: slice bounds out of range [:-8]" path=poc/evil.lz
12:13AM INF scanned ~0 bytes (0) in 26.8ms
12:13AM INF no leaks found
```

The bad archive is skipped with a warning and the scan continues (exit 0). A real secret sitting next to the payload is still reported, closing the fail-open bypass.

## Tests

- `TestFile_extractorFragments_recoversPanic` — unit test with a `panicExtractor`.
- `TestFile_Fragments_malformedRarDoesNotPanic` — end-to-end test driving the real 16-byte RAR5 payload through the public `Fragments` entry point.
