### PR TITLE
rule confidence + attribute

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -299,6 +299,7 @@ type ruleView struct {
 	Keywords    []string        `toml:"keywords,omitempty"`
 	Tags        []string        `toml:"tags,omitempty"`
 	Specificity int             `toml:"specificity,omitempty"`
+	Confidence  string          `toml:"confidence,omitempty"`
 	Components  []componentView `toml:"components,omitempty"`
 	Validate    string          `toml:"validate,omitempty"`
 	SkipReport  bool            `toml:"skipReport,omitempty"`
@@ -331,6 +332,7 @@ func renderConfig(cfg *configpkg.Config) configView {
 			Keywords:    rule.Keywords,
 			Tags:        rule.Tags,
 			Specificity: renderedSpecificity(rule.Specificity),
+			Confidence:  rule.Confidence,
 			Validate:    rule.ValidateExpr,
 			SkipReport:  rule.SkipReport,
 			Filter:      rule.Filter,
@@ -370,6 +372,7 @@ func renderConfigTOML(view configView) string {
 		writeStrings(&b, "keywords", rule.Keywords)
 		writeStrings(&b, "tags", rule.Tags)
 		writeInt(&b, "specificity", rule.Specificity)
+		writeString(&b, "confidence", rule.Confidence)
 		writeString(&b, "validate", rule.Validate)
 		writeBool(&b, "skipReport", rule.SkipReport)
 		writeString(&b, "filter", rule.Filter)

--- a/cmd/generate/config/rules/config.tmpl
+++ b/cmd/generate/config/rules/config.tmpl
@@ -41,6 +41,8 @@ specificity = 0
 {{- else if $rule.Specificity }}
 specificity = {{ $rule.Specificity }}
 {{- end -}}
+{{- with $rule.Confidence }}
+confidence = "{{ . }}"{{ end -}}
 {{- with $rule.Keywords }}
 {{- if gt (len .) 1}}
 keywords = [{{ range $j, $keyword := . }}

--- a/cmd/generate/config/rules/generic.go
+++ b/cmd/generate/config/rules/generic.go
@@ -36,6 +36,7 @@ func GenericCredential() *config.Rule {
 			"token",
 		},
 		Specificity: 0,
+		Confidence:  "low",
 		Filter: `// Provider checks use a fixed window around the match, clamped to its line.
 let providerMatchContext = finding["fragment_raw"][
   max(finding["match_start_idx"] - 150, finding["match_line_start_idx"]):
@@ -56,6 +57,11 @@ let genericMatchPrefix = filter.findMatch(
 let genericMatchContext =
   genericMatchPrefix +
   finding["fragment_raw"][finding["match_start_idx"]:finding["match_end_idx"]];
+
+let level = filter.matchesAny(genericMatchContext, [
+  ` + "`(?i)\\b[a-z0-9]+[_.-]+token\\b`" + `
+]) ? "medium" : "low";
+let _ = filter.setConfidence(level);
 
 // big ol expression to filter out FPs
 entropy(finding["secret"]) <= 3.5

--- a/cmd/generate/config/rules/openai.go
+++ b/cmd/generate/config/rules/openai.go
@@ -15,6 +15,7 @@ func OpenAI() *config.Rule {
 		Keywords: []string{
 			"T3BlbkFJ",
 		},
+		Confidence: "high",
 		ValidateExpr: `let r = http.get("https://api.openai.com/v1/models", {
     "Authorization": "Bearer " + finding["secret"]
   }); r.status == 200 && (r.json?.object ?? "") == "list" ? {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect"
+	"github.com/betterleaks/betterleaks/internal/confidence"
 	"github.com/betterleaks/betterleaks/internal/contextwindow"
 	"github.com/betterleaks/betterleaks/logging"
 	"github.com/betterleaks/betterleaks/regexp"
@@ -30,6 +31,10 @@ var banner = fmt.Sprintf(`
 
 `, version.Version)
 
+func confidenceFlag(cmd *cobra.Command) (string, error) {
+	return confidence.Parse(mustGetStringFlag(cmd, "confidence"))
+}
+
 const configDescription = `config file path
 order of precedence:
 1. --config/-c
@@ -44,6 +49,9 @@ var (
 		Short:   "Betterleaks scans code, past or present, for secrets",
 		Version: version.Version,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if _, err := confidenceFlag(cmd); err != nil {
+				return err
+			}
 			// Set the timeout for all the commands
 			if timeout, err := cmd.Flags().GetInt("timeout"); err != nil {
 				return err
@@ -77,6 +85,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("report-template", "", "", "template file used to generate the report (implies --report-format=template)")
 	rootCmd.PersistentFlags().StringP("baseline-path", "b", "", "path to baseline with issues that can be ignored")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")
+	rootCmd.PersistentFlags().String("confidence", "", "minimum confidence to include (low, medium, high)")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "show verbose output from scan")
 	rootCmd.PersistentFlags().Bool("legacy-print", false, "use legacy key/value verbose finding format (requires --verbose)")
 	rootCmd.PersistentFlags().BoolP("no-color", "", false, "turn off color for verbose output")
@@ -381,6 +390,10 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 	valOpts.Timeout, _ = cmd.Flags().GetDuration("validation-timeout")
 
 	detector := detect.NewDetectorContext(cmd.Context(), cfg, valOpts)
+	detector.MinConfidence, err = confidenceFlag(cmd)
+	if err != nil {
+		logging.Fatal().Err(err).Send()
+	}
 	if diagnosticsManager != nil && diagnosticsManager.RuleTimings != nil {
 		detector.RuleTimings = diagnosticsManager.RuleTimings
 	}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -1,7 +1,7 @@
 # This file has been auto-generated. Do not edit manually.
 # If you would like to contribute new rules, please use
 # cmd/generate/config/main.go and follow the contributing guidelines
-# at https://github.com/betterleaks/betterleaks/blob/master/CONTRIBUTING.md
+# at https://github.com/betterleaks/betterleaks/blob/main/.github/CONTRIBUTING.md
 #
 # How the hell does secret scanning work? Read this:
 #   https://lookingatcomputer.substack.com/p/regex-is-almost-all-you-need
@@ -3003,6 +3003,7 @@ id = "generic-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
 regex = '''(?i)(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passw(?:or)?d|secret|token)(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}([\w.=-]{10,150}|[a-z0-9][a-z0-9+/]{11,}={0,3})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 specificity = 0
+confidence = "low"
 keywords = [
     "access",
     "api",
@@ -3036,6 +3037,11 @@ let genericMatchPrefix = filter.findMatch(
 let genericMatchContext =
   genericMatchPrefix +
   finding["fragment_raw"][finding["match_start_idx"]:finding["match_end_idx"]];
+
+let level = filter.matchesAny(genericMatchContext, [
+  `(?i)\b[a-z0-9]+[_.-]+token\b`
+]) ? "medium" : "low";
+let _ = filter.setConfidence(level);
 
 // big ol expression to filter out FPs
 entropy(finding["secret"]) <= 3.5
@@ -6490,6 +6496,7 @@ entropy(finding["secret"]) < 3.5
 id = "openai-api-key"
 description = "Found an OpenAI API Key, posing a risk of unauthorized access to AI services and data manipulation."
 regex = '''\b(sk-(?:proj|svcacct|admin)-(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58}|[A-Za-z0-9_-]{20})T3BlbkFJ(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58}|[A-Za-z0-9_-]{20})\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+confidence = "high"
 keywords = ["t3blbkfj"]
 validate = '''
 let r = http.get("https://api.openai.com/v1/models", {

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ type rawRule struct {
 	Keywords    []string `toml:"keywords"`
 	Tags        []string `toml:"tags"`
 	Specificity *int     `toml:"specificity"`
+	Confidence  string   `toml:"confidence"`
 
 	// Deprecated: this is a shim for backwards-compatibility.
 	// TODO: Remove this in 9.x.
@@ -234,6 +235,7 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 			Keywords:        vr.Keywords,
 			Tags:            vr.Tags,
 			Specificity:     specificity,
+			Confidence:      vr.Confidence,
 			SkipReport:      vr.SkipReport,
 			TokenEfficiency: vr.TokenEfficiency,
 		}
@@ -691,6 +693,9 @@ func (c *Config) extend(extensionConfig *Config) {
 			}
 			if currentRule.ValidateExpr != "" {
 				baseRule.ValidateExpr = currentRule.ValidateExpr
+			}
+			if currentRule.Confidence != "" {
+				baseRule.Confidence = currentRule.Confidence
 			}
 			// Current rule's Filter replaces the extending one if set.
 			if currentRule.Filter != "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -128,6 +128,33 @@ func TestDefaultConfigExpressionsCompileWithExpr(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestGenericRuleConfidence(t *testing.T) {
+	cfg, err := Default()
+	require.NoError(t, err)
+	require.Equal(t, "low", cfg.Rules["generic-api-key"].Confidence)
+	require.Contains(t, cfg.Rules["generic-api-key"].Filter, `\b[a-z0-9]+[_.-]+token\b`)
+	require.Contains(t, cfg.Rules["generic-api-key"].Filter, `]) ? "medium" : "low";`)
+}
+
+func TestRuleConfidence(t *testing.T) {
+	cfg, err := ParseTOMLString(`
+[[rules]]
+id = "test"
+regex = "secret"
+confidence = "high"
+`, "")
+	require.NoError(t, err)
+	require.Equal(t, "high", cfg.Rules["test"].Confidence)
+
+	_, err = ParseTOMLString(`
+[[rules]]
+id = "test"
+regex = "secret"
+confidence = "certain"
+`, "")
+	require.ErrorContains(t, err, "invalid confidence")
+}
+
 func TestTranslateAllowlists(t *testing.T) {
 	tests := []translateCase{
 		// Global

--- a/config/rule.go
+++ b/config/rule.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/betterleaks/betterleaks/internal/confidence"
 	"github.com/betterleaks/betterleaks/internal/contextwindow"
 	"github.com/betterleaks/betterleaks/internal/exprruntime"
 	"github.com/betterleaks/betterleaks/regexp"
@@ -41,6 +42,9 @@ type Rule struct {
 	// Specificity controls precedence when overlapping findings compete.
 	// Higher specificity findings suppress lower specificity findings.
 	Specificity int
+
+	// Confidence estimates how likely a match is to be a real secret.
+	Confidence string
 
 	// Keywords are used for pre-regex check filtering. Rules that contain
 	// keywords will perform a quick string compare check to make sure the
@@ -118,6 +122,9 @@ func (r *Rule) Validate() error {
 	// Ensure the rule actually matches something.
 	if r.Regex == nil && r.Path == nil {
 		return errors.New(r.RuleID + ": both |regex| and |path| are empty, this rule will have no effect")
+	}
+	if r.Confidence != "" && !confidence.Valid(r.Confidence) {
+		return fmt.Errorf("%s: invalid confidence %q (expected low, medium, or high)", r.RuleID, r.Confidence)
 	}
 
 	// Ensure |secretGroup| works.

--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/internal/confidence"
 	"github.com/betterleaks/betterleaks/logging"
 	"github.com/betterleaks/betterleaks/report"
 	"github.com/betterleaks/betterleaks/sources"
@@ -164,6 +165,9 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		logger.Debug().
 			Str("fingerprint", finding.Fingerprint).
 			Msgf("skipping finding: baseline")
+		return
+	}
+	if !confidence.Meets(finding.Attr(confidence.Attribute), d.MinConfidence) {
 		return
 	}
 

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -562,9 +562,6 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 					if d.ignore(finding) {
 						continue
 					}
-					if !confidence.Meets(finding.Attr(confidence.Attribute), d.MinConfidence) {
-						continue
-					}
 					if d.ValidationPool != nil {
 						if prg, ok, err := d.validationProgram(finding.RuleID); err != nil {
 							return err
@@ -769,7 +766,11 @@ ScanLoop:
 					break ScanLoop
 				default:
 					rule := d.Config.Rules[ruleID]
-					findings = append(findings, d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings)...)
+					for _, finding := range d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings) {
+						if confidence.Meets(finding.Attr(confidence.Attribute), d.MinConfidence) {
+							findings = append(findings, finding)
+						}
+					}
 				}
 			}
 			// Pool entries must be blank because later scans may run on any goroutine.

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -20,6 +20,7 @@ import (
 	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect/codec"
 	"github.com/betterleaks/betterleaks/internal/ahocorasick"
+	"github.com/betterleaks/betterleaks/internal/confidence"
 	"github.com/betterleaks/betterleaks/internal/contextwindow"
 	"github.com/betterleaks/betterleaks/internal/exprruntime"
 	"github.com/betterleaks/betterleaks/internal/validate"
@@ -92,6 +93,9 @@ type Detector struct {
 	// ValidationStatusFilter, when non-empty, restricts which findings are
 	// printed in verbose mode. Parsed from --validation-status.
 	ValidationStatusFilter map[string]struct{}
+
+	// MinConfidence suppresses classified findings below this level.
+	MinConfidence string
 
 	// ValidationPool is the expression validation worker pool.
 	ValidationPool *validate.Pool
@@ -462,6 +466,9 @@ func newPathOnlyFinding(r config.Rule, fragment sources.Fragment) report.Finding
 		Attributes:      maps.Clone(fragment.Attributes),
 		RuleSpecificity: r.Specificity,
 	}
+	if r.Confidence != "" {
+		finding.SetAttr(confidence.Attribute, r.Confidence)
+	}
 	finding.SyncDeprecatedSourceFields()
 	return finding
 }
@@ -553,6 +560,9 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 				findings := d.detectFragment(runCtx, fragment)
 				for _, finding := range findings {
 					if d.ignore(finding) {
+						continue
+					}
+					if !confidence.Meets(finding.Attr(confidence.Attribute), d.MinConfidence) {
 						continue
 					}
 					if d.ValidationPool != nil {
@@ -928,6 +938,9 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			Tags:            tags,
 			RuleSpecificity: r.Specificity,
 		}
+		if r.Confidence != "" {
+			finding.SetAttr(confidence.Attribute, r.Confidence)
+		}
 
 		// TODO eventually move this git specific bit into somewhere... better?
 		platform := finding.Attr(sources.AttrGitPlatform)
@@ -1010,6 +1023,9 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		// Build finding map once, only when at least one filter program is compiled.
 		var findingMap map[string]any
 		if hasGlobalFilter || hasRuleFilter {
+			if finding.Attributes == nil {
+				finding.Attributes = make(map[string]string)
+			}
 			findingMap = make(map[string]any, 12)
 			for key, value := range finding.ToExprMap() {
 				findingMap[key] = value
@@ -1037,7 +1053,7 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		if prg, ok, err := d.globalFilterProgram(); err != nil {
 			logger.Warn().Err(err).Msg("global filter compile error")
 		} else if ok {
-			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, fragment.Attributes)
+			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, finding.Attributes)
 			if err != nil {
 				logger.Warn().Err(err).Msg("global filter eval error")
 			} else if skip {
@@ -1052,7 +1068,7 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		if prg, ok, err := d.ruleFilterProgram(r); err != nil {
 			logger.Warn().Err(err).Msg("rule filter compile error")
 		} else if ok {
-			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, fragment.Attributes)
+			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, finding.Attributes)
 			if err != nil {
 				logger.Warn().Err(err).Msg("rule filter eval error")
 			} else if skip {

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -430,16 +430,12 @@ func TestDetectFilterMatchesContextWindow(t *testing.T) {
 }
 
 func TestConfidenceAttributeAndFilter(t *testing.T) {
-	rule := config.Rule{
-		RuleID:     "confidence",
-		Regex:      regexp.MustCompile(`[A-Z0-9]{20}`),
-		Confidence: "medium",
-		Filter:     `let _ = filter.setConfidence("high"); false`,
-	}
+	low := config.Rule{RuleID: "specific-low", Regex: regexp.MustCompile(`[A-Z0-9]{20}`), Specificity: 1, Confidence: "low"}
+	promoted := config.Rule{RuleID: "promoted", Regex: regexp.MustCompile(`[A-Z0-9]{20}`), Confidence: "medium", Filter: `let _ = filter.setConfidence("high"); false`}
 	cfg := &config.Config{
-		Rules:          map[string]config.Rule{rule.RuleID: rule},
-		NoKeywordRules: []string{rule.RuleID},
-		OrderedRules:   []string{rule.RuleID},
+		Rules:          map[string]config.Rule{low.RuleID: low, promoted.RuleID: promoted},
+		NoKeywordRules: []string{low.RuleID, promoted.RuleID},
+		OrderedRules:   []string{low.RuleID, promoted.RuleID},
 	}
 	require.NoError(t, cfg.CompileFilters(nil))
 
@@ -447,6 +443,7 @@ func TestConfidenceAttributeAndFilter(t *testing.T) {
 	detector.MinConfidence = "high"
 	findings := detector.DetectString("ABCDEFGHIJKLMNOPQRST")
 	require.Len(t, findings, 1)
+	require.Equal(t, "promoted", findings[0].RuleID)
 	require.Equal(t, "high", findings[0].Attributes["confidence"])
 }
 

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -429,6 +429,27 @@ func TestDetectFilterMatchesContextWindow(t *testing.T) {
 	assert.Equal(t, "ABCDEFGHIJKLMNOPQRST", findings[0].Secret)
 }
 
+func TestConfidenceAttributeAndFilter(t *testing.T) {
+	rule := config.Rule{
+		RuleID:     "confidence",
+		Regex:      regexp.MustCompile(`[A-Z0-9]{20}`),
+		Confidence: "medium",
+		Filter:     `let _ = filter.setConfidence("high"); false`,
+	}
+	cfg := &config.Config{
+		Rules:          map[string]config.Rule{rule.RuleID: rule},
+		NoKeywordRules: []string{rule.RuleID},
+		OrderedRules:   []string{rule.RuleID},
+	}
+	require.NoError(t, cfg.CompileFilters(nil))
+
+	detector := NewDetector(cfg)
+	detector.MinConfidence = "high"
+	findings := detector.DetectString("ABCDEFGHIJKLMNOPQRST")
+	require.Len(t, findings, 1)
+	require.Equal(t, "high", findings[0].Attributes["confidence"])
+}
+
 func TestDecodedFilterUsesDecodedMatchContext(t *testing.T) {
 	decoded := "provider decoded-secret-ABCDEFGHIJKLMNOPQRST"
 	raw := base64.StdEncoding.EncodeToString([]byte(decoded))

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,7 @@ Each `[[rules]]` entry can use:
 - `keywords`: strings used for fast pre-regex filtering.
 - `regex`: regular expression used to detect the secret.
 - `filter`: rule-specific Expr expression to discard false positives.
+- `confidence`: optional `low`, `medium`, or `high` likelihood classification.
 - `validate`: Expr expression to actively verify whether a secret is live.
 - `components`: required or optional component rules used to build multipart findings.
 
@@ -101,6 +102,7 @@ with Expr. If a filter expression evaluates to `true`, the item is skipped.
 | `filter.containsAny(string, list)` | Returns `true` if the string contains any listed term. Uses an efficient Aho-Corasick substring match. |
 | `filter.entropy(string)` | Returns Shannon entropy as a float. Useful for filtering non-random placeholders. |
 | `filter.failsTokenEfficiency(string)` | Returns `true` if the string tokenizes too efficiently and looks like natural language rather than a random secret. |
+| `filter.setConfidence(level)` | Sets the current finding's `confidence` attribute. Use as `let _ = filter.setConfidence(level);`. |
 
 Example:
 
@@ -126,6 +128,23 @@ filter = '''
 )
 '''
 ```
+
+Rules may set a default confidence and broad rules may refine it in their
+filter:
+
+```toml
+[[rules]]
+id = "generic-api-key"
+confidence = "low"
+filter = '''
+let level = filter.matchesAny(finding["line"], [`(?i)\b[a-z0-9]+[_.-]+token\b`]) ? "medium" : "low";
+let _ = filter.setConfidence(level);
+false
+'''
+```
+
+`--confidence low|medium|high` keeps findings at or above that level. Findings
+without a recognized confidence attribute remain included.
 
 ## Validation
 

--- a/internal/confidence/confidence.go
+++ b/internal/confidence/confidence.go
@@ -1,0 +1,42 @@
+package confidence
+
+import (
+	"fmt"
+	"strings"
+)
+
+const Attribute = "confidence"
+
+func Valid(value string) bool {
+	return value == "low" || value == "medium" || value == "high"
+}
+
+func Parse(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" || Valid(value) {
+		return value, nil
+	}
+	return "", fmt.Errorf("invalid confidence %q (expected low, medium, or high)", value)
+}
+
+// Meets reports whether a finding confidence meets minimum. Unset or custom
+// values are retained for backward compatibility with arbitrary attributes.
+func Meets(value, minimum string) bool {
+	if minimum == "" || !Valid(value) {
+		return true
+	}
+	return rank(value) >= rank(minimum)
+}
+
+func rank(value string) int {
+	switch value {
+	case "low":
+		return 1
+	case "medium":
+		return 2
+	case "high":
+		return 3
+	default:
+		return 0
+	}
+}

--- a/internal/confidence/confidence_test.go
+++ b/internal/confidence/confidence_test.go
@@ -1,0 +1,27 @@
+package confidence
+
+import "testing"
+
+func TestMeets(t *testing.T) {
+	for _, tc := range []struct {
+		value, minimum string
+		want           bool
+	}{
+		{"low", "medium", false},
+		{"medium", "medium", true},
+		{"high", "medium", true},
+		{"", "high", true},
+		{"custom", "high", true},
+	} {
+		if got := Meets(tc.value, tc.minimum); got != tc.want {
+			t.Fatalf("Meets(%q, %q) = %v, want %v", tc.value, tc.minimum, got, tc.want)
+		}
+	}
+
+	if got, err := Parse(" HIGH "); err != nil || got != "high" {
+		t.Fatalf("Parse(HIGH) = %q, %v", got, err)
+	}
+	if _, err := Parse("certain"); err == nil {
+		t.Fatal("Parse(certain) succeeded")
+	}
+}

--- a/internal/exprruntime/bindings_filter.go
+++ b/internal/exprruntime/bindings_filter.go
@@ -1,11 +1,13 @@
 package exprruntime
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strings"
 	"sync"
 
+	"github.com/betterleaks/betterleaks/internal/confidence"
 	"github.com/betterleaks/betterleaks/internal/words"
 	blregexp "github.com/betterleaks/betterleaks/regexp"
 	tiktoken "github.com/pkoukk/tiktoken-go"
@@ -25,6 +27,14 @@ func filterNamespace(rt *runtimeBindings) map[string]any {
 		"entropy":              shannonEntropy,
 		"failsTokenEfficiency": rt.failsTokenEfficiency,
 	}
+}
+
+func (rt *runtimeBindings) setConfidence(value string) (string, error) {
+	if !confidence.Valid(value) {
+		return "", fmt.Errorf("filter.setConfidence: invalid confidence %q (expected low, medium, or high)", value)
+	}
+	rt.attrs.(map[string]string)[confidence.Attribute] = value
+	return value, nil
 }
 
 func orderedKey(ss []string) string { return strings.Join(ss, "\x00") }

--- a/internal/exprruntime/conventions_test.go
+++ b/internal/exprruntime/conventions_test.go
@@ -35,7 +35,7 @@ func TestProjectFunctionNamesFollowConvention(t *testing.T) {
 			fns:  functionNames(filterBindings(nil, emptyFilterFinding, emptyStringMap)),
 			current: []string{
 				"filter.matchesAny", "filter.findMatch", "filter.containsAny", "filter.entropy",
-				"filter.failsTokenEfficiency",
+				"filter.failsTokenEfficiency", "filter.setConfidence",
 			},
 			deprecated: []string{"matchesAny", "containsAny", "entropy", "failsTokenEfficiency"},
 		},
@@ -96,6 +96,18 @@ func TestFilterEntropy(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 	require.True(t, skip)
+}
+
+func TestFilterSetConfidence(t *testing.T) {
+	env, err := New(nil)
+	require.NoError(t, err)
+	prg, err := env.CompileFilter(`let _ = filter.setConfidence("high"); false`, nil)
+	require.NoError(t, err)
+
+	attributes := map[string]string{}
+	_, err = env.EvalFilter(prg, nil, attributes)
+	require.NoError(t, err)
+	require.Equal(t, "high", attributes["confidence"])
 }
 
 func TestFilterEvalUsesPerCallBindings(t *testing.T) {

--- a/internal/exprruntime/runtime.go
+++ b/internal/exprruntime/runtime.go
@@ -257,8 +257,17 @@ func (e *Runtime) EvalFilter(prg Program, finding map[string]any, attributes map
 	if finding == nil {
 		finding = emptyFilterFinding
 	}
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
 	b["finding"] = finding
-	b["attributes"] = nonNilStringMap(attributes)
+	b["attributes"] = attributes
+	if rt, ok := b["__runtime"].(*runtimeBindings); ok {
+		rt.attrs = attributes
+		filter := filterNamespace(rt)
+		filter["setConfidence"] = rt.setConfidence
+		b["filter"] = filter
+	}
 	return runBool(prg, b, "filter")
 }
 
@@ -493,7 +502,9 @@ func nonNilStringMap(m map[string]string) map[string]string {
 }
 
 func filterBindings(tokenizer *tiktoken.Tiktoken, finding map[string]any, attributes map[string]string) bindings {
-	b := baseBindings(&runtimeBindings{tokenizer: tokenizer, attrs: attributes})
+	rt := &runtimeBindings{tokenizer: tokenizer, attrs: attributes}
+	b := baseBindings(rt)
+	b["filter"].(map[string]any)["setConfidence"] = rt.setConfidence
 	b["finding"] = finding
 	return b
 }


### PR DESCRIPTION
This pull request introduces a new "confidence" attribute to secret detection rules, allowing findings to be classified by their likelihood of being true positives (low, medium, high). It adds support for filtering findings by minimum confidence via a new CLI flag, updates the configuration and detection logic to propagate and respect confidence levels, and includes validation and tests to ensure correct usage.


`betterleaks dir . --confidence medium` for example