### PR TITLE
Rule/generic uri

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -490,6 +490,7 @@ func main() {
 		rules.ZAIAPIKey(),
 		rules.ZendeskSecretKey(),
 		rules.ZuploConsumerAPIKey(),
+		rules.GenericCredentialURI(),
 		rules.GenericUsername(),
 		rules.GenericPassword(),
 		rules.GenericCredential(),

--- a/cmd/generate/config/rules/generic_credential_uri.go
+++ b/cmd/generate/config/rules/generic_credential_uri.go
@@ -7,8 +7,13 @@ import (
 )
 
 func GenericCredentialURI() *config.Rule {
-	reservedHostPattern := `(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?`
-	ignoredHostsPattern := `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@` + reservedHostPattern + `(?::[0-9]{1,5})?(?:,` + reservedHostPattern + `(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
+	documentationHostPattern := `(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?\.?`
+	localOrReservedHostPattern := `(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?`
+	onlyHostListPattern := func(hostPattern string) string {
+		return `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@` + hostPattern + `(?::[0-9]{1,5})?(?:,` + hostPattern + `(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
+	}
+	ignoredHostsPattern := onlyHostListPattern(documentationHostPattern)
+	lowConfidenceHostsPattern := onlyHostListPattern(localOrReservedHostPattern)
 
 	// Capture the password as the reported secret while retaining the URI's
 	// credential-bearing structure as named captures. Every supported scheme
@@ -65,10 +70,14 @@ let isTestOrDocumentationSource = filter.matchesAny(attributes["path"], [
 let hasIgnoredHost = filter.matchesAny(finding["match"], [
   ` + "`" + ignoredHostsPattern + "`" + `
 ]);
+let hasLowConfidenceHost = filter.matchesAny(finding["match"], [
+  ` + "`" + lowConfidenceHostsPattern + "`" + `
+]);
 let level = (
   isExampleValue
   || isSyntheticCredentialTuple
   || isTestOrDocumentationSource
+  || hasLowConfidenceHost
 ) ? "low" : "medium";
 let _ = filter.setConfidence(level);
 
@@ -112,6 +121,10 @@ isInstructionalPlaceholder
 		`SSH_URL=ssh://foo:bar@gitlab.internal/repository`,
 		`DATABASE_URL=postgresql://alice:hunter2@example.com,db.internal/app`,
 		`SERVICE_URL=https://username:password@gitlab.company.com/api`,
+		`SSH_URL=ssh://alice:hunter2@host.invalid/repository`,
+		`SERVICE_URL=https://alice:s3cr3t@service.test/v1`,
+		`SERVICE_URL=https://alice:s3cr3t@localhost/v1`,
+		`REDIS_URL=redis://:s3cr3t@cache.localhost:6379/0`,
 	}
 	fps := []string{
 		`DATABASE_URL=postgres://alice@db.internal/app`,
@@ -127,14 +140,9 @@ isInstructionalPlaceholder
 		`SERVICE_URL=https://alice:s3cr3t@api.example.com/v1`,
 		`DATABASE_URL=postgres://alice:hunter2@db.example.net/app`,
 		`REDIS_URL=redis://:s3cr3t@cache.example/0`,
-		`SSH_URL=ssh://alice:hunter2@host.invalid/repository`,
-		`SERVICE_URL=https://alice:s3cr3t@service.test/v1`,
 		`SERVICE_URL=http://user:pass:word@old_configurator.example.com)`,
-		`SERVICE_URL=https://alice:s3cr3t@localhost/v1`,
-		`REDIS_URL=redis://:s3cr3t@cache.localhost:6379/0`,
 		`SERVICE_URL=https://alice:s3cr3t@example.com./v1`,
 		`SERVICE_URL=https://alice:s3cr3t@example.com?mode=test`,
-		`REDIS_URL=redis://:s3cr3t@cache.localhost.:6379/0`,
 		`DATABASE_URL=postgresql://alice:hunter2@example.com,db.example.net/app`,
 		`SERVICE_URL=http://username:password@example.com,https://test:test@example.org:9200`,
 		`DATABASE_URL=postgres://alice:replace_me@db.internal/app`,

--- a/cmd/generate/config/rules/generic_credential_uri.go
+++ b/cmd/generate/config/rules/generic_credential_uri.go
@@ -8,15 +8,17 @@ import (
 
 func GenericCredentialURI() *config.Rule {
 	// Capture the password as the reported secret while retaining the URI's
-	// credential-bearing structure as named captures. The deliberately narrow
-	// scheme list keeps ordinary HTTP URLs and email addresses out of this rule.
+	// credential-bearing structure as named captures. Every supported scheme
+	// still requires explicit userinfo, keeping ordinary URLs and emails out.
 	r := config.Rule{
 		RuleID:      "generic-credential-uri",
 		Confidence:  "medium",
 		Description: "Detected a password embedded in a service connection URI, which may expose direct access to the referenced service.",
-		Regex:       regexp.MustCompile(`(?i)\b(?P<uri>(?P<scheme>postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)`),
+		Regex:       regexp.MustCompile(`(?i)\b(?P<uri>(?P<scheme>https?|postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)`),
 		SecretGroup: 4,
 		Keywords: []string{
+			"http://",
+			"https://",
 			"postgres://",
 			"postgresql://",
 			"mysql://",
@@ -39,17 +41,29 @@ func GenericCredentialURI() *config.Rule {
 		// rules while leaving provider-specific rules at the default 100 ahead.
 		Specificity: 30,
 		Filter: `let isExampleValue = filter.matchesAny(finding["secret"], [
-  ` + "`(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`" + `,
-  ` + "`(?i)^(?:your[_-]?(?:password|passwd|pwd)|replace[_-]?me|password[_-]?goes[_-]?here|insert[_-].*[_-]here|placeholder)$`" + `
+  ` + "`(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`" + `
+]);
+let isInstructionalPlaceholder = filter.matchesAny(finding["secret"], [
+  ` + "`(?i)^(?:[a-z0-9]+[_.-])?(?:your[_.-]?(?:password|passwd|pwd)|(?:password|passwd|pwd)[_.-]goes[_.-]?here|replace[_.-]?me|insert[_.-].*[_.-]here|placeholder)$`" + `
+]);
+let isSyntheticExampleURI = filter.matchesAny(finding["match"], [
+  ` + "`(?i)^[a-z][a-z0-9+.-]*://(?:foo|user(?:name)?|example(?:[_.-]?user)?):(?:bar|pass(?:word)?|passwd|pwd|example(?:[_.-]?(?:password|passwd|pwd))?)@(?:(?:example|test)\\.(?:com|org|net)|example\\.invalid)(?::[0-9]{1,5})?(?:[/\\s'\"\\x60#]|$)`" + `
+]);
+let hasIgnoredHost = filter.matchesAny(finding["match"], [
+  ` + "`(?i)^[a-z][a-z0-9+.-]*://[^@\\s]+@(?:(?:[a-z0-9_-]+\\.)*example(?:\\.(?:com|org|net))?|(?:[a-z0-9_-]+\\.)*(?:invalid|test|localhost))(?::[0-9]{1,5})?(?:[/\\s'\"\\x60#<>{}\\[\\],;)]|$)`" + `
 ]);
 let level = isExampleValue ? "low" : "medium";
 let _ = filter.setConfidence(level);
 
 // Discard mechanically non-literal credentials. Weak and default passwords
 // remain reportable because the URI establishes their credential role.
-filter.matchesAny(finding["secret"], [
+isInstructionalPlaceholder
+|| isSyntheticExampleURI
+|| hasIgnoredHost
+|| filter.matchesAny(finding["secret"], [
   ` + "`^\\*+$`" + `,
   ` + "`^\\.+$`" + `,
+  ` + "`(?i)^x{4,}$`" + `,
   ` + "`^•+$`" + `,
   ` + "`(?i)^\\[?(?:redacted|masked|filtered)\\]?$`" + `,
   ` + "`^\\$\\{.*}$`" + `,
@@ -62,28 +76,44 @@ filter.matchesAny(finding["secret"], [
   ` + "`^%[A-Za-z_][A-Za-z0-9_]*%$`" + `,
   ` + "`^<[^>]+>$`" + `,
   ` + "`^\\[[A-Za-z_][A-Za-z0-9_.-]*]$`" + `,
+  ` + "`^\\{[^}]+}$`" + `,
   ` + "`(?:\\$\\{|#\\{|\\{\\{|%\\{)`" + `
 ])`,
 	}
 
 	tps := []string{
-		`DATABASE_URL="postgresql://alice:hunter2@db.example.com/app"`,
+		`DATABASE_URL="postgresql://alice:hunter2@db.internal/app"`,
+		`SERVICE_URL="https://alice:s3cr3t@service.internal/api"`,
+		`PROXY_URL=http://api-user:p%40ssword@proxy.internal:8080/v1`,
 		`REDIS_URL=redis://:s3cr3t@cache.internal:6379/0`,
-		`AMQP_URL='amqps://service:p%40ssword@rabbitmq.example.com/vhost'`,
+		`AMQP_URL='amqps://service:p%40ssword@rabbitmq.internal/vhost'`,
 		`LDAP_URL=ldaps://directory-user:correct-horse@ldap.internal:636/dc=example,dc=com`,
 		`SSH_URL=ssh://root:changeme@192.0.2.10:22/`,
 		`MONGO_URL=mongodb://reader:q9V7nB2K4xL8@mongo1.internal:27017,mongo2.internal:27017/app`,
-		`DATABASE_URL=POSTGRES://alice:example_password@localhost/app`,
-		`DATABASE_URL=postgres://alice:example%5Fpassword@localhost/app`,
+		`DATABASE_URL=POSTGRES://alice:example_password@db.internal/app`,
+		`DATABASE_URL=postgres://alice:example%5Fpassword@db.internal/app`,
+		`SSH_URL=ssh://foo:bar@gitlab.internal/repository`,
 	}
 	fps := []string{
-		`DATABASE_URL=postgres://alice@db.example.com/app`,
-		`DATABASE_URL=postgres://alice:@db.example.com/app`,
-		`DATABASE_URL=postgres://alice:${DB_PASSWORD}@db.example.com/app`,
-		`DATABASE_URL=postgres://alice:$DB_PASSWORD@db.example.com/app`,
-		`DATABASE_URL=postgres://{{ db_user }}:{{ db_password }}@db.example.com/app`,
-		`DATABASE_URL=postgres://<username>:<password>@db.example.com/app`,
-		`https://alice:hunter2@example.com/api`,
+		`DATABASE_URL=postgres://alice@db.internal/app`,
+		`DATABASE_URL=postgres://alice:@db.internal/app`,
+		`DATABASE_URL=postgres://alice:${DB_PASSWORD}@db.internal/app`,
+		`DATABASE_URL=postgres://alice:$DB_PASSWORD@db.internal/app`,
+		`DATABASE_URL=postgres://{{ db_user }}:{{ db_password }}@db.internal/app`,
+		`DATABASE_URL=postgres://<username>:<password>@db.internal/app`,
+		`SSH_URL=ssh://foo:bar@example.com`,
+		`FTP_URL=ftp://foo:bar@test.com/repository`,
+		`REDIS_URL=redis://:redis-password-goes-here@gitlab-redis/`,
+		`DATABASE_URL=postgres://user:password@example.org/app`,
+		`SERVICE_URL=https://alice:s3cr3t@api.example.com/v1`,
+		`DATABASE_URL=postgres://alice:hunter2@db.example.net/app`,
+		`REDIS_URL=redis://:s3cr3t@cache.example/0`,
+		`SSH_URL=ssh://alice:hunter2@host.invalid/repository`,
+		`SERVICE_URL=https://alice:s3cr3t@service.test/v1`,
+		`SERVICE_URL=http://user:pass:word@old_configurator.example.com)`,
+		`SERVICE_URL=https://alice:s3cr3t@localhost/v1`,
+		`REDIS_URL=redis://:s3cr3t@cache.localhost:6379/0`,
+		`DATABASE_URL=postgres://alice:replace_me@db.internal/app`,
 		`alice:hunter2@example.com`,
 	}
 	return utils.Validate(r, tps, fps)

--- a/cmd/generate/config/rules/generic_credential_uri.go
+++ b/cmd/generate/config/rules/generic_credential_uri.go
@@ -1,0 +1,90 @@
+package rules
+
+import (
+	"github.com/betterleaks/betterleaks/cmd/generate/config/utils"
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/regexp"
+)
+
+func GenericCredentialURI() *config.Rule {
+	// Capture the password as the reported secret while retaining the URI's
+	// credential-bearing structure as named captures. The deliberately narrow
+	// scheme list keeps ordinary HTTP URLs and email addresses out of this rule.
+	r := config.Rule{
+		RuleID:      "generic-credential-uri",
+		Confidence:  "medium",
+		Description: "Detected a password embedded in a service connection URI, which may expose direct access to the referenced service.",
+		Regex:       regexp.MustCompile(`(?i)\b(?P<uri>(?P<scheme>postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)`),
+		SecretGroup: 4,
+		Keywords: []string{
+			"postgres://",
+			"postgresql://",
+			"mysql://",
+			"mariadb://",
+			"mongodb://",
+			"mongodb+srv://",
+			"redis://",
+			"rediss://",
+			"amqp://",
+			"amqps://",
+			"ldap://",
+			"ldaps://",
+			"smtp://",
+			"smtps://",
+			"ftp://",
+			"ftps://",
+			"ssh://",
+		},
+		// Prefer this structural URI match over the generic username/password
+		// rules while leaving provider-specific rules at the default 100 ahead.
+		Specificity: 30,
+		Filter: `let isExampleValue = filter.matchesAny(finding["secret"], [
+  ` + "`(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`" + `,
+  ` + "`(?i)^(?:your[_-]?(?:password|passwd|pwd)|replace[_-]?me|password[_-]?goes[_-]?here|insert[_-].*[_-]here|placeholder)$`" + `
+]);
+let level = isExampleValue ? "low" : "medium";
+let _ = filter.setConfidence(level);
+
+// Discard mechanically non-literal credentials. Weak and default passwords
+// remain reportable because the URI establishes their credential role.
+filter.matchesAny(finding["secret"], [
+  ` + "`^\\*+$`" + `,
+  ` + "`^\\.+$`" + `,
+  ` + "`^•+$`" + `,
+  ` + "`(?i)^\\[?(?:redacted|masked|filtered)\\]?$`" + `,
+  ` + "`^\\$\\{.*}$`" + `,
+  ` + "`^\\$\\([^\\r\\n]+\\)$`" + `,
+  ` + "`^#\\{[^}\\r\\n]+}$`" + `,
+  ` + "`^\\{\\{[ \\t]*.+[ \\t]*}}$`" + `,
+  ` + "`^%\\{[^}]+}$`" + `,
+  ` + "`^\\$[A-Za-z_][A-Za-z0-9_]*$`" + `,
+  ` + "`(?i)^\\$env:[A-Za-z_][A-Za-z0-9_]*$`" + `,
+  ` + "`^%[A-Za-z_][A-Za-z0-9_]*%$`" + `,
+  ` + "`^<[^>]+>$`" + `,
+  ` + "`^\\[[A-Za-z_][A-Za-z0-9_.-]*]$`" + `,
+  ` + "`(?:\\$\\{|#\\{|\\{\\{|%\\{)`" + `
+])`,
+	}
+
+	tps := []string{
+		`DATABASE_URL="postgresql://alice:hunter2@db.example.com/app"`,
+		`REDIS_URL=redis://:s3cr3t@cache.internal:6379/0`,
+		`AMQP_URL='amqps://service:p%40ssword@rabbitmq.example.com/vhost'`,
+		`LDAP_URL=ldaps://directory-user:correct-horse@ldap.internal:636/dc=example,dc=com`,
+		`SSH_URL=ssh://root:changeme@192.0.2.10:22/`,
+		`MONGO_URL=mongodb://reader:q9V7nB2K4xL8@mongo1.internal:27017,mongo2.internal:27017/app`,
+		`DATABASE_URL=POSTGRES://alice:example_password@localhost/app`,
+		`DATABASE_URL=postgres://alice:example%5Fpassword@localhost/app`,
+	}
+	fps := []string{
+		`DATABASE_URL=postgres://alice@db.example.com/app`,
+		`DATABASE_URL=postgres://alice:@db.example.com/app`,
+		`DATABASE_URL=postgres://alice:${DB_PASSWORD}@db.example.com/app`,
+		`DATABASE_URL=postgres://alice:$DB_PASSWORD@db.example.com/app`,
+		`DATABASE_URL=postgres://{{ db_user }}:{{ db_password }}@db.example.com/app`,
+		`DATABASE_URL=postgres://<username>:<password>@db.example.com/app`,
+		`https://alice:hunter2@example.com/api`,
+		`alice:hunter2@example.com`,
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/generic_credential_uri.go
+++ b/cmd/generate/config/rules/generic_credential_uri.go
@@ -7,6 +7,9 @@ import (
 )
 
 func GenericCredentialURI() *config.Rule {
+	reservedHostPattern := `(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?`
+	ignoredHostsPattern := `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@` + reservedHostPattern + `(?::[0-9]{1,5})?(?:,` + reservedHostPattern + `(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
+
 	// Capture the password as the reported secret while retaining the URI's
 	// credential-bearing structure as named captures. Every supported scheme
 	// still requires explicit userinfo, keeping ordinary URLs and emails out.
@@ -49,10 +52,24 @@ let isInstructionalPlaceholder = filter.matchesAny(finding["secret"], [
 let isSyntheticExampleURI = filter.matchesAny(finding["match"], [
   ` + "`(?i)^[a-z][a-z0-9+.-]*://(?:foo|user(?:name)?|example(?:[_.-]?user)?):(?:bar|pass(?:word)?|passwd|pwd|example(?:[_.-]?(?:password|passwd|pwd))?)@(?:(?:example|test)\\.(?:com|org|net)|example\\.invalid)(?::[0-9]{1,5})?(?:[/\\s'\"\\x60#]|$)`" + `
 ]);
-let hasIgnoredHost = filter.matchesAny(finding["match"], [
-  ` + "`(?i)^[a-z][a-z0-9+.-]*://[^@\\s]+@(?:(?:[a-z0-9_-]+\\.)*example(?:\\.(?:com|org|net))?|(?:[a-z0-9_-]+\\.)*(?:invalid|test|localhost))(?::[0-9]{1,5})?(?:[/\\s'\"\\x60#<>{}\\[\\],;)]|$)`" + `
+let isSyntheticCredentialTuple = filter.matchesAny(finding["match"], [
+  ` + "`(?i)^[a-z][a-z0-9+.-]*://(?:foo|test|user(?:name)?|example(?:[_.-]?user)?)[0-9]{0,4}:(?:bar|test|pass(?:word)?|passwd|pwd|token|secret)[0-9]{0,4}[!?.]?@`" + `
 ]);
-let level = isExampleValue ? "low" : "medium";
+let isTestOrDocumentationSource = filter.matchesAny(attributes["path"], [
+  ` + "`(?i)(?:^|[/\\\\])(?:__tests__|tests?|testdata|specs?|fixtures?|mocks?|examples?|samples?|demos?|tutorials?|templates?|qa|e2e|documentation|docs?(?:[-_][a-z0-9-]+)?)(?:[/\\\\]|$)`" + `,
+  ` + "`(?i)(?:^|[/\\\\])readme(?:\\.[^/\\\\]+)?$`" + `,
+  ` + "`(?i)(?:^|[/\\\\])[^/\\\\]*(?:[_.-](?:test|spec)|(?:test|spec)[_.-])[^/\\\\]*\\.[^/\\\\]+$`" + `,
+  ` + "`(?i)\\.(?:example|sample|template)(?:\\.[^/\\\\]+)?$`" + `,
+  ` + "`(?i)\\.(?:md|mdx|rst|adoc|asciidoc)$`" + `
+]);
+let hasIgnoredHost = filter.matchesAny(finding["match"], [
+  ` + "`" + ignoredHostsPattern + "`" + `
+]);
+let level = (
+  isExampleValue
+  || isSyntheticCredentialTuple
+  || isTestOrDocumentationSource
+) ? "low" : "medium";
 let _ = filter.setConfidence(level);
 
 // Discard mechanically non-literal credentials. Weak and default passwords
@@ -93,6 +110,8 @@ isInstructionalPlaceholder
 		`DATABASE_URL=POSTGRES://alice:example_password@db.internal/app`,
 		`DATABASE_URL=postgres://alice:example%5Fpassword@db.internal/app`,
 		`SSH_URL=ssh://foo:bar@gitlab.internal/repository`,
+		`DATABASE_URL=postgresql://alice:hunter2@example.com,db.internal/app`,
+		`SERVICE_URL=https://username:password@gitlab.company.com/api`,
 	}
 	fps := []string{
 		`DATABASE_URL=postgres://alice@db.internal/app`,
@@ -113,6 +132,11 @@ isInstructionalPlaceholder
 		`SERVICE_URL=http://user:pass:word@old_configurator.example.com)`,
 		`SERVICE_URL=https://alice:s3cr3t@localhost/v1`,
 		`REDIS_URL=redis://:s3cr3t@cache.localhost:6379/0`,
+		`SERVICE_URL=https://alice:s3cr3t@example.com./v1`,
+		`SERVICE_URL=https://alice:s3cr3t@example.com?mode=test`,
+		`REDIS_URL=redis://:s3cr3t@cache.localhost.:6379/0`,
+		`DATABASE_URL=postgresql://alice:hunter2@example.com,db.example.net/app`,
+		`SERVICE_URL=http://username:password@example.com,https://test:test@example.org:9200`,
 		`DATABASE_URL=postgres://alice:replace_me@db.internal/app`,
 		`alice:hunter2@example.com`,
 	}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4814,11 +4814,13 @@ entropy(finding["secret"]) <= 3.5
 [[rules]]
 id = "generic-credential-uri"
 description = "Detected a password embedded in a service connection URI, which may expose direct access to the referenced service."
-regex = '''(?i)\b(?P<uri>(?P<scheme>postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)'''
+regex = '''(?i)\b(?P<uri>(?P<scheme>https?|postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)'''
 secretGroup = 4
 specificity = 30
 confidence = "medium"
 keywords = [
+    "http://",
+    "https://",
     "postgres://",
     "postgresql://",
     "mysql://",
@@ -4839,17 +4841,29 @@ keywords = [
 ]
 filter = '''
 let isExampleValue = filter.matchesAny(finding["secret"], [
-  `(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`,
-  `(?i)^(?:your[_-]?(?:password|passwd|pwd)|replace[_-]?me|password[_-]?goes[_-]?here|insert[_-].*[_-]here|placeholder)$`
+  `(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`
+]);
+let isInstructionalPlaceholder = filter.matchesAny(finding["secret"], [
+  `(?i)^(?:[a-z0-9]+[_.-])?(?:your[_.-]?(?:password|passwd|pwd)|(?:password|passwd|pwd)[_.-]goes[_.-]?here|replace[_.-]?me|insert[_.-].*[_.-]here|placeholder)$`
+]);
+let isSyntheticExampleURI = filter.matchesAny(finding["match"], [
+  `(?i)^[a-z][a-z0-9+.-]*://(?:foo|user(?:name)?|example(?:[_.-]?user)?):(?:bar|pass(?:word)?|passwd|pwd|example(?:[_.-]?(?:password|passwd|pwd))?)@(?:(?:example|test)\.(?:com|org|net)|example\.invalid)(?::[0-9]{1,5})?(?:[/\s'"\x60#]|$)`
+]);
+let hasIgnoredHost = filter.matchesAny(finding["match"], [
+  `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))(?::[0-9]{1,5})?(?:[/\s'"\x60#<>{}\[\],;)]|$)`
 ]);
 let level = isExampleValue ? "low" : "medium";
 let _ = filter.setConfidence(level);
 
 // Discard mechanically non-literal credentials. Weak and default passwords
 // remain reportable because the URI establishes their credential role.
-filter.matchesAny(finding["secret"], [
+isInstructionalPlaceholder
+|| isSyntheticExampleURI
+|| hasIgnoredHost
+|| filter.matchesAny(finding["secret"], [
   `^\*+$`,
   `^\.+$`,
+  `(?i)^x{4,}$`,
   `^•+$`,
   `(?i)^\[?(?:redacted|masked|filtered)\]?$`,
   `^\$\{.*}$`,
@@ -4862,6 +4876,7 @@ filter.matchesAny(finding["secret"], [
   `^%[A-Za-z_][A-Za-z0-9_]*%$`,
   `^<[^>]+>$`,
   `^\[[A-Za-z_][A-Za-z0-9_.-]*]$`,
+  `^\{[^}]+}$`,
   `(?:\$\{|#\{|\{\{|%\{)`
 ])
 '''

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4849,10 +4849,24 @@ let isInstructionalPlaceholder = filter.matchesAny(finding["secret"], [
 let isSyntheticExampleURI = filter.matchesAny(finding["match"], [
   `(?i)^[a-z][a-z0-9+.-]*://(?:foo|user(?:name)?|example(?:[_.-]?user)?):(?:bar|pass(?:word)?|passwd|pwd|example(?:[_.-]?(?:password|passwd|pwd))?)@(?:(?:example|test)\.(?:com|org|net)|example\.invalid)(?::[0-9]{1,5})?(?:[/\s'"\x60#]|$)`
 ]);
-let hasIgnoredHost = filter.matchesAny(finding["match"], [
-  `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))(?::[0-9]{1,5})?(?:[/\s'"\x60#<>{}\[\],;)]|$)`
+let isSyntheticCredentialTuple = filter.matchesAny(finding["match"], [
+  `(?i)^[a-z][a-z0-9+.-]*://(?:foo|test|user(?:name)?|example(?:[_.-]?user)?)[0-9]{0,4}:(?:bar|test|pass(?:word)?|passwd|pwd|token|secret)[0-9]{0,4}[!?.]?@`
 ]);
-let level = isExampleValue ? "low" : "medium";
+let isTestOrDocumentationSource = filter.matchesAny(attributes["path"], [
+  `(?i)(?:^|[/\\])(?:__tests__|tests?|testdata|specs?|fixtures?|mocks?|examples?|samples?|demos?|tutorials?|templates?|qa|e2e|documentation|docs?(?:[-_][a-z0-9-]+)?)(?:[/\\]|$)`,
+  `(?i)(?:^|[/\\])readme(?:\.[^/\\]+)?$`,
+  `(?i)(?:^|[/\\])[^/\\]*(?:[_.-](?:test|spec)|(?:test|spec)[_.-])[^/\\]*\.[^/\\]+$`,
+  `(?i)\.(?:example|sample|template)(?:\.[^/\\]+)?$`,
+  `(?i)\.(?:md|mdx|rst|adoc|asciidoc)$`
+]);
+let hasIgnoredHost = filter.matchesAny(finding["match"], [
+  `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?(?::[0-9]{1,5})?(?:,(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
+]);
+let level = (
+  isExampleValue
+  || isSyntheticCredentialTuple
+  || isTestOrDocumentationSource
+) ? "low" : "medium";
 let _ = filter.setConfidence(level);
 
 // Discard mechanically non-literal credentials. Weak and default passwords

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4860,12 +4860,16 @@ let isTestOrDocumentationSource = filter.matchesAny(attributes["path"], [
   `(?i)\.(?:md|mdx|rst|adoc|asciidoc)$`
 ]);
 let hasIgnoredHost = filter.matchesAny(finding["match"], [
+  `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?\.?(?::[0-9]{1,5})?(?:,(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?\.?(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
+]);
+let hasLowConfidenceHost = filter.matchesAny(finding["match"], [
   `(?i)^[a-z][a-z0-9+.-]*://[^@\s]+@(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?(?::[0-9]{1,5})?(?:,(?:(?:[a-z0-9_-]+\.)*example(?:\.(?:com|org|net))?|(?:[a-z0-9_-]+\.)*(?:invalid|test|localhost))\.?(?::[0-9]{1,5})?)*(?:[/?\s'"\x60#<>{}\[\];)]|,?$)`
 ]);
 let level = (
   isExampleValue
   || isSyntheticCredentialTuple
   || isTestOrDocumentationSource
+  || hasLowConfidenceHost
 ) ? "low" : "medium";
 let _ = filter.setConfidence(level);
 

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -4809,6 +4809,64 @@ entropy(finding["secret"]) <= 3.5
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# generic-credential-uri
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "generic-credential-uri"
+description = "Detected a password embedded in a service connection URI, which may expose direct access to the referenced service."
+regex = '''(?i)\b(?P<uri>(?P<scheme>postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|ldaps?|smtps?|ftps?|ssh)://(?P<username>[^:/@\s'"\x60]{0,128}):(?P<password>[^/@\s'"\x60]{1,256})@(?P<host>(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252}))(?::[0-9]{1,5})?(?:,(?:\[[0-9a-f:.%]+\]|[a-z0-9][a-z0-9._-]{0,252})(?::[0-9]{1,5})?)*(?:[/?][a-z0-9._~!$&(*+,;=:@%/?-]*)?)(?:[\s'"\x60#<>{}\[\],;)]|\\[nr]|$)'''
+secretGroup = 4
+specificity = 30
+confidence = "medium"
+keywords = [
+    "postgres://",
+    "postgresql://",
+    "mysql://",
+    "mariadb://",
+    "mongodb://",
+    "mongodb+srv://",
+    "redis://",
+    "rediss://",
+    "amqp://",
+    "amqps://",
+    "ldap://",
+    "ldaps://",
+    "smtp://",
+    "smtps://",
+    "ftp://",
+    "ftps://",
+    "ssh://",
+]
+filter = '''
+let isExampleValue = filter.matchesAny(finding["secret"], [
+  `(?i)^(?:(?:(?:an?|my)(?:[ _.-]|%(?:20|2d|5f))*)?example(?:(?:[ _.-]|%(?:20|2d|5f))*(?:password|passwd|pwd))?|(?:password|passwd|pwd)(?:[ _.-]|%(?:20|2d|5f))*example)(?:(?:[ _.-]|%(?:20|2d|5f))*[0-9]{1,4})?[!?.]*$`,
+  `(?i)^(?:your[_-]?(?:password|passwd|pwd)|replace[_-]?me|password[_-]?goes[_-]?here|insert[_-].*[_-]here|placeholder)$`
+]);
+let level = isExampleValue ? "low" : "medium";
+let _ = filter.setConfidence(level);
+
+// Discard mechanically non-literal credentials. Weak and default passwords
+// remain reportable because the URI establishes their credential role.
+filter.matchesAny(finding["secret"], [
+  `^\*+$`,
+  `^\.+$`,
+  `^•+$`,
+  `(?i)^\[?(?:redacted|masked|filtered)\]?$`,
+  `^\$\{.*}$`,
+  `^\$\([^\r\n]+\)$`,
+  `^#\{[^}\r\n]+}$`,
+  `^\{\{[ \t]*.+[ \t]*}}$`,
+  `^%\{[^}]+}$`,
+  `^\$[A-Za-z_][A-Za-z0-9_]*$`,
+  `(?i)^\$env:[A-Za-z_][A-Za-z0-9_]*$`,
+  `^%[A-Za-z_][A-Za-z0-9_]*%$`,
+  `^<[^>]+>$`,
+  `^\[[A-Za-z_][A-Za-z0-9_.-]*]$`,
+  `(?:\$\{|#\{|\{\{|%\{)`
+])
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # generic-password
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -715,6 +715,128 @@ end`
 	assert.Empty(t, genericPasswordFindings(`log-in(user, "hunter2")`))
 }
 
+func TestGenericCredentialURI(t *testing.T) {
+	detector, err := NewDetectorDefaultConfig()
+	require.NoError(t, err)
+
+	findingsForRule := func(raw, ruleID string) []report.Finding {
+		t.Helper()
+		var findings []report.Finding
+		for _, finding := range detector.DetectString(raw) {
+			if finding.RuleID == ruleID {
+				findings = append(findings, finding)
+			}
+		}
+		return findings
+	}
+
+	for name, tc := range map[string]struct {
+		raw      string
+		secret   string
+		scheme   string
+		username string
+		host     string
+	}{
+		"PostgreSQL": {
+			raw:      `DATABASE_URL="postgresql://alice:hunter2@db.example.com/app"`,
+			secret:   "hunter2",
+			scheme:   "postgresql",
+			username: "alice",
+			host:     "db.example.com",
+		},
+		"password-only Redis": {
+			raw:    `REDIS_URL=redis://:s3cr3t@cache.internal:6379/0`,
+			secret: "s3cr3t",
+			scheme: "redis",
+			host:   "cache.internal",
+		},
+		"percent-encoded AMQP": {
+			raw:      `AMQP_URL='amqps://service:p%40ssword@rabbitmq.example.com/vhost'`,
+			secret:   "p%40ssword",
+			scheme:   "amqps",
+			username: "service",
+			host:     "rabbitmq.example.com",
+		},
+		"short weak password": {
+			raw:      `SSH_URL=ssh://root:root@192.0.2.10:22/`,
+			secret:   "root",
+			scheme:   "ssh",
+			username: "root",
+			host:     "192.0.2.10",
+		},
+		"IPv6 host and fragment": {
+			raw:      `MYSQL_URL=mysql://service:p%2Fss@[2001:db8::1]:3306#primary`,
+			secret:   "p%2Fss",
+			scheme:   "mysql",
+			username: "service",
+			host:     "[2001:db8::1]",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule(tc.raw, "generic-credential-uri")
+			require.Len(t, findings, 1)
+			finding := findings[0]
+			assert.Equal(t, tc.secret, finding.Secret)
+			assert.Equal(t, "medium", finding.Attributes["confidence"])
+			assert.Equal(t, tc.scheme, finding.CaptureGroups["scheme"])
+			assert.Equal(t, tc.username, finding.CaptureGroups["username"])
+			assert.Equal(t, tc.secret, finding.CaptureGroups["password"])
+			assert.Equal(t, tc.host, finding.CaptureGroups["host"])
+			assert.Contains(t, finding.CaptureGroups["uri"], tc.secret)
+		})
+	}
+
+	for name, password := range map[string]string{
+		"example":          "example",
+		"numbered example": "example123!",
+		"example password": "example_password",
+		"reversed example": "PasswordExample!",
+		"encoded example":  "example%5Fpassword",
+		"instructional":    "replace_me",
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule("postgres://alice:"+password+"@db.example.com/app", "generic-credential-uri")
+			require.Len(t, findings, 1)
+			assert.Equal(t, password, findings[0].Secret)
+			assert.Equal(t, "low", findings[0].Attributes["confidence"])
+		})
+	}
+
+	// Weak and common default passwords are still credentials when embedded in
+	// a URI; their strength must not be confused with detection confidence.
+	for _, password := range []string{"changeme", "password", "guest"} {
+		findings := findingsForRule("postgres://alice:"+password+"@localhost/app", "generic-credential-uri")
+		require.Len(t, findings, 1)
+		assert.Equal(t, "medium", findings[0].Attributes["confidence"])
+	}
+
+	for name, raw := range map[string]string{
+		"missing password":     `postgres://alice@db.example.com/app`,
+		"empty password":       `postgres://alice:@db.example.com/app`,
+		"braced variable":      `postgres://alice:${DB_PASSWORD}@db.example.com/app`,
+		"shell variable":       `postgres://alice:$DB_PASSWORD@db.example.com/app`,
+		"template expressions": `postgres://{{ db_user }}:{{ db_password }}@db.example.com/app`,
+		"angle placeholders":   `postgres://<username>:<password>@db.example.com/app`,
+		"ordinary HTTPS URL":   `https://alice:hunter2@example.com/api`,
+		"email-like text":      `alice:hunter2@example.com`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Empty(t, findingsForRule(raw, "generic-credential-uri"))
+		})
+	}
+
+	// Provider-specific rules should suppress this generic fallback when they
+	// accept the same credential.
+	mongodb := detector.DetectString(`MONGO_URL="mongodb://svc-reader:q9V7nB2K4xL8@mongo.example.com:27017/app"`)
+	var mongodbRules []string
+	for _, finding := range mongodb {
+		if finding.RuleID == "mongodb-connection-string" || finding.RuleID == "generic-credential-uri" {
+			mongodbRules = append(mongodbRules, finding.RuleID)
+		}
+	}
+	assert.Equal(t, []string{"mongodb-connection-string"}, mongodbRules)
+}
+
 func TestComponentProximity(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -738,11 +738,25 @@ func TestGenericCredentialURI(t *testing.T) {
 		host     string
 	}{
 		"PostgreSQL": {
-			raw:      `DATABASE_URL="postgresql://alice:hunter2@db.example.com/app"`,
+			raw:      `DATABASE_URL="postgresql://alice:hunter2@db.internal/app"`,
 			secret:   "hunter2",
 			scheme:   "postgresql",
 			username: "alice",
-			host:     "db.example.com",
+			host:     "db.internal",
+		},
+		"HTTPS basic auth": {
+			raw:      `SERVICE_URL="https://alice:s3cr3t@service.internal/api"`,
+			secret:   "s3cr3t",
+			scheme:   "https",
+			username: "alice",
+			host:     "service.internal",
+		},
+		"HTTP percent-encoded password": {
+			raw:      `PROXY_URL=http://api-user:p%40ssword@proxy.internal:8080/v1`,
+			secret:   "p%40ssword",
+			scheme:   "http",
+			username: "api-user",
+			host:     "proxy.internal",
 		},
 		"password-only Redis": {
 			raw:    `REDIS_URL=redis://:s3cr3t@cache.internal:6379/0`,
@@ -751,11 +765,11 @@ func TestGenericCredentialURI(t *testing.T) {
 			host:   "cache.internal",
 		},
 		"percent-encoded AMQP": {
-			raw:      `AMQP_URL='amqps://service:p%40ssword@rabbitmq.example.com/vhost'`,
+			raw:      `AMQP_URL='amqps://service:p%40ssword@rabbitmq.internal/vhost'`,
 			secret:   "p%40ssword",
 			scheme:   "amqps",
 			username: "service",
-			host:     "rabbitmq.example.com",
+			host:     "rabbitmq.internal",
 		},
 		"short weak password": {
 			raw:      `SSH_URL=ssh://root:root@192.0.2.10:22/`,
@@ -792,10 +806,9 @@ func TestGenericCredentialURI(t *testing.T) {
 		"example password": "example_password",
 		"reversed example": "PasswordExample!",
 		"encoded example":  "example%5Fpassword",
-		"instructional":    "replace_me",
 	} {
 		t.Run(name, func(t *testing.T) {
-			findings := findingsForRule("postgres://alice:"+password+"@db.example.com/app", "generic-credential-uri")
+			findings := findingsForRule("postgres://alice:"+password+"@db.internal/app", "generic-credential-uri")
 			require.Len(t, findings, 1)
 			assert.Equal(t, password, findings[0].Secret)
 			assert.Equal(t, "low", findings[0].Attributes["confidence"])
@@ -805,29 +818,66 @@ func TestGenericCredentialURI(t *testing.T) {
 	// Weak and common default passwords are still credentials when embedded in
 	// a URI; their strength must not be confused with detection confidence.
 	for _, password := range []string{"changeme", "password", "guest"} {
-		findings := findingsForRule("postgres://alice:"+password+"@localhost/app", "generic-credential-uri")
+		findings := findingsForRule("postgres://alice:"+password+"@db.internal/app", "generic-credential-uri")
 		require.Len(t, findings, 1)
 		assert.Equal(t, "medium", findings[0].Attributes["confidence"])
 	}
 
 	for name, raw := range map[string]string{
-		"missing password":     `postgres://alice@db.example.com/app`,
-		"empty password":       `postgres://alice:@db.example.com/app`,
-		"braced variable":      `postgres://alice:${DB_PASSWORD}@db.example.com/app`,
-		"shell variable":       `postgres://alice:$DB_PASSWORD@db.example.com/app`,
-		"template expressions": `postgres://{{ db_user }}:{{ db_password }}@db.example.com/app`,
-		"angle placeholders":   `postgres://<username>:<password>@db.example.com/app`,
-		"ordinary HTTPS URL":   `https://alice:hunter2@example.com/api`,
-		"email-like text":      `alice:hunter2@example.com`,
+		"missing password":             `postgres://alice@db.internal/app`,
+		"empty password":               `postgres://alice:@db.internal/app`,
+		"braced variable":              `postgres://alice:${DB_PASSWORD}@db.internal/app`,
+		"shell variable":               `postgres://alice:$DB_PASSWORD@db.internal/app`,
+		"template expressions":         `postgres://{{ db_user }}:{{ db_password }}@db.internal/app`,
+		"angle placeholders":           `postgres://<username>:<password>@db.internal/app`,
+		"synthetic SSH URI":            `ssh://foo:bar@example.com`,
+		"synthetic database URI":       `postgres://username:password@example.org/app`,
+		"synthetic FTP URI":            `ftp://foo:bar@test.com/repository`,
+		"example.com host":             `https://alice:s3cr3t@example.com/api`,
+		"example.com subdomain":        `https://alice:s3cr3t@api.example.com/v1`,
+		"example.com underscore host":  `http://user:pass:word@old_configurator.example.com)`,
+		"example.net host":             `postgres://alice:hunter2@db.example.net/app`,
+		"reserved example TLD":         `redis://:s3cr3t@cache.example/0`,
+		"reserved invalid TLD":         `ssh://alice:hunter2@host.invalid/repository`,
+		"reserved test TLD":            `https://alice:s3cr3t@service.test/v1`,
+		"localhost":                    `https://alice:s3cr3t@localhost/v1`,
+		"localhost subdomain":          `redis://:s3cr3t@cache.localhost:6379/0`,
+		"instructional Redis password": `redis://:redis-password-goes-here@gitlab-redis/`,
+		"masked Redis password":        `redis://:xxxx@gitlab-redis/`,
+		"braced HTTP placeholder":      `http://user:{password}@service.internal/`,
+		"replace-me password":          `postgres://alice:replace_me@db.internal/app`,
+		"HTTPS URL without userinfo":   `https://example.com/api`,
+		"email-like text":              `alice:hunter2@example.com`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			assert.Empty(t, findingsForRule(raw, "generic-credential-uri"))
 		})
 	}
 
+	placeholderShapedInternalURI := findingsForRule(
+		`ssh://foo:bar@gitlab.internal/repository`,
+		"generic-credential-uri",
+	)
+	require.Len(t, placeholderShapedInternalURI, 1)
+	assert.Equal(t, "medium", placeholderShapedInternalURI[0].Attributes["confidence"])
+
+	nonReservedExamplePrefix := findingsForRule(
+		`https://alice:s3cr3t@example.company.internal/v1`,
+		"generic-credential-uri",
+	)
+	require.Len(t, nonReservedExamplePrefix, 1)
+	assert.Equal(t, "medium", nonReservedExamplePrefix[0].Attributes["confidence"])
+
+	nonReservedLocalhostPrefix := findingsForRule(
+		`https://alice:s3cr3t@localhost.internal/v1`,
+		"generic-credential-uri",
+	)
+	require.Len(t, nonReservedLocalhostPrefix, 1)
+	assert.Equal(t, "medium", nonReservedLocalhostPrefix[0].Attributes["confidence"])
+
 	// Provider-specific rules should suppress this generic fallback when they
 	// accept the same credential.
-	mongodb := detector.DetectString(`MONGO_URL="mongodb://svc-reader:q9V7nB2K4xL8@mongo.example.com:27017/app"`)
+	mongodb := detector.DetectString(`MONGO_URL="mongodb://svc-reader:q9V7nB2K4xL8@mongo.internal:27017/app"`)
 	var mongodbRules []string
 	for _, finding := range mongodb {
 		if finding.RuleID == "mongodb-connection-string" || finding.RuleID == "generic-credential-uri" {

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -719,10 +719,17 @@ func TestGenericCredentialURI(t *testing.T) {
 	detector, err := NewDetectorDefaultConfig()
 	require.NoError(t, err)
 
-	findingsForRule := func(raw, ruleID string) []report.Finding {
+	findingsForRule := func(raw, ruleID string, path ...string) []report.Finding {
 		t.Helper()
+		detected := detector.DetectString(raw)
+		if len(path) > 0 {
+			detected = detector.Detect(sources.Fragment{
+				Raw:        raw,
+				Attributes: map[string]string{sources.AttrPath: path[0]},
+			})
+		}
 		var findings []report.Finding
-		for _, finding := range detector.DetectString(raw) {
+		for _, finding := range detected {
 			if finding.RuleID == ruleID {
 				findings = append(findings, finding)
 			}
@@ -815,6 +822,50 @@ func TestGenericCredentialURI(t *testing.T) {
 		})
 	}
 
+	for name, raw := range map[string]string{
+		"generic username and password": `https://username:password@gitlab.company.com/api`,
+		"foo and bar":                   `https://foo:bar@demo.host/api`,
+		"numbered test tuple":           `https://test123:test123!@anotherhost/api`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule(raw, "generic-credential-uri")
+			require.Len(t, findings, 1)
+			assert.Equal(t, "low", findings[0].Attributes["confidence"])
+		})
+	}
+
+	for name, path := range map[string]string{
+		"test directory":          `test/integration/client.go`,
+		"spec filename":           `app/services/client_spec.rb`,
+		"fixture directory":       `config/fixtures/database.yml`,
+		"testdata directory":      `internal/client/testdata/config.yml`,
+		"example filename":        `config/database.example.yml`,
+		"template directory":      `ci/templates/database.yml`,
+		"QA directory":            `qa/runtime/config.rb`,
+		"documentation directory": `doc-locale/ja-jp/setup.md`,
+		"documentation extension": `guides/setup.rst`,
+		"readme":                  `config/README.md`,
+		"Windows test path":       `test\fixtures\database.yml`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule(
+				`postgresql://alice:hunter2@db.internal/app`,
+				"generic-credential-uri",
+				path,
+			)
+			require.Len(t, findings, 1)
+			assert.Equal(t, "low", findings[0].Attributes["confidence"])
+		})
+	}
+
+	productionSource := findingsForRule(
+		`postgresql://alice:hunter2@db.internal/app`,
+		"generic-credential-uri",
+		`config/production.yml`,
+	)
+	require.Len(t, productionSource, 1)
+	assert.Equal(t, "medium", productionSource[0].Attributes["confidence"])
+
 	// Weak and common default passwords are still credentials when embedded in
 	// a URI; their strength must not be confused with detection confidence.
 	for _, password := range []string{"changeme", "password", "guest"} {
@@ -842,6 +893,10 @@ func TestGenericCredentialURI(t *testing.T) {
 		"reserved test TLD":            `https://alice:s3cr3t@service.test/v1`,
 		"localhost":                    `https://alice:s3cr3t@localhost/v1`,
 		"localhost subdomain":          `redis://:s3cr3t@cache.localhost:6379/0`,
+		"example.com trailing dot":     `https://alice:s3cr3t@example.com./v1`,
+		"example.com query":            `https://alice:s3cr3t@example.com?mode=test`,
+		"localhost trailing dot":       `redis://:s3cr3t@cache.localhost.:6379/0`,
+		"all reserved hosts":           `postgresql://alice:hunter2@example.com,db.example.net/app`,
 		"instructional Redis password": `redis://:redis-password-goes-here@gitlab-redis/`,
 		"masked Redis password":        `redis://:xxxx@gitlab-redis/`,
 		"braced HTTP placeholder":      `http://user:{password}@service.internal/`,
@@ -854,12 +909,17 @@ func TestGenericCredentialURI(t *testing.T) {
 		})
 	}
 
+	assert.Empty(t, findingsForRule(
+		`http://username:password@example.com,https://test:test@example.org:9200`,
+		"generic-credential-uri",
+	))
+
 	placeholderShapedInternalURI := findingsForRule(
 		`ssh://foo:bar@gitlab.internal/repository`,
 		"generic-credential-uri",
 	)
 	require.Len(t, placeholderShapedInternalURI, 1)
-	assert.Equal(t, "medium", placeholderShapedInternalURI[0].Attributes["confidence"])
+	assert.Equal(t, "low", placeholderShapedInternalURI[0].Attributes["confidence"])
 
 	nonReservedExamplePrefix := findingsForRule(
 		`https://alice:s3cr3t@example.company.internal/v1`,
@@ -874,6 +934,17 @@ func TestGenericCredentialURI(t *testing.T) {
 	)
 	require.Len(t, nonReservedLocalhostPrefix, 1)
 	assert.Equal(t, "medium", nonReservedLocalhostPrefix[0].Attributes["confidence"])
+
+	for name, raw := range map[string]string{
+		"reserved host first": `postgresql://alice:hunter2@example.com,db.internal/app`,
+		"reserved host last":  `postgresql://alice:hunter2@db.internal,example.com/app`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule(raw, "generic-credential-uri")
+			require.Len(t, findings, 1)
+			assert.Equal(t, "medium", findings[0].Attributes["confidence"])
+		})
+	}
 
 	// Provider-specific rules should suppress this generic fallback when they
 	// accept the same credential.

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -834,6 +834,21 @@ func TestGenericCredentialURI(t *testing.T) {
 		})
 	}
 
+	for name, raw := range map[string]string{
+		"reserved invalid TLD":   `ssh://alice:hunter2@host.invalid/repository`,
+		"reserved test TLD":      `https://alice:s3cr3t@service.test/v1`,
+		"localhost":              `https://alice:s3cr3t@localhost/v1`,
+		"localhost subdomain":    `redis://:s3cr3t@cache.localhost:6379/0`,
+		"localhost trailing dot": `redis://:s3cr3t@cache.localhost.:6379/0`,
+		"documentation and test": `postgresql://alice:hunter2@example.com,service.test/app`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			findings := findingsForRule(raw, "generic-credential-uri")
+			require.Len(t, findings, 1)
+			assert.Equal(t, "low", findings[0].Attributes["confidence"])
+		})
+	}
+
 	for name, path := range map[string]string{
 		"test directory":          `test/integration/client.go`,
 		"spec filename":           `app/services/client_spec.rb`,
@@ -889,13 +904,8 @@ func TestGenericCredentialURI(t *testing.T) {
 		"example.com underscore host":  `http://user:pass:word@old_configurator.example.com)`,
 		"example.net host":             `postgres://alice:hunter2@db.example.net/app`,
 		"reserved example TLD":         `redis://:s3cr3t@cache.example/0`,
-		"reserved invalid TLD":         `ssh://alice:hunter2@host.invalid/repository`,
-		"reserved test TLD":            `https://alice:s3cr3t@service.test/v1`,
-		"localhost":                    `https://alice:s3cr3t@localhost/v1`,
-		"localhost subdomain":          `redis://:s3cr3t@cache.localhost:6379/0`,
 		"example.com trailing dot":     `https://alice:s3cr3t@example.com./v1`,
 		"example.com query":            `https://alice:s3cr3t@example.com?mode=test`,
-		"localhost trailing dot":       `redis://:s3cr3t@cache.localhost.:6379/0`,
 		"all reserved hosts":           `postgresql://alice:hunter2@example.com,db.example.net/app`,
 		"instructional Redis password": `redis://:redis-password-goes-here@gitlab-redis/`,
 		"masked Redis password":        `redis://:xxxx@gitlab-redis/`,
@@ -936,8 +946,10 @@ func TestGenericCredentialURI(t *testing.T) {
 	assert.Equal(t, "medium", nonReservedLocalhostPrefix[0].Attributes["confidence"])
 
 	for name, raw := range map[string]string{
-		"reserved host first": `postgresql://alice:hunter2@example.com,db.internal/app`,
-		"reserved host last":  `postgresql://alice:hunter2@db.internal,example.com/app`,
+		"reserved host first":  `postgresql://alice:hunter2@example.com,db.internal/app`,
+		"reserved host last":   `postgresql://alice:hunter2@db.internal,example.com/app`,
+		"localhost host first": `postgresql://alice:hunter2@localhost,db.internal/app`,
+		"test host last":       `postgresql://alice:hunter2@db.internal,service.test/app`,
 	} {
 		t.Run(name, func(t *testing.T) {
 			findings := findingsForRule(raw, "generic-credential-uri")


### PR DESCRIPTION
Adds a new generic-credential-uri rule for passwords embedded directly in connection URIs:
```
https://alice:s3cr3t@service.internal/api
postgresql://alice:hunter2@db.internal/app
redis://:s3cr3t@cache.internal:6379/0
```

We'll eventually add validators for non-http resources like postgres and redis but for no this is what we got.

Like all the generic rules, the filter is the trickest, nastiest part. The filter removes findings that are mechanically or structurally clear placeholders:
- Instructional values such as your_password, replace_me, and redis-password-goes-here.
- Synthetic tuples such as foo:bar@example.com.
- Masked or redacted values including ****, xxxx, [REDACTED], and bullet masks.
- Environment variables, shell substitutions, template expressions, and interpolations.
- Angle-, square-, and brace-delimited placeholders.
- Credentials targeting reserved documentation hosts:
  - example.com, example.net, and example.org, including subdomains.
  - Reserved .example, .invalid, and .test namespaces.
- localhost and any *.localhost hostname.