### PR TITLE
add validation limits

### DIFF
--- a/cmd/flag_retrievers.go
+++ b/cmd/flag_retrievers.go
@@ -44,3 +44,11 @@ func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
 	}
 	return value
 }
+
+func mustGetFloat64Flag(cmd *cobra.Command, name string) float64 {
+	value, err := cmd.Flags().GetFloat64(name)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
+	}
+	return value
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,6 +103,11 @@ func init() {
 	rootCmd.PersistentFlags().String("validation-status", "", "comma-separated list of validation statuses to include: valid, needs_validation, invalid, revoked, error, unknown, none (none = rules without validation)")
 	rootCmd.PersistentFlags().Duration("validation-timeout", 10*time.Second, "per-request timeout for validation")
 	rootCmd.PersistentFlags().Int("validation-workers", 10, "number of concurrent validation workers")
+	rootCmd.PersistentFlags().Int("validation-max-requests", 0, "maximum validation requests sent to each provider target (0 = unlimited)")
+	rootCmd.PersistentFlags().Int("validation-max-request", 0, "alias for --validation-max-requests")
+	_ = rootCmd.PersistentFlags().MarkHidden("validation-max-request")
+	rootCmd.PersistentFlags().Float64("validation-rps", 0, "global validation requests per second (0 = unlimited)")
+	rootCmd.PersistentFlags().StringSlice("validation-rps-rule", nil, "rule-specific validation request rate as RULE=RPS (repeatable)")
 	rootCmd.PersistentFlags().Bool("validation-extract-empty", false, "include empty values from extractors in output")
 	rootCmd.PersistentFlags().Bool("validation-debug", false, "include validation HTTP debug metadata in output")
 	rootCmd.PersistentFlags().StringSlice("validation-env-vars", nil, "comma-separated env var names the validation env(...) binding may read (repeat flag to add more); unset means env() is disabled")
@@ -347,13 +352,32 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 	if err != nil {
 		logging.Fatal().Err(err).Msg("validation-env-vars flag")
 	}
+	validationMaxRequests, err := getValidationMaxRequests(cmd)
+	if err != nil {
+		logging.Fatal().Err(err).Msg("validation maximum requests")
+	}
+	validationRPS := mustGetFloat64Flag(cmd, "validation-rps")
+	if err := validateValidationRPS(validationRPS); err != nil {
+		logging.Fatal().Err(err).Msg("validation-rps")
+	}
+	validationRPSRuleValues, err := cmd.Flags().GetStringSlice("validation-rps-rule")
+	if err != nil {
+		logging.Fatal().Err(err).Msg("validation-rps-rule flag")
+	}
+	validationRPSByRule, err := parseValidationRuleRPS(validationRPSRuleValues)
+	if err != nil {
+		logging.Fatal().Err(err).Msg("validation-rps-rule")
+	}
 	valOpts := detect.ValidationOptions{
-		Enabled:           mustGetBoolFlag(cmd, "validation"),
-		Debug:             mustGetBoolFlag(cmd, "validation-debug"),
-		Workers:           mustGetIntFlag(cmd, "validation-workers"),
-		ExtractEmpty:      mustGetBoolFlag(cmd, "validation-extract-empty"),
-		StatusFilter:      mustGetStringFlag(cmd, "validation-status"),
-		ValidationEnvVars: validationEnvVars,
+		Enabled:                 mustGetBoolFlag(cmd, "validation"),
+		Debug:                   mustGetBoolFlag(cmd, "validation-debug"),
+		Workers:                 mustGetIntFlag(cmd, "validation-workers"),
+		ExtractEmpty:            mustGetBoolFlag(cmd, "validation-extract-empty"),
+		StatusFilter:            mustGetStringFlag(cmd, "validation-status"),
+		MaxRequestsPerTarget:    validationMaxRequests,
+		RequestsPerSecond:       validationRPS,
+		RequestsPerSecondByRule: validationRPSByRule,
+		ValidationEnvVars:       validationEnvVars,
 	}
 	valOpts.Timeout, _ = cmd.Flags().GetDuration("validation-timeout")
 

--- a/cmd/validation_flags.go
+++ b/cmd/validation_flags.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func getValidationMaxRequests(cmd *cobra.Command) (int, error) {
+	maxRequests, err := cmd.Flags().GetInt("validation-max-requests")
+	if err != nil {
+		return 0, err
+	}
+	alias, err := cmd.Flags().GetInt("validation-max-request")
+	if err != nil {
+		return 0, err
+	}
+
+	canonicalChanged := cmd.Flags().Changed("validation-max-requests")
+	aliasChanged := cmd.Flags().Changed("validation-max-request")
+	if canonicalChanged && aliasChanged && maxRequests != alias {
+		return 0, fmt.Errorf(
+			"--validation-max-requests and --validation-max-request disagree (%d and %d)",
+			maxRequests,
+			alias,
+		)
+	}
+	if aliasChanged {
+		maxRequests = alias
+	}
+	if maxRequests < 0 {
+		return 0, fmt.Errorf("must be non-negative")
+	}
+	return maxRequests, nil
+}
+
+func validateValidationRPS(rps float64) error {
+	if math.IsNaN(rps) || math.IsInf(rps, 0) || rps < 0 {
+		return fmt.Errorf("must be a finite non-negative number")
+	}
+	return nil
+}
+
+func parseValidationRuleRPS(values []string) (map[string]float64, error) {
+	rates := make(map[string]float64, len(values))
+	for _, value := range values {
+		rawRuleID, rawRPS, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid value %q: expected RULE=RPS", value)
+		}
+		ruleID := strings.TrimSpace(rawRuleID)
+		if ruleID == "" {
+			return nil, fmt.Errorf("invalid value %q: rule ID cannot be empty", value)
+		}
+		if _, exists := rates[ruleID]; exists {
+			return nil, fmt.Errorf("duplicate rate for rule %q", ruleID)
+		}
+
+		rps, err := strconv.ParseFloat(strings.TrimSpace(rawRPS), 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid rate for rule %q: %w", ruleID, err)
+		}
+		if err := validateValidationRPS(rps); err != nil || rps == 0 {
+			if err == nil {
+				err = fmt.Errorf("must be greater than zero")
+			}
+			return nil, fmt.Errorf("invalid rate for rule %q: %w", ruleID, err)
+		}
+		rates[ruleID] = rps
+	}
+	return rates, nil
+}

