### PR TITLE
ignore Dojo Toolkit's deactivated Flickr API token

### DIFF
--- a/cmd/generate/config/rules/generic_api_key_filter.go
+++ b/cmd/generate/config/rules/generic_api_key_filter.go
@@ -61,6 +61,7 @@ var testAndPublicAPIFilters = []testAndPublicAPIFilter{
 	{regex: `public-token-test-` + uuidHex},                             // Stytch Public Test Token
 	{regex: `public-token-live-` + uuidHex},                             // Stytch Public Live Token
 	{regex: `pdl_sdbx_apikey_[a-z\d]{26}_[a-zA-Z\d]{22}_[a-zA-Z\d]{3}`}, // Paddle Sandbox API Key
+	{regex: `8c6803164dbc395fb7131c9d54843627`},                         // Flickr API key in Dojo Toolkit (deactivated)
 	// Regex + Keyword
 	{`pk_test_[A-Za-z0-9]{24}(?:[A-Za-z0-9]{10})?(?:[A-Za-z0-9]{65})?`, []string{"stripe", "woo", "wcm"}}, // Stripe and WooCommerce Sandbox Publishable Key
 	{`rk_test_[A-Za-z0-9]{24}(?:[A-Za-z0-9]{10})?(?:[A-Za-z0-9]{65})?`, []string{"stripe"}},               // Stripe Sandbox Restricted Key

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -1,7 +1,7 @@
 # This file has been auto-generated. Do not edit manually.
 # If you would like to contribute new rules, please use
 # cmd/generate/config/main.go and follow the contributing guidelines
-# at https://github.com/betterleaks/betterleaks/blob/master/CONTRIBUTING.md
+# at https://github.com/betterleaks/betterleaks/blob/main/.github/CONTRIBUTING.md
 #
 # How the hell does secret scanning work? Read this:
 #   https://lookingatcomputer.substack.com/p/regex-is-almost-all-you-need
@@ -4523,7 +4523,8 @@ entropy(finding["secret"]) <= 3.5
   `^mob-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
   `^public-token-test-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
   `^public-token-live-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`,
-  `^pdl_sdbx_apikey_[a-z\d]{26}_[a-zA-Z\d]{22}_[a-zA-Z\d]{3}$`
+  `^pdl_sdbx_apikey_[a-z\d]{26}_[a-zA-Z\d]{22}_[a-zA-Z\d]{3}$`,
+  `^8c6803164dbc395fb7131c9d54843627$`
 ])
 || (matchesAny(finding["secret"], [`^pk_test_[A-Za-z0-9]{24}(?:[A-Za-z0-9]{10})?(?:[A-Za-z0-9]{65})?$`]) && filter.containsAny(providerMatchContext, ["stripe", "woo", "wcm"]))
 || (matchesAny(finding["secret"], [`^rk_test_[A-Za-z0-9]{24}(?:[A-Za-z0-9]{10})?(?:[A-Za-z0-9]{65})?$`]) && filter.containsAny(providerMatchContext, ["stripe"]))


### PR DESCRIPTION
Fixes #295

With the change in this PR, betterleaks ignores the key:
```sh
% ./betterleaks --no-banner --verbose file FlickrBadge.js 
1:13PM INF scanned ~2698 bytes (2.70 KB) in 109ms
1:13PM INF no leaks found
```
I looked at filtering this in the [flickr.go](/betterleaks/betterleaks/blob/main/cmd/generate/config/rules/flickr.go) rule, but that matches on lines that contain "flickr", and most references to this token look more like this, and are skipped by that rule:

```
				query: {
					userid: "44153025@N00",
					apikey: "8c6803164dbc395fb7131c9d54843627",
```
