### PR TITLE
additional gitlab incoming mail token detection

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -239,6 +239,7 @@ func main() {
 		rules.GitlabFeatureFlagClientToken(),
 		rules.GitlabFeedToken(),
 		rules.GitlabIncomingMailToken(),
+		rules.GitlabIncomingMailAddressToken(),
 		rules.GitlabKubernetesAgentToken(),
 		rules.GitlabOauthAppSecret(),
 		rules.GitlabPat(),

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -37,7 +37,10 @@ path = '''{{ . }}'''{{ end -}}
 {{- with $rule.SecretGroup }}
 secretGroup = {{ . }}{{ end -}}
 {{- if eq $rule.RuleID "generic-api-key" }}
-specificity = 0{{ end -}}
+specificity = 0
+{{- else if $rule.Specificity }}
+specificity = {{ $rule.Specificity }}
+{{- end -}}
 {{- with $rule.Keywords }}
 {{- if gt (len .) 1}}
 keywords = [{{ range $j, $keyword := . }}

--- a/cmd/generate/config/rules/gitlab.go
+++ b/cmd/generate/config/rules/gitlab.go
@@ -111,6 +111,29 @@ func GitlabIncomingMailToken() *config.Rule {
 	return utils.Validate(r, tps, nil)
 }
 
+// GitlabIncomingMailAddressToken finds incoming-mail tokens embedded in GitLab
+// reply-by-email addresses. Prefer gitlab-incoming-mail-token (glimt- prefix)
+// when both match; this rule covers legacy tokens and arbitrary prefixes.
+func GitlabIncomingMailAddressToken() *config.Rule {
+	r := config.Rule{
+		RuleID:      "gitlab-incoming-mail-address-token",
+		Description: "Identified a GitLab incoming mail token embedded in an email address, risking manipulation of data sent by mail.",
+		Regex:       regexp.MustCompile(`incoming\+[A-Za-z0-9._-]+?-\d+-([A-Za-z0-9_][A-Za-z0-9._-]*)-(?:issue(?:-\d+)?|merge-request)@`),
+		Keywords:    []string{"incoming+"},
+		Specificity: 50,
+		Filter:      `entropy(finding["secret"]) <= 3.0`,
+	}
+	token := secrets.NewSecretWithEntropy(utils.AlphaNumeric("25"), 3)
+	glimtToken := "glimt-" + secrets.NewSecretWithEntropy(utils.AlphaNumeric("25"), 3)
+	tps := []string{
+		"incoming+gitlab-org-project-123-" + token + "-issue@example.com",
+		"incoming+my.group_path-456-" + token + "-merge-request@gitlab.example.com",
+		"incoming+project.path-789-" + token + "-issue-42@example.com",
+		"incoming+gitlab-org-gitlab-foss-20-" + glimtToken + "-issue@example.com",
+	}
+	return utils.Validate(r, tps, nil)
+}
+
 func GitlabKubernetesAgentToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "gitlab-kubernetes-agent-token",

--- a/cmd/generate/config/rules/gitlab.go
+++ b/cmd/generate/config/rules/gitlab.go
@@ -118,7 +118,7 @@ func GitlabIncomingMailAddressToken() *config.Rule {
 	r := config.Rule{
 		RuleID:      "gitlab-incoming-mail-address-token",
 		Description: "Identified a GitLab incoming mail token embedded in an email address, risking manipulation of data sent by mail.",
-		Regex:       regexp.MustCompile(`incoming\+[A-Za-z0-9._-]+?-\d+-([A-Za-z0-9_][A-Za-z0-9._-]*)-(?:issue(?:-\d+)?|merge-request)@`),
+		Regex:       regexp.MustCompile(`incoming\+(?:[A-Za-z0-9._-]+-)?\d+-([A-Za-z0-9_-]+)-(?:issue(?:-\d+)?|merge-request)@`),
 		Keywords:    []string{"incoming+"},
 		Specificity: 50,
 		Filter:      `entropy(finding["secret"]) <= 3.0`,

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4787,6 +4787,19 @@ entropy(finding["secret"]) <= 3.0
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# gitlab-incoming-mail-address-token
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "gitlab-incoming-mail-address-token"
+description = "Identified a GitLab incoming mail token embedded in an email address, risking manipulation of data sent by mail."
+regex = '''incoming\+[A-Za-z0-9._-]+?-\d+-([A-Za-z0-9_][A-Za-z0-9._-]*)-(?:issue(?:-\d+)?|merge-request)@'''
+specificity = 50
+keywords = ["incoming+"]
+filter = '''
+entropy(finding["secret"]) <= 3.0
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # gitlab-incoming-mail-token
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4792,7 +4792,7 @@ entropy(finding["secret"]) <= 3.0
 [[rules]]
 id = "gitlab-incoming-mail-address-token"
 description = "Identified a GitLab incoming mail token embedded in an email address, risking manipulation of data sent by mail."
-regex = '''incoming\+[A-Za-z0-9._-]+?-\d+-([A-Za-z0-9_][A-Za-z0-9._-]*)-(?:issue(?:-\d+)?|merge-request)@'''
+regex = '''incoming\+(?:[A-Za-z0-9._-]+-)?\d+-([A-Za-z0-9_-]+)-(?:issue(?:-\d+)?|merge-request)@'''
 specificity = 50
 keywords = ["incoming+"]
 filter = '''


### PR DESCRIPTION
The existing GitLab incoming mail token detector misses two cases:
(1) Users setting custom token prefixes. 
(2) Tokens found in email addresses before the `glimt-` prefix existed. Easily found a dozen cases of these online. There are probably many more. 

This PR creates a new rule `GitlabIncomingMailAddressToken` that provides detection for these two cases. Since this will also sweep up existing `glimt-` tokens surfaced by the `GitlabIncomingMailToken` rule, it adds a specificity value, so that the `GitlabIncomingMailToken` result takes priority and we avoid duplicates. 