--- a/cmd/validation_flags_test.go
+++ b/cmd/validation_flags_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"math"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestParseValidationRuleRPS(t *testing.T) {
+	got, err := parseValidationRuleRPS([]string{"github-pat=2", "gcp-service-account=0.5"})
+	if err != nil {
+		t.Fatalf("parseValidationRuleRPS: %v", err)
+	}
+	if got["github-pat"] != 2 {
+		t.Fatalf("github rate = %v, want 2", got["github-pat"])
+	}
+	if got["gcp-service-account"] != 0.5 {
+		t.Fatalf("gcp rate = %v, want 0.5", got["gcp-service-account"])
+	}
+}
+
+func TestParseValidationRuleRPSRejectsInvalidValues(t *testing.T) {
+	for _, value := range []string{
+		"github-pat",
+		"=1",
+		"github-pat=0",
+		"github-pat=-1",
+		"github-pat=not-a-number",
+		"github-pat=1,github-pat=2",
+	} {
+		if _, err := parseValidationRuleRPS([]string{value}); err == nil {
+			t.Fatalf("parseValidationRuleRPS(%q) returned no error", value)
+		}
+	}
+	if _, err := parseValidationRuleRPS([]string{"github-pat=1", "github-pat=2"}); err == nil {
+		t.Fatal("duplicate rule rate returned no error")
+	}
+}
+
+func TestValidateValidationRPS(t *testing.T) {
+	for _, value := range []float64{0, 0.5, 10} {
+		if err := validateValidationRPS(value); err != nil {
+			t.Fatalf("validateValidationRPS(%v): %v", value, err)
+		}
+	}
+	for _, value := range []float64{-1, math.NaN(), math.Inf(1)} {
+		if err := validateValidationRPS(value); err == nil {
+			t.Fatalf("validateValidationRPS(%v) returned no error", value)
+		}
+	}
+}
+
+func TestGetValidationMaxRequestsSupportsSingularAlias(t *testing.T) {
+	newCommand := func(args ...string) *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		cmd.Flags().Int("validation-max-requests", 0, "")
+		cmd.Flags().Int("validation-max-request", 0, "")
+		if err := cmd.ParseFlags(args); err != nil {
+			t.Fatalf("ParseFlags: %v", err)
+		}
+		return cmd
+	}
+
+	for _, test := range []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "default", want: 0},
+		{name: "canonical", args: []string{"--validation-max-requests=10"}, want: 10},
+		{name: "alias", args: []string{"--validation-max-request=20"}, want: 20},
+		{
+			name: "both equal",
+			args: []string{"--validation-max-requests=30", "--validation-max-request=30"},
+			want: 30,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := getValidationMaxRequests(newCommand(test.args...))
+			if err != nil {
+				t.Fatalf("getValidationMaxRequests: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("max requests = %d, want %d", got, test.want)
+			}
+		})
+	}
+
+	if _, err := getValidationMaxRequests(newCommand(
+		"--validation-max-requests=10",
+		"--validation-max-request=20",
+	)); err == nil {
+		t.Fatal("conflicting aliases returned no error")
+	}
+	if _, err := getValidationMaxRequests(newCommand("--validation-max-requests=-1")); err == nil {
+		t.Fatal("negative maximum returned no error")
+	}
+}

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -35,12 +35,15 @@ import (
 // ValidationOptions controls secret validation behavior.
 // Zero value means validation is disabled.
 type ValidationOptions struct {
-	Enabled      bool
-	Debug        bool
-	Workers      int
-	Timeout      time.Duration
-	ExtractEmpty bool
-	StatusFilter string // comma-separated list of statuses to include
+	Enabled                 bool
+	Debug                   bool
+	Workers                 int
+	Timeout                 time.Duration
+	ExtractEmpty            bool
+	StatusFilter            string // comma-separated list of statuses to include
+	MaxRequestsPerTarget    int
+	RequestsPerSecond       float64
+	RequestsPerSecondByRule map[string]float64
 	// ValidationEnvVars lists environment variable names the validation Expr
 	// env(...) binding may read (see --validation-env-vars). Parsed into
 	// exprruntime.Runtime.AllowedEnv when the validation env is created.
@@ -306,11 +309,18 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		if valOpts.Timeout > 0 {
 			validationRuntime.SetHTTPClient(&http.Client{Timeout: valOpts.Timeout})
 		}
+		if err := validationRuntime.SetValidationRequestLimits(exprruntime.ValidationRequestLimits{
+			MaxRequestsPerTarget:    valOpts.MaxRequestsPerTarget,
+			RequestsPerSecond:       valOpts.RequestsPerSecond,
+			RequestsPerSecondByRule: valOpts.RequestsPerSecondByRule,
+		}); err != nil {
+			logging.Fatal().Err(err).Msg("invalid validation request limits")
+		}
 		workers := valOpts.Workers
 		if workers <= 0 {
 			workers = 10
 		}
-		d.ValidationPool = validate.NewPool(workers, validationRuntime)
+		d.ValidationPool = validate.NewPoolContext(ctx, workers, validationRuntime)
 		d.ValidationPool.Debug = valOpts.Debug
 
 		if valOpts.StatusFilter != "" {

--- a/docs/config.md
+++ b/docs/config.md
@@ -152,7 +152,9 @@ Rate limits use strict spacing with no initial burst. A provider target is an
 HTTP origin such as `https://api.github.com`; multiple rules that use the same
 origin share its maximum-request budget. Redirects and multi-request validation
 expressions count each actual outbound request. Validation cache hits do not
-count.
+count. Time spent waiting for an RPS slot does not consume
+`--validation-timeout`; that timeout begins when the provider request starts and
+remains active while its response body is read.
 
 For example:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -134,6 +134,42 @@ the `--validation` flag.
 Validation runs asynchronously, and responses are cached in memory so duplicate
 secrets only trigger one network request.
 
+### Request limits
+
+Live validation can send many authentication requests when a scan finds
+different candidate credentials for the same provider. The following flags
+limit the actual outbound requests made by generic HTTP validators and the
+built-in AWS, GCP, and Azure validators:
+
+| Flag | Description |
+| :--- | :--- |
+| `--validation-max-requests N` | Sends at most `N` requests to each provider target origin during the scan. `0` means unlimited. The singular `--validation-max-request` spelling is accepted as an alias. |
+| `--validation-rps N` | Limits all validation requests to `N` requests per second. Fractional values are accepted; `0` means unlimited. |
+| `--validation-rps-rule RULE=N` | Limits one exact rule ID to `N` requests per second. Repeat the flag for additional rules. |
+
+The global and rule-specific rates compose: a request must satisfy both limits.
+Rate limits use strict spacing with no initial burst. A provider target is an
+HTTP origin such as `https://api.github.com`; multiple rules that use the same
+origin share its maximum-request budget. Redirects and multi-request validation
+expressions count each actual outbound request. Validation cache hits do not
+count.
+
+For example:
+
+```sh
+betterleaks dir . --validation \
+  --validation-max-requests 1000 \
+  --validation-rps 10 \
+  --validation-rps-rule github-pat=2 \
+  --validation-rps-rule github-fine-grained-pat=2
+```
+
+Once a provider target reaches `--validation-max-requests`, further validations
+that need to call it return `needs_validation` without sending the request. The
+finding includes `betterleaks_max_requests_hit`,
+`betterleaks_validation_target`, `betterleaks_validation_max_requests`, and
+`betterleaks_validation_requests_sent` metadata.
+
 ### Result format
 
 A validation expression must return a map with a `"result"` key. Supported

--- a/docs/config.md
+++ b/docs/config.md
@@ -154,7 +154,9 @@ origin share its maximum-request budget. Redirects and multi-request validation
 expressions count each actual outbound request. Validation cache hits do not
 count. Time spent waiting for an RPS slot does not consume
 `--validation-timeout`; that timeout begins when the provider request starts and
-remains active while its response body is read.
+remains active while its response body is read. Redirect hops share that one
+provider-time budget, while each hop still counts as an outbound request for RPS
+and maximum-request enforcement.
 
 For example:
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -563,6 +563,12 @@ betterleaks git . --baseline-path findings.json
 # enable live validation
 betterleaks dir . --validation --validation-status valid,unknown
 
+# cap and rate-limit outbound validation requests
+betterleaks dir . --validation \
+	--validation-max-requests 1000 \
+	--validation-rps 10 \
+	--validation-rps-rule github-pat=2
+
 # redact output
 betterleaks git . -v --redact
 

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -57,13 +57,17 @@ type EvalOptions struct {
 }
 
 type EvalResult struct {
-	Value any
-	Debug map[string]any
+	Value           any
+	Debug           map[string]any
+	RequestLimitHit *ValidationRequestLimitHit
 }
 
 type evalState struct {
 	debug bool
 	meta  map[string]any
+
+	limitMu  sync.Mutex
+	limitHit *ValidationRequestLimitHit
 }
 
 func (s *evalState) addDebug(name string, value any) {
@@ -76,12 +80,39 @@ func (s *evalState) addDebug(name string, value any) {
 	s.meta[name] = value
 }
 
+func (s *evalState) recordValidationLimitHit(hit ValidationRequestLimitHit) {
+	if s == nil {
+		return
+	}
+	s.limitMu.Lock()
+	defer s.limitMu.Unlock()
+	if s.limitHit == nil {
+		s.limitHit = &hit
+	}
+}
+
+func (s *evalState) validationLimitHit() *ValidationRequestLimitHit {
+	if s == nil {
+		return nil
+	}
+	s.limitMu.Lock()
+	defer s.limitMu.Unlock()
+	if s.limitHit == nil {
+		return nil
+	}
+	hit := *s.limitHit
+	return &hit
+}
+
 // maxResponseBody is the maximum number of bytes read from an HTTP response body.
 const maxResponseBody = 1 << 20 // 1 MB
 
 // Runtime holds compiled Expr programs and validation services (if needed).
 type Runtime struct {
 	client *http.Client
+	// validationLimiter is applied to every request made through client,
+	// including generic HTTP and typed cloud validation bindings.
+	validationLimiter *validationRequestLimiter
 
 	mu    sync.RWMutex
 	cache map[string]Program
@@ -105,7 +136,21 @@ func DefaultHTTPClient() *http.Client {
 	return &http.Client{Timeout: 10 * time.Second}
 }
 
-func (e *Runtime) SetHTTPClient(c *http.Client) { e.client = c }
+func (e *Runtime) SetHTTPClient(c *http.Client) {
+	e.client = wrapValidationLimitClient(c, e.validationLimiter)
+}
+
+// SetValidationRequestLimits applies request-level validation limits to the
+// Runtime's shared HTTP client.
+func (e *Runtime) SetValidationRequestLimits(cfg ValidationRequestLimits) error {
+	limiter, err := newValidationRequestLimiter(cfg)
+	if err != nil {
+		return err
+	}
+	e.validationLimiter = limiter
+	e.client = wrapValidationLimitClient(e.client, limiter)
+	return nil
+}
 
 func (e *Runtime) SetTokenizerProvider(provider func() *tiktoken.Tiktoken) {
 	e.tokenizerProvider = provider
@@ -274,10 +319,21 @@ func (e *Runtime) EvalWithContext(ctx context.Context, prg Program, finding, cap
 }
 
 func (e *Runtime) EvalValidation(ctx context.Context, prg Program, finding, captures, attributes map[string]string, opts EvalOptions) (EvalResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	state := &evalState{debug: opts.Debug}
+	ctx = context.WithValue(ctx, validationRequestContextKey{}, &validationRequestContext{
+		ruleID: lookupString(finding, "rule_id"),
+		state:  state,
+	})
 	b := e.validationBindings(ctx, finding, captures, attributes, state)
 	val, err := expr.Run(prg.vm, b)
-	return EvalResult{Value: val, Debug: state.meta}, err
+	return EvalResult{
+		Value:           val,
+		Debug:           state.meta,
+		RequestLimitHit: state.validationLimitHit(),
+	}, err
 }
 
 func (e *Runtime) validationBindings(ctx context.Context, finding, captures, attributes map[string]string, state *evalState) bindings {

--- a/internal/exprruntime/validation_limits.go
+++ b/internal/exprruntime/validation_limits.go
@@ -61,6 +61,8 @@ type validationRequestContext struct {
 	state  *evalState
 }
 
+type validationTimeoutBudgetContextKey struct{}
+
 type validationRequestLimiter struct {
 	mu sync.Mutex
 
@@ -245,6 +247,11 @@ func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response,
 		return nil, err
 	}
 
+	timeoutBudget := validationTimeoutBudgetForRequest(req, t.requestTimeout)
+	if timeoutBudget != nil && !timeoutBudget.hasRemaining() {
+		return nil, context.DeadlineExceeded
+	}
+
 	if hit := t.limiter.admit(ruleID, target); hit != nil {
 		if requestContext != nil && requestContext.state != nil {
 			requestContext.state.recordValidationLimitHit(*hit)
@@ -253,52 +260,111 @@ func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response,
 	}
 
 	providerReq := req
-	var cancel context.CancelFunc
-	if t.requestTimeout > 0 {
-		var providerCtx context.Context
-		providerCtx, cancel = context.WithTimeout(req.Context(), t.requestTimeout)
+	var finishProviderRequest func()
+	if timeoutBudget != nil {
+		providerCtx, finish, err := timeoutBudget.start(req.Context())
+		if err != nil {
+			return nil, err
+		}
+		providerCtx = context.WithValue(providerCtx, validationTimeoutBudgetContextKey{}, timeoutBudget)
 		providerReq = req.Clone(providerCtx)
+		finishProviderRequest = finish
 	}
 
 	resp, err := base.RoundTrip(providerReq)
 	if err != nil {
-		if cancel != nil {
-			cancel()
+		if finishProviderRequest != nil {
+			finishProviderRequest()
 		}
 		return nil, err
 	}
-	if cancel != nil {
+	if finishProviderRequest != nil {
 		if resp.Body == nil {
-			cancel()
+			finishProviderRequest()
 		} else {
 			resp.Body = &validationTimeoutBody{
 				ReadCloser: resp.Body,
-				cancel:     cancel,
+				finish:     finishProviderRequest,
 			}
 		}
 	}
+	// Preserve the shared timeout budget for a redirect request even when a
+	// custom RoundTripper omits or replaces Response.Request.
+	resp.Request = providerReq
 	return resp, nil
 }
 
+// validationTimeoutBudget tracks provider-active time across every request in
+// one redirect chain. Rate-limit waits happen before start and do not consume
+// the budget.
+type validationTimeoutBudget struct {
+	mu        sync.Mutex
+	remaining time.Duration
+}
+
+// validationTimeoutBudgetForRequest starts a budget for an initial request and
+// recovers it from the previous response for redirects. The budget value
+// survives cancellation of the prior hop's request context.
+func validationTimeoutBudgetForRequest(req *http.Request, timeout time.Duration) *validationTimeoutBudget {
+	if timeout <= 0 {
+		return nil
+	}
+	if req != nil && req.Response != nil && req.Response.Request != nil {
+		if budget, ok := req.Response.Request.Context().Value(validationTimeoutBudgetContextKey{}).(*validationTimeoutBudget); ok {
+			return budget
+		}
+	}
+	return &validationTimeoutBudget{remaining: timeout}
+}
+
+func (b *validationTimeoutBudget) hasRemaining() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.remaining > 0
+}
+
+func (b *validationTimeoutBudget) start(parent context.Context) (context.Context, func(), error) {
+	b.mu.Lock()
+	remaining := b.remaining
+	b.mu.Unlock()
+	if remaining <= 0 {
+		return nil, nil, context.DeadlineExceeded
+	}
+
+	started := time.Now()
+	ctx, cancel := context.WithTimeout(parent, remaining)
+	var once sync.Once
+	finish := func() {
+		once.Do(func() {
+			cancel()
+			elapsed := time.Since(started)
+			b.mu.Lock()
+			b.remaining = max(0, b.remaining-elapsed)
+			b.mu.Unlock()
+		})
+	}
+	return ctx, finish, nil
+}
+
 // validationTimeoutBody keeps the provider request context alive until the
-// response body is consumed or closed. This preserves http.Client.Timeout's
-// body-read coverage while starting the timeout after the rate-limit wait.
+// response body is consumed or closed and then charges that active time to the
+// redirect chain's shared timeout budget.
 type validationTimeoutBody struct {
 	io.ReadCloser
-	cancel context.CancelFunc
+	finish func()
 	once   sync.Once
 }
 
 func (b *validationTimeoutBody) Read(p []byte) (int, error) {
 	n, err := b.ReadCloser.Read(p)
 	if err != nil {
-		b.once.Do(b.cancel)
+		b.once.Do(b.finish)
 	}
 	return n, err
 }
 
 func (b *validationTimeoutBody) Close() error {
-	b.once.Do(b.cancel)
+	b.once.Do(b.finish)
 	return b.ReadCloser.Close()
 }
 

--- a/internal/exprruntime/validation_limits.go
+++ b/internal/exprruntime/validation_limits.go
@@ -1,0 +1,292 @@
+package exprruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ValidationRequestLimits controls outbound validation requests. Zero values
+// disable the corresponding limit.
+type ValidationRequestLimits struct {
+	// MaxRequestsPerTarget is the maximum number of requests admitted to each
+	// target origin over the lifetime of the Runtime.
+	MaxRequestsPerTarget int
+
+	// RequestsPerSecond is the aggregate request rate across all validation
+	// targets and rules.
+	RequestsPerSecond float64
+
+	// RequestsPerSecondByRule contains exact rule-ID request rates. A rule rate
+	// composes with, rather than replaces, RequestsPerSecond.
+	RequestsPerSecondByRule map[string]float64
+}
+
+// ValidationRequestLimitHit describes a validation request rejected before it
+// reached the provider.
+type ValidationRequestLimitHit struct {
+	RuleID       string
+	Target       string
+	MaxRequests  int
+	RequestsSent int
+}
+
+// ValidationRequestLimitError is returned by the validation HTTP transport
+// when a target has exhausted its request budget.
+type ValidationRequestLimitError struct {
+	Hit ValidationRequestLimitHit
+}
+
+func (e *ValidationRequestLimitError) Error() string {
+	return fmt.Sprintf(
+		"validation request limit reached for %s (%d requests sent, maximum %d)",
+		e.Hit.Target,
+		e.Hit.RequestsSent,
+		e.Hit.MaxRequests,
+	)
+}
+
+type validationRequestContextKey struct{}
+
+type validationRequestContext struct {
+	ruleID string
+	state  *evalState
+}
+
+type validationRequestLimiter struct {
+	mu sync.Mutex
+
+	maxRequestsPerTarget int
+	requestsByTarget     map[string]int
+
+	globalInterval time.Duration
+	globalNext     time.Time
+	ruleIntervals  map[string]time.Duration
+	ruleNext       map[string]time.Time
+}
+
+func newValidationRequestLimiter(cfg ValidationRequestLimits) (*validationRequestLimiter, error) {
+	if cfg.MaxRequestsPerTarget < 0 {
+		return nil, errors.New("validation maximum requests must be non-negative")
+	}
+
+	globalInterval, err := validationRequestInterval(cfg.RequestsPerSecond)
+	if err != nil {
+		return nil, fmt.Errorf("validation requests per second: %w", err)
+	}
+
+	ruleIntervals := make(map[string]time.Duration, len(cfg.RequestsPerSecondByRule))
+	for rawRuleID, rps := range cfg.RequestsPerSecondByRule {
+		ruleID := strings.TrimSpace(rawRuleID)
+		if ruleID == "" {
+			return nil, errors.New("validation rule request rate has an empty rule ID")
+		}
+		interval, intervalErr := validationRequestInterval(rps)
+		if intervalErr != nil {
+			return nil, fmt.Errorf("validation requests per second for rule %q: %w", ruleID, intervalErr)
+		}
+		if interval == 0 {
+			return nil, fmt.Errorf("validation requests per second for rule %q must be greater than zero", ruleID)
+		}
+		ruleIntervals[ruleID] = interval
+	}
+
+	if cfg.MaxRequestsPerTarget == 0 && globalInterval == 0 && len(ruleIntervals) == 0 {
+		return nil, nil
+	}
+
+	return &validationRequestLimiter{
+		maxRequestsPerTarget: cfg.MaxRequestsPerTarget,
+		requestsByTarget:     make(map[string]int),
+		globalInterval:       globalInterval,
+		ruleIntervals:        ruleIntervals,
+		ruleNext:             make(map[string]time.Time),
+	}, nil
+}
+
+func validationRequestInterval(rps float64) (time.Duration, error) {
+	if math.IsNaN(rps) || math.IsInf(rps, 0) || rps < 0 {
+		return 0, errors.New("must be a finite non-negative number")
+	}
+	if rps == 0 {
+		return 0, nil
+	}
+
+	seconds := 1 / rps
+	if seconds > float64(math.MaxInt64)/float64(time.Second) {
+		return 0, errors.New("is too small to represent")
+	}
+	interval := time.Duration(seconds * float64(time.Second))
+	if interval <= 0 {
+		return 0, errors.New("is too large to represent")
+	}
+	return interval, nil
+}
+
+// wait admits a request only when both the global and exact-rule rate limits
+// have a current slot. Future slots are not reserved: a slow rule therefore
+// cannot block unrelated rules from using otherwise available global capacity.
+func (l *validationRequestLimiter) wait(ctx context.Context, ruleID string) error {
+	if l == nil || (l.globalInterval == 0 && l.ruleIntervals[ruleID] == 0) {
+		return nil
+	}
+
+	ruleInterval := l.ruleIntervals[ruleID]
+	for {
+		now := time.Now()
+		l.mu.Lock()
+		sendAt := now
+		if l.globalInterval > 0 && l.globalNext.After(sendAt) {
+			sendAt = l.globalNext
+		}
+		if ruleInterval > 0 && l.ruleNext[ruleID].After(sendAt) {
+			sendAt = l.ruleNext[ruleID]
+		}
+		if !sendAt.After(now) {
+			if l.globalInterval > 0 {
+				l.globalNext = now.Add(l.globalInterval)
+			}
+			if ruleInterval > 0 {
+				l.ruleNext[ruleID] = now.Add(ruleInterval)
+			}
+			l.mu.Unlock()
+			return nil
+		}
+		l.mu.Unlock()
+
+		timer := time.NewTimer(time.Until(sendAt))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (l *validationRequestLimiter) admit(ruleID, target string) *ValidationRequestLimitHit {
+	if l == nil || l.maxRequestsPerTarget == 0 {
+		return nil
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if hit := l.limitHitLocked(ruleID, target); hit != nil {
+		return hit
+	}
+	l.requestsByTarget[target]++
+	return nil
+}
+
+func (l *validationRequestLimiter) limitHit(ruleID, target string) *ValidationRequestLimitHit {
+	if l == nil || l.maxRequestsPerTarget == 0 {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.limitHitLocked(ruleID, target)
+}
+
+func (l *validationRequestLimiter) limitHitLocked(ruleID, target string) *ValidationRequestLimitHit {
+	sent := l.requestsByTarget[target]
+	if sent >= l.maxRequestsPerTarget {
+		return &ValidationRequestLimitHit{
+			RuleID:       ruleID,
+			Target:       target,
+			MaxRequests:  l.maxRequestsPerTarget,
+			RequestsSent: sent,
+		}
+	}
+	return nil
+}
+
+type validationLimitTransport struct {
+	base    http.RoundTripper
+	limiter *validationRequestLimiter
+}
+
+func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	if t.limiter == nil {
+		return base.RoundTrip(req)
+	}
+
+	requestContext, _ := req.Context().Value(validationRequestContextKey{}).(*validationRequestContext)
+	ruleID := ""
+	if requestContext != nil {
+		ruleID = requestContext.ruleID
+	}
+
+	target := validationRequestTarget(req.URL)
+	if hit := t.limiter.limitHit(ruleID, target); hit != nil {
+		if requestContext != nil && requestContext.state != nil {
+			requestContext.state.recordValidationLimitHit(*hit)
+		}
+		return nil, &ValidationRequestLimitError{Hit: *hit}
+	}
+
+	if err := t.limiter.wait(req.Context(), ruleID); err != nil {
+		return nil, err
+	}
+
+	if hit := t.limiter.admit(ruleID, target); hit != nil {
+		if requestContext != nil && requestContext.state != nil {
+			requestContext.state.recordValidationLimitHit(*hit)
+		}
+		return nil, &ValidationRequestLimitError{Hit: *hit}
+	}
+
+	return base.RoundTrip(req)
+}
+
+func validationRequestTarget(u *url.URL) string {
+	if u == nil {
+		return "unknown"
+	}
+	scheme := strings.ToLower(u.Scheme)
+	hostname := strings.ToLower(u.Hostname())
+	port := u.Port()
+	if (scheme == "https" && port == "443") || (scheme == "http" && port == "80") {
+		port = ""
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	if host == "" {
+		host = strings.ToLower(u.Host)
+	}
+	if scheme == "" {
+		return host
+	}
+	return scheme + "://" + host
+}
+
+func wrapValidationLimitClient(client *http.Client, limiter *validationRequestLimiter) *http.Client {
+	if client == nil {
+		client = DefaultHTTPClient()
+	}
+	clone := *client
+	base := clone.Transport
+	if current, ok := base.(*validationLimitTransport); ok {
+		base = current.base
+	}
+	clone.Transport = base
+	if limiter != nil {
+		clone.Transport = &validationLimitTransport{base: base, limiter: limiter}
+	}
+	return &clone
+}

--- a/internal/exprruntime/validation_limits.go
+++ b/internal/exprruntime/validation_limits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -209,8 +210,9 @@ func (l *validationRequestLimiter) limitHitLocked(ruleID, target string) *Valida
 }
 
 type validationLimitTransport struct {
-	base    http.RoundTripper
-	limiter *validationRequestLimiter
+	base           http.RoundTripper
+	limiter        *validationRequestLimiter
+	requestTimeout time.Duration
 }
 
 func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -239,6 +241,9 @@ func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response,
 	if err := t.limiter.wait(req.Context(), ruleID); err != nil {
 		return nil, err
 	}
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
 
 	if hit := t.limiter.admit(ruleID, target); hit != nil {
 		if requestContext != nil && requestContext.state != nil {
@@ -247,7 +252,54 @@ func (t *validationLimitTransport) RoundTrip(req *http.Request) (*http.Response,
 		return nil, &ValidationRequestLimitError{Hit: *hit}
 	}
 
-	return base.RoundTrip(req)
+	providerReq := req
+	var cancel context.CancelFunc
+	if t.requestTimeout > 0 {
+		var providerCtx context.Context
+		providerCtx, cancel = context.WithTimeout(req.Context(), t.requestTimeout)
+		providerReq = req.Clone(providerCtx)
+	}
+
+	resp, err := base.RoundTrip(providerReq)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		return nil, err
+	}
+	if cancel != nil {
+		if resp.Body == nil {
+			cancel()
+		} else {
+			resp.Body = &validationTimeoutBody{
+				ReadCloser: resp.Body,
+				cancel:     cancel,
+			}
+		}
+	}
+	return resp, nil
+}
+
+// validationTimeoutBody keeps the provider request context alive until the
+// response body is consumed or closed. This preserves http.Client.Timeout's
+// body-read coverage while starting the timeout after the rate-limit wait.
+type validationTimeoutBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+	once   sync.Once
+}
+
+func (b *validationTimeoutBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	if err != nil {
+		b.once.Do(b.cancel)
+	}
+	return n, err
+}
+
+func (b *validationTimeoutBody) Close() error {
+	b.once.Do(b.cancel)
+	return b.ReadCloser.Close()
 }
 
 func validationRequestTarget(u *url.URL) string {
@@ -281,12 +333,26 @@ func wrapValidationLimitClient(client *http.Client, limiter *validationRequestLi
 	}
 	clone := *client
 	base := clone.Transport
+	requestTimeout := clone.Timeout
 	if current, ok := base.(*validationLimitTransport); ok {
 		base = current.base
+		if requestTimeout == 0 {
+			requestTimeout = current.requestTimeout
+		}
 	}
 	clone.Transport = base
 	if limiter != nil {
-		clone.Transport = &validationLimitTransport{base: base, limiter: limiter}
+		// http.Client.Timeout starts before RoundTrip, so leaving it here would
+		// count rate-limit queue time against the provider request. The wrapper
+		// starts the same timeout immediately before the underlying RoundTrip.
+		clone.Timeout = 0
+		clone.Transport = &validationLimitTransport{
+			base:           base,
+			limiter:        limiter,
+			requestTimeout: requestTimeout,
+		}
+	} else {
+		clone.Timeout = requestTimeout
 	}
 	return &clone
 }

--- a/internal/exprruntime/validation_limits_test.go
+++ b/internal/exprruntime/validation_limits_test.go
@@ -18,6 +18,12 @@ type validationRecordingTransport struct {
 	times   []time.Time
 }
 
+type validationRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f validationRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
 func (t *validationRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.mu.Lock()
 	t.targets = append(t.targets, validationRequestTarget(req.URL))
@@ -332,6 +338,171 @@ func TestCanceledSlowRuleDoesNotReserveFutureGlobalCapacity(t *testing.T) {
 	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
 		t.Fatalf("slow rule reserved global capacity for %s", elapsed)
 	}
+}
+
+func TestRateWaitDoesNotConsumeProviderRequestTimeout(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{
+		Transport: recorder,
+		Timeout:   40 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		RequestsPerSecond: 10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err != nil {
+		t.Fatalf("first evaluation: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err != nil {
+		t.Fatalf("second evaluation after rate wait: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 70*time.Millisecond {
+		t.Fatalf("second evaluation waited only %s; test did not exceed provider timeout", elapsed)
+	}
+}
+
+func TestProviderRequestTimeoutStartsAfterLimiter(t *testing.T) {
+	rt, err := New(&http.Client{
+		Transport: validationRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			<-req.Context().Done()
+			return nil, req.Context().Err()
+		}),
+		Timeout: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err == nil {
+		t.Fatal("provider request returned no timeout error")
+	}
+	elapsed := time.Since(start)
+	if elapsed < 20*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("provider timeout elapsed = %s, want approximately 30ms", elapsed)
+	}
+}
+
+func TestProviderRequestTimeoutCoversResponseBodyRead(t *testing.T) {
+	rt, err := New(&http.Client{
+		Transport: validationRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       &validationContextBody{ctx: req.Context()},
+				Request:    req,
+			}, nil
+		}),
+		Timeout: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err == nil {
+		t.Fatal("response body read returned no timeout error")
+	}
+	elapsed := time.Since(start)
+	if elapsed < 20*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("body-read timeout elapsed = %s, want approximately 30ms", elapsed)
+	}
+}
+
+func TestDisablingValidationLimitsRestoresClientTimeout(t *testing.T) {
+	const requestTimeout = 75 * time.Millisecond
+	rt, err := New(&http.Client{Timeout: requestTimeout})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+	}); err != nil {
+		t.Fatalf("enable limits: %v", err)
+	}
+	if rt.client.Timeout != 0 {
+		t.Fatalf("limited client timeout = %s, want 0", rt.client.Timeout)
+	}
+
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{}); err != nil {
+		t.Fatalf("disable limits: %v", err)
+	}
+	if rt.client.Timeout != requestTimeout {
+		t.Fatalf("restored client timeout = %s, want %s", rt.client.Timeout, requestTimeout)
+	}
+	if _, ok := rt.client.Transport.(*validationLimitTransport); ok {
+		t.Fatal("disabled client still has validation limit transport")
+	}
+}
+
+type validationContextBody struct {
+	ctx context.Context
+}
+
+func (b *validationContextBody) Read(_ []byte) (int, error) {
+	<-b.ctx.Done()
+	return 0, b.ctx.Err()
+}
+
+func (b *validationContextBody) Close() error {
+	return nil
 }
 
 func TestValidationRequestLimitConfigurationRejectsInvalidRates(t *testing.T) {

--- a/internal/exprruntime/validation_limits_test.go
+++ b/internal/exprruntime/validation_limits_test.go
@@ -24,6 +24,49 @@ func (f validationRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, e
 	return f(req)
 }
 
+type validationRedirectTransport struct {
+	mu        sync.Mutex
+	delay     time.Duration
+	redirects int
+	calls     int
+	responses []bool
+}
+
+func (t *validationRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	timer := time.NewTimer(t.delay)
+	select {
+	case <-req.Context().Done():
+		timer.Stop()
+		return nil, req.Context().Err()
+	case <-timer.C:
+	}
+
+	t.mu.Lock()
+	t.calls++
+	call := t.calls
+	t.responses = append(t.responses, req.Response != nil)
+	t.mu.Unlock()
+
+	status := http.StatusOK
+	header := make(http.Header)
+	if call <= t.redirects {
+		status = http.StatusFound
+		header.Set("Location", "/hop")
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		Request:    req,
+	}, nil
+}
+
+func (t *validationRedirectTransport) snapshot() (int, []bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls, append([]bool(nil), t.responses...)
+}
+
 func (t *validationRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.mu.Lock()
 	t.targets = append(t.targets, validationRequestTarget(req.URL))
@@ -489,6 +532,191 @@ func TestDisablingValidationLimitsRestoresClientTimeout(t *testing.T) {
 	}
 	if _, ok := rt.client.Transport.(*validationLimitTransport); ok {
 		t.Fatal("disabled client still has validation limit transport")
+	}
+}
+
+func TestRedirectsShareProviderRequestTimeout(t *testing.T) {
+	redirects := &validationRedirectTransport{
+		delay:     35 * time.Millisecond,
+		redirects: 2,
+	}
+	rt, err := New(&http.Client{
+		Transport: redirects,
+		Timeout:   80 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err == nil {
+		t.Fatal("redirect chain returned no timeout error")
+	}
+	elapsed := time.Since(start)
+	if elapsed < 65*time.Millisecond || elapsed > 500*time.Millisecond {
+		t.Fatalf("redirect-chain timeout elapsed = %s, want approximately 80ms", elapsed)
+	}
+
+	calls, responses := redirects.snapshot()
+	if calls != 2 {
+		t.Fatalf("completed provider requests = %d, want 2 before third hop timed out", calls)
+	}
+	if len(responses) != 2 || responses[0] || !responses[1] {
+		t.Fatalf("request redirect markers = %v, want [false true]", responses)
+	}
+}
+
+func TestRedirectRateWaitDoesNotConsumeSharedProviderTimeout(t *testing.T) {
+	redirects := &validationRedirectTransport{
+		delay:     10 * time.Millisecond,
+		redirects: 1,
+	}
+	rt, err := New(&http.Client{
+		Transport: redirects,
+		Timeout:   40 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+		RequestsPerSecond:    10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	start := time.Now()
+	result, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if err != nil {
+		t.Fatalf("redirect evaluation: %v", err)
+	}
+	if result.Value != int64(http.StatusOK) {
+		t.Fatalf("redirect status = %#v, want %d", result.Value, http.StatusOK)
+	}
+	if elapsed := time.Since(start); elapsed < 80*time.Millisecond {
+		t.Fatalf("redirect evaluation elapsed = %s; RPS wait was not exercised", elapsed)
+	}
+}
+
+func TestRedirectHopsCountTowardTargetRequestCap(t *testing.T) {
+	redirects := &validationRedirectTransport{
+		redirects: 1,
+	}
+	rt, err := New(&http.Client{
+		Transport: redirects,
+		Timeout:   time.Second,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 1,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	result, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if err == nil {
+		t.Fatal("redirect over target cap returned no expression error")
+	}
+	if result.RequestLimitHit == nil {
+		t.Fatal("redirect over target cap did not report limit metadata")
+	}
+	if got, want := result.RequestLimitHit.RequestsSent, 1; got != want {
+		t.Fatalf("requests sent = %d, want %d", got, want)
+	}
+	if calls, _ := redirects.snapshot(); calls != 1 {
+		t.Fatalf("provider requests = %d, want 1", calls)
+	}
+}
+
+func TestIndependentRequestsReceiveIndependentProviderTimeouts(t *testing.T) {
+	rt, err := New(&http.Client{
+		Transport: validationRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			timer := time.NewTimer(20 * time.Millisecond)
+			select {
+			case <-req.Context().Done():
+				timer.Stop()
+				return nil, req.Context().Err()
+			case <-timer.C:
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Request:    req,
+			}, nil
+		}),
+		Timeout: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 10,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(
+		`let firstReq = http.get("https://api.example.test/first", {}); ` +
+			`let secondReq = http.get("https://api.example.test/second", {}); ` +
+			`firstReq.status == 200 && secondReq.status == 200`,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	result, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if err != nil {
+		t.Fatalf("independent evaluations: %v", err)
+	}
+	if result.Value != true {
+		t.Fatalf("independent evaluation result = %#v, want true", result.Value)
 	}
 }
 

--- a/internal/exprruntime/validation_limits_test.go
+++ b/internal/exprruntime/validation_limits_test.go
@@ -1,0 +1,410 @@
+package exprruntime
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type validationRecordingTransport struct {
+	mu      sync.Mutex
+	targets []string
+	times   []time.Time
+}
+
+func (t *validationRecordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	t.targets = append(t.targets, validationRequestTarget(req.URL))
+	t.times = append(t.times, time.Now())
+	t.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		Request:    req,
+	}, nil
+}
+
+func (t *validationRecordingTransport) snapshot() ([]string, []time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.targets...), append([]time.Time(nil), t.times...)
+}
+
+func TestValidationMaxRequestsSharedByTargetAcrossRules(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{Transport: recorder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{MaxRequestsPerTarget: 2}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+
+	firstTarget, err := rt.CompileValidation(`http.get("https://api.example.test/v1/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile first target: %v", err)
+	}
+	otherTarget, err := rt.CompileValidation(`http.get("https://other.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile other target: %v", err)
+	}
+
+	for _, ruleID := range []string{"rule-a", "rule-b"} {
+		result, evalErr := rt.EvalValidation(
+			context.Background(),
+			firstTarget,
+			map[string]string{"rule_id": ruleID},
+			nil,
+			nil,
+			EvalOptions{},
+		)
+		if evalErr != nil {
+			t.Fatalf("admitted evaluation for %s: %v", ruleID, evalErr)
+		}
+		if result.RequestLimitHit != nil {
+			t.Fatalf("admitted evaluation for %s reported limit: %#v", ruleID, result.RequestLimitHit)
+		}
+	}
+
+	blocked, evalErr := rt.EvalValidation(
+		context.Background(),
+		firstTarget,
+		map[string]string{"rule_id": "rule-c"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if evalErr == nil {
+		t.Fatal("blocked evaluation returned no expression error")
+	}
+	if blocked.RequestLimitHit == nil {
+		t.Fatal("blocked evaluation did not report request limit")
+	}
+	if got, want := blocked.RequestLimitHit.Target, "https://api.example.test"; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+	if got, want := blocked.RequestLimitHit.RequestsSent, 2; got != want {
+		t.Fatalf("requests sent = %d, want %d", got, want)
+	}
+	if got, want := blocked.RequestLimitHit.RuleID, "rule-c"; got != want {
+		t.Fatalf("rule ID = %q, want %q", got, want)
+	}
+
+	if _, evalErr := rt.EvalValidation(
+		context.Background(),
+		otherTarget,
+		map[string]string{"rule_id": "rule-c"},
+		nil,
+		nil,
+		EvalOptions{},
+	); evalErr != nil {
+		t.Fatalf("different target should have its own budget: %v", evalErr)
+	}
+
+	targets, _ := recorder.snapshot()
+	if got, want := len(targets), 3; got != want {
+		t.Fatalf("provider requests = %d, want %d", got, want)
+	}
+}
+
+func TestValidationLimitsCoverTypedCloudBindings(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{Transport: recorder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	rt.STSEndpoint = "https://api.example.test/sts"
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{MaxRequestsPerTarget: 1}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+
+	generic, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile generic: %v", err)
+	}
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		generic,
+		map[string]string{"rule_id": "generic-rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err != nil {
+		t.Fatalf("generic evaluation: %v", err)
+	}
+
+	awsProgram, err := rt.CompileValidation(
+		`aws.validate("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY").status`,
+	)
+	if err != nil {
+		t.Fatalf("compile AWS: %v", err)
+	}
+	blocked, _ := rt.EvalValidation(
+		context.Background(),
+		awsProgram,
+		map[string]string{"rule_id": "aws-secret-access-key"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if blocked.RequestLimitHit == nil {
+		t.Fatal("typed AWS validation did not report shared request limit")
+	}
+	if got, want := blocked.RequestLimitHit.Target, "https://api.example.test"; got != want {
+		t.Fatalf("target = %q, want %q", got, want)
+	}
+	targets, _ := recorder.snapshot()
+	if got, want := len(targets), 1; got != want {
+		t.Fatalf("provider requests = %d, want %d", got, want)
+	}
+}
+
+func TestValidationMaxRequestsDoesNotWaitForRPSAfterTargetIsExhausted(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{Transport: recorder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+		MaxRequestsPerTarget: 1,
+		RequestsPerSecond:    1,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err != nil {
+		t.Fatalf("first evaluation: %v", err)
+	}
+
+	start := time.Now()
+	blocked, _ := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	)
+	if blocked.RequestLimitHit == nil {
+		t.Fatal("second evaluation did not report request limit")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("exhausted target waited %s for RPS limit", elapsed)
+	}
+}
+
+func TestValidationGlobalRPSStrictlySpacesRequests(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{Transport: recorder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{RequestsPerSecond: 50}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	runConcurrentValidations(t, rt, prg, "rule", 3)
+	_, times := recorder.snapshot()
+	assertMinimumRequestSpacing(t, times, 15*time.Millisecond)
+}
+
+func TestValidationRuleRPSComposesWithGlobalRPS(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		globalRPS float64
+		ruleRPS   float64
+	}{
+		{name: "rule is stricter", globalRPS: 100, ruleRPS: 20},
+		{name: "global is stricter", globalRPS: 20, ruleRPS: 100},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := &validationRecordingTransport{}
+			rt, err := New(&http.Client{Transport: recorder})
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			if err := rt.SetValidationRequestLimits(ValidationRequestLimits{
+				RequestsPerSecond:       test.globalRPS,
+				RequestsPerSecondByRule: map[string]float64{"limited-rule": test.ruleRPS},
+			}); err != nil {
+				t.Fatalf("SetValidationRequestLimits: %v", err)
+			}
+			prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+
+			runConcurrentValidations(t, rt, prg, "limited-rule", 3)
+			_, times := recorder.snapshot()
+			assertMinimumRequestSpacing(t, times, 40*time.Millisecond)
+		})
+	}
+}
+
+func TestValidationRPSWaitHonorsCancellationAndDoesNotCountRequest(t *testing.T) {
+	recorder := &validationRecordingTransport{}
+	rt, err := New(&http.Client{Transport: recorder})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(ValidationRequestLimits{RequestsPerSecond: 1}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(`http.get("https://api.example.test/check", {}).status`)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	if _, err := rt.EvalValidation(
+		context.Background(),
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err != nil {
+		t.Fatalf("first evaluation: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if _, err := rt.EvalValidation(
+		ctx,
+		prg,
+		map[string]string{"rule_id": "rule"},
+		nil,
+		nil,
+		EvalOptions{},
+	); err == nil {
+		t.Fatal("canceled evaluation returned no error")
+	}
+
+	targets, _ := recorder.snapshot()
+	if got, want := len(targets), 1; got != want {
+		t.Fatalf("provider requests = %d, want %d", got, want)
+	}
+}
+
+func TestCanceledSlowRuleDoesNotReserveFutureGlobalCapacity(t *testing.T) {
+	limiter, err := newValidationRequestLimiter(ValidationRequestLimits{
+		RequestsPerSecond:       100,
+		RequestsPerSecondByRule: map[string]float64{"slow-rule": 1},
+	})
+	if err != nil {
+		t.Fatalf("newValidationRequestLimiter: %v", err)
+	}
+	if err := limiter.wait(context.Background(), "slow-rule"); err != nil {
+		t.Fatalf("first slow-rule wait: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := limiter.wait(ctx, "slow-rule"); err == nil {
+		t.Fatal("second slow-rule wait returned no cancellation error")
+	}
+
+	start := time.Now()
+	if err := limiter.wait(context.Background(), "other-rule"); err != nil {
+		t.Fatalf("other-rule wait: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("slow rule reserved global capacity for %s", elapsed)
+	}
+}
+
+func TestValidationRequestLimitConfigurationRejectsInvalidRates(t *testing.T) {
+	tests := []ValidationRequestLimits{
+		{MaxRequestsPerTarget: -1},
+		{RequestsPerSecond: -1},
+		{RequestsPerSecondByRule: map[string]float64{"": 1}},
+		{RequestsPerSecondByRule: map[string]float64{"rule": 0}},
+	}
+	for _, cfg := range tests {
+		if _, err := newValidationRequestLimiter(cfg); err == nil {
+			t.Fatalf("newValidationRequestLimiter(%#v) returned no error", cfg)
+		}
+	}
+}
+
+func TestValidationRequestTargetNormalizesDefaultPorts(t *testing.T) {
+	for _, test := range []struct {
+		raw  string
+		want string
+	}{
+		{raw: "https://API.EXAMPLE.TEST:443/v1", want: "https://api.example.test"},
+		{raw: "http://API.EXAMPLE.TEST:80/v1", want: "http://api.example.test"},
+		{raw: "https://api.example.test:8443/v1", want: "https://api.example.test:8443"},
+		{raw: "https://[::1]:443/v1", want: "https://[::1]"},
+	} {
+		u, err := url.Parse(test.raw)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", test.raw, err)
+		}
+		if got := validationRequestTarget(u); got != test.want {
+			t.Fatalf("validationRequestTarget(%q) = %q, want %q", test.raw, got, test.want)
+		}
+	}
+}
+
+func runConcurrentValidations(t *testing.T, rt *Runtime, prg Program, ruleID string, count int) {
+	t.Helper()
+	var wg sync.WaitGroup
+	errs := make(chan error, count)
+	for range count {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := rt.EvalValidation(
+				context.Background(),
+				prg,
+				map[string]string{"rule_id": ruleID},
+				nil,
+				nil,
+				EvalOptions{},
+			)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("evaluation: %v", err)
+		}
+	}
+}
+
+func assertMinimumRequestSpacing(t *testing.T, times []time.Time, minimum time.Duration) {
+	t.Helper()
+	if len(times) < 2 {
+		t.Fatalf("recorded %d request times, want at least 2", len(times))
+	}
+	sort.Slice(times, func(i, j int) bool { return times[i].Before(times[j]) })
+	for i := 1; i < len(times); i++ {
+		if spacing := times[i].Sub(times[i-1]); spacing < minimum {
+			t.Fatalf("request spacing %s is less than %s", spacing, minimum)
+		}
+	}
+}

--- a/internal/validate/pool.go
+++ b/internal/validate/pool.go
@@ -2,6 +2,7 @@ package validate
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
 	"sync"
@@ -21,6 +22,7 @@ type validationJob struct {
 type Pool struct {
 	runtime *exprruntime.Runtime
 	cache   *Cache
+	ctx     context.Context
 	Debug   bool
 
 	// one job per to-be-validated finding
@@ -35,12 +37,22 @@ type Pool struct {
 
 // NewPool creates a validation pool with the given number of workers.
 func NewPool(workers int, runtime *exprruntime.Runtime) *Pool {
+	return NewPoolContext(context.Background(), workers, runtime)
+}
+
+// NewPoolContext creates a validation pool whose evaluations and request-limit
+// waits are canceled with ctx.
+func NewPoolContext(ctx context.Context, workers int, runtime *exprruntime.Runtime) *Pool {
 	if workers <= 0 {
 		workers = 10
+	}
+	if ctx == nil {
+		ctx = context.Background()
 	}
 	p := &Pool{
 		runtime: runtime,
 		cache:   NewCache(),
+		ctx:     ctx,
 		jobs:    make(chan validationJob, workers*10),
 	}
 
@@ -203,7 +215,29 @@ func (p *Pool) evalWithCacheKey(cacheKey string, program exprruntime.Program, fi
 }
 
 func (p *Pool) evalProgram(program exprruntime.Program, finding, captures, attributes map[string]string) (*Result, error) {
-	result, evalErr := p.runtime.EvalValidation(context.Background(), program, finding, captures, attributes, exprruntime.EvalOptions{Debug: p.Debug})
+	result, evalErr := p.runtime.EvalValidation(p.ctx, program, finding, captures, attributes, exprruntime.EvalOptions{Debug: p.Debug})
+	if result.RequestLimitHit != nil {
+		hit := result.RequestLimitHit
+		metadata := map[string]any{
+			"betterleaks_max_requests_hit":         true,
+			"betterleaks_validation_target":        hit.Target,
+			"betterleaks_validation_max_requests":  hit.MaxRequests,
+			"betterleaks_validation_requests_sent": hit.RequestsSent,
+		}
+		if hit.RuleID != "" {
+			metadata["betterleaks_validation_rule_id"] = hit.RuleID
+		}
+		maps.Copy(metadata, result.Debug)
+		return &Result{
+			Status: report.ValidationStatusNeedsValidation,
+			Reason: fmt.Sprintf(
+				"validation request limit reached for %s after %d requests",
+				hit.Target,
+				hit.RequestsSent,
+			),
+			Metadata: metadata,
+		}, nil
+	}
 	if evalErr != nil {
 		metadata := map[string]any{}
 		maps.Copy(metadata, result.Debug)

--- a/internal/validate/pool_test.go
+++ b/internal/validate/pool_test.go
@@ -1,12 +1,15 @@
 package validate
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
 	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/betterleaks/betterleaks/report"
 )
 
 func TestPoolDebugMetadata(t *testing.T) {
@@ -55,5 +58,87 @@ func TestPoolDebugMetadata(t *testing.T) {
 	}
 	if got := requests.Load(); got != 2 {
 		t.Fatalf("debug validation requests = %d, want 2", got)
+	}
+}
+
+type validationRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f validationRoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPoolMaxRequestsReturnsNeedsValidationMetadataAndDoesNotCountCacheHits(t *testing.T) {
+	var requests atomic.Int32
+	client := &http.Client{Transport: validationRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		requests.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			Request:    req,
+		}, nil
+	})}
+	rt, err := exprruntime.New(client)
+	if err != nil {
+		t.Fatalf("exprruntime.New: %v", err)
+	}
+	if err := rt.SetValidationRequestLimits(exprruntime.ValidationRequestLimits{
+		MaxRequestsPerTarget: 1,
+	}); err != nil {
+		t.Fatalf("SetValidationRequestLimits: %v", err)
+	}
+	prg, err := rt.CompileValidation(
+		`let r = http.get("https://api.example.test/check", {}); ` +
+			`r.status == 200 ? {"result": "valid"} : {"result": "unknown"}`,
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	p := NewPool(1, rt)
+	defer p.Close()
+	finding := map[string]string{"rule_id": "example-rule", "secret": "secret-a"}
+
+	first, err := p.evalWithCaptures(prg, "example-rule", "secret-a", finding, nil, nil)
+	if err != nil {
+		t.Fatalf("first eval: %v", err)
+	}
+	if first.Status != report.ValidationStatusValid {
+		t.Fatalf("first status = %q, want valid", first.Status)
+	}
+
+	cached, err := p.evalWithCaptures(prg, "example-rule", "secret-a", finding, nil, nil)
+	if err != nil {
+		t.Fatalf("cached eval: %v", err)
+	}
+	if cached.Status != report.ValidationStatusValid {
+		t.Fatalf("cached status = %q, want valid", cached.Status)
+	}
+
+	finding["secret"] = "secret-b"
+	blocked, err := p.evalWithCaptures(prg, "example-rule", "secret-b", finding, nil, nil)
+	if err != nil {
+		t.Fatalf("blocked eval: %v", err)
+	}
+	if blocked.Status != report.ValidationStatusNeedsValidation {
+		t.Fatalf("blocked status = %q, want needs_validation", blocked.Status)
+	}
+	if blocked.Metadata["betterleaks_max_requests_hit"] != true {
+		t.Fatalf("max request metadata = %#v", blocked.Metadata)
+	}
+	if blocked.Metadata["betterleaks_validation_target"] != "https://api.example.test" {
+		t.Fatalf("target metadata = %#v", blocked.Metadata["betterleaks_validation_target"])
+	}
+	if blocked.Metadata["betterleaks_validation_max_requests"] != 1 {
+		t.Fatalf("max metadata = %#v", blocked.Metadata["betterleaks_validation_max_requests"])
+	}
+	if blocked.Metadata["betterleaks_validation_requests_sent"] != 1 {
+		t.Fatalf("sent metadata = %#v", blocked.Metadata["betterleaks_validation_requests_sent"])
+	}
+	if blocked.Metadata["betterleaks_validation_rule_id"] != "example-rule" {
+		t.Fatalf("rule metadata = %#v", blocked.Metadata["betterleaks_validation_rule_id"])
+	}
+	if got, want := requests.Load(), int32(1); got != want {
+		t.Fatalf("provider requests = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
This pull request introduces configurable request limits for validation, allowing users to control the number and rate of outbound validation requests. Don't wanna accidentally DOS providers 