### PR TITLE
Add `report replay` and `report convert` commands

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func init() {
+	rootCmd.AddCommand(reportCmd)
+}
+
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "operate on existing report files",
+}

--- a/cmd/report_convert.go
+++ b/cmd/report_convert.go
@@ -21,11 +21,11 @@ func init() {
 var convertCmd = &cobra.Command{
 	Use:   "convert",
 	Short: "convert a JSON report to another format",
-	Long: `Reads a JSON report and writes it in the requested output format.
+	Long: `Reads a JSON or JSONL report and writes it in the requested output format.
 
 No filtering or suppression is applied; all input findings appear in the output.
 Use --report-path and --report-format (or --report-template) to select the output.
-Use --verbose to print findings to stdout in addition to writing the report file.`,
+Use --verbose to print verbose findings to stdout.`,
 	RunE: runConvert,
 }
 
@@ -47,7 +47,7 @@ func runConvert(cmd *cobra.Command, _ []string) error {
 	verbose := mustGetBoolFlag(cmd, "verbose")
 	legacyPrint := mustGetBoolFlag(cmd, "legacy-print")
 
-	findings, err := loadReplayInput(inputPath)
+	findings, err := report.LoadFindings(inputPath)
 	if err != nil {
 		return fmt.Errorf("--input: %w", err)
 	}

--- a/cmd/report_convert.go
+++ b/cmd/report_convert.go
@@ -14,12 +14,11 @@ import (
 
 func init() {
 	reportCmd.AddCommand(convertCmd)
-	convertCmd.Flags().String("input", "", `path to JSON report to convert ("-" for stdin)`)
-	_ = convertCmd.MarkFlagRequired("input")
 }
 
 var convertCmd = &cobra.Command{
-	Use:   "convert",
+	Use:   "convert [report.json]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "convert a JSON report to another format",
 	Long: `Reads a JSON or JSONL report and writes it in the requested output format.
 
@@ -29,8 +28,11 @@ Use --verbose to print verbose findings to stdout.`,
 	RunE: runConvert,
 }
 
-func runConvert(cmd *cobra.Command, _ []string) error {
-	inputPath := mustGetStringFlag(cmd, "input")
+func runConvert(cmd *cobra.Command, args []string) error {
+	inputPath := "-"
+	if len(args) > 0 {
+		inputPath = args[0]
+	}
 
 	// Config is only needed for SARIF rule ordering; use the input file's
 	// directory for discovery, falling back to "." for stdin.
@@ -49,7 +51,7 @@ func runConvert(cmd *cobra.Command, _ []string) error {
 
 	findings, err := report.LoadFindings(inputPath)
 	if err != nil {
-		return fmt.Errorf("--input: %w", err)
+		return fmt.Errorf("reading input: %w", err)
 	}
 
 	// Verbose output (Print handles its own redaction on a value copy).

--- a/cmd/report_convert.go
+++ b/cmd/report_convert.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/betterleaks/betterleaks/detect"
+	"github.com/betterleaks/betterleaks/report"
+)
+
+func init() {
+	reportCmd.AddCommand(convertCmd)
+	convertCmd.Flags().String("input", "", `path to JSON report to convert ("-" for stdin)`)
+	_ = convertCmd.MarkFlagRequired("input")
+}
+
+var convertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "convert a JSON report to another format",
+	Long: `Reads a JSON report and writes it in the requested output format.
+
+No filtering or suppression is applied; all input findings appear in the output.
+Use --report-path and --report-format (or --report-template) to select the output.
+Use --verbose to print findings to stdout in addition to writing the report file.`,
+	RunE: runConvert,
+}
+
+func runConvert(cmd *cobra.Command, _ []string) error {
+	inputPath := mustGetStringFlag(cmd, "input")
+
+	// Config is only needed for SARIF rule ordering; use the input file's
+	// directory for discovery, falling back to "." for stdin.
+	inputDir := "."
+	if inputPath != "-" {
+		inputDir = filepath.Dir(inputPath)
+	}
+	initConfig(inputDir)
+	initDiagnostics()
+	cfg := Config(cmd)
+
+	noColor := mustGetBoolFlag(cmd, "no-color")
+	redact := mustGetUIntFlag(cmd, "redact")
+	verbose := mustGetBoolFlag(cmd, "verbose")
+	legacyPrint := mustGetBoolFlag(cmd, "legacy-print")
+
+	findings, err := loadReplayInput(inputPath)
+	if err != nil {
+		return fmt.Errorf("--input: %w", err)
+	}
+
+	// Verbose output (Print handles its own redaction on a value copy).
+	if verbose {
+		for _, f := range findings {
+			if legacyPrint {
+				f.PrintLegacy(noColor, redact)
+			} else {
+				f.Print(noColor, redact)
+			}
+		}
+	}
+
+	// Permanently redact before writing the report.
+	detect.RedactFindings(findings, redact)
+
+	reporter, reportPath, err := buildReporter(cmd, cfg)
+	if err != nil {
+		return err
+	}
+	if reporter == nil {
+		return nil
+	}
+
+	var out io.WriteCloser
+	if reportPath == report.StdoutReportPath {
+		out = os.Stdout
+	} else {
+		if out, err = os.Create(reportPath); err != nil {
+			return fmt.Errorf("opening report path: %w", err)
+		}
+		defer func() { _ = out.Close() }()
+	}
+	if err = reporter.Write(out, findings); err != nil {
+		return fmt.Errorf("writing report: %w", err)
+	}
+	return nil
+}

--- a/cmd/report_replay.go
+++ b/cmd/report_replay.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -18,7 +17,7 @@ import (
 
 func init() {
 	reportCmd.AddCommand(replayCmd)
-	replayCmd.Flags().String("input", "", `path to JSON report to replay ("-" for stdin)`)
+	replayCmd.Flags().String("input", "", `path to JSON or JSONL report to replay ("-" for stdin)`)
 	_ = replayCmd.MarkFlagRequired("input")
 }
 
@@ -64,7 +63,7 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 	legacyPrint := mustGetBoolFlag(cmd, "legacy-print")
 
 	// Load input findings.
-	findings, err := loadReplayInput(inputPath)
+	findings, err := report.LoadFindings(inputPath)
 	if err != nil {
 		return fmt.Errorf("--input: %w", err)
 	}
@@ -138,26 +137,6 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 		os.Exit(exitCode)
 	}
 	return nil
-}
-
-// loadReplayInput decodes a JSON findings report from path or stdin ("-").
-func loadReplayInput(path string) ([]report.Finding, error) {
-	var r io.Reader
-	if path == "-" {
-		r = os.Stdin
-	} else {
-		f, err := os.Open(path)
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = f.Close() }()
-		r = f
-	}
-	var findings []report.Finding
-	if err := json.NewDecoder(r).Decode(&findings); err != nil {
-		return nil, fmt.Errorf("decoding JSON: %w", err)
-	}
-	return findings, nil
 }
 
 // loadReplaySuppression builds a Suppression from the standard ignore/baseline flags.

--- a/cmd/report_replay.go
+++ b/cmd/report_replay.go
@@ -17,12 +17,11 @@ import (
 
 func init() {
 	reportCmd.AddCommand(replayCmd)
-	replayCmd.Flags().String("input", "", `path to JSON or JSONL report to replay ("-" for stdin)`)
-	_ = replayCmd.MarkFlagRequired("input")
 }
 
 var replayCmd = &cobra.Command{
-	Use:   "replay",
+	Use:   "replay [report.json]",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "re-evaluate filters and suppression rules against a saved report",
 	Long: `Reads a previously generated JSON report and re-evaluates the current
 config's prefilter, filters, and ignore/baseline suppression against every
@@ -39,10 +38,13 @@ ValidationMeta are copied verbatim from the input report.`,
 	RunE: runReplay,
 }
 
-func runReplay(cmd *cobra.Command, _ []string) error {
+func runReplay(cmd *cobra.Command, args []string) error {
 	start := time.Now()
 
-	inputPath := mustGetStringFlag(cmd, "input")
+	inputPath := "-"
+	if len(args) > 0 {
+		inputPath = args[0]
+	}
 
 	// Use the input file's directory for config + ignore-file discovery.
 	// Falls back to "." when reading from stdin.
@@ -65,7 +67,7 @@ func runReplay(cmd *cobra.Command, _ []string) error {
 	// Load input findings.
 	findings, err := report.LoadFindings(inputPath)
 	if err != nil {
-		return fmt.Errorf("--input: %w", err)
+		return fmt.Errorf("reading input: %w", err)
 	}
 
 	// Build expr runtime and compile prefilter.

--- a/cmd/report_replay.go
+++ b/cmd/report_replay.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/betterleaks/betterleaks/detect"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/report"
+)
+
+func init() {
+	reportCmd.AddCommand(replayCmd)
+	replayCmd.Flags().String("input", "", `path to JSON report to replay ("-" for stdin)`)
+	_ = replayCmd.MarkFlagRequired("input")
+}
+
+var replayCmd = &cobra.Command{
+	Use:   "replay",
+	Short: "re-evaluate filters and suppression rules against a saved report",
+	Long: `Reads a previously generated JSON report and re-evaluates the current
+config's prefilter, filters, and ignore/baseline suppression against every
+finding. Produces a new report containing only the findings that still pass.
+
+Filters referencing finding.line require the original scan to have been run
+with --report-include-line.
+
+filter.setConfidence(...) side effects are applied: findings whose confidence
+is changed by a filter expression appear with the updated value in the output.
+
+Validation is not re-evaluated; ValidationStatus, ValidationReason, and
+ValidationMeta are copied verbatim from the input report.`,
+	RunE: runReplay,
+}
+
+func runReplay(cmd *cobra.Command, _ []string) error {
+	start := time.Now()
+
+	inputPath := mustGetStringFlag(cmd, "input")
+
+	// Use the input file's directory for config + ignore-file discovery.
+	// Falls back to "." when reading from stdin.
+	inputDir := "."
+	if inputPath != "-" {
+		inputDir = filepath.Dir(inputPath)
+	}
+
+	initConfig(inputDir)
+	initDiagnostics()
+
+	cfg := Config(cmd)
+
+	exitCode := mustGetIntFlag(cmd, "exit-code")
+	noColor := mustGetBoolFlag(cmd, "no-color")
+	redact := mustGetUIntFlag(cmd, "redact")
+	verbose := mustGetBoolFlag(cmd, "verbose")
+	legacyPrint := mustGetBoolFlag(cmd, "legacy-print")
+
+	// Load input findings.
+	findings, err := loadReplayInput(inputPath)
+	if err != nil {
+		return fmt.Errorf("--input: %w", err)
+	}
+
+	// Build expr runtime and compile prefilter.
+	rt, err := exprruntime.New(nil)
+	if err != nil {
+		return fmt.Errorf("creating expr runtime: %w", err)
+	}
+	if err = cfg.CompileFilters(nil); err != nil {
+		return fmt.Errorf("compiling filters: %w", err)
+	}
+
+	// Load ignore file + baseline suppression.
+	suppression, err := loadReplaySuppression(cmd, inputDir, redact)
+	if err != nil {
+		return err
+	}
+
+	// Run replay engine.
+	results, err := report.Replay(findings, report.ReplayOptions{
+		Config:      cfg,
+		ExprRuntime: rt,
+		FilterSet:   detect.NewFilterSet(cfg, rt),
+		Suppression: suppression,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Verbose output (Print handles its own redaction on a value copy).
+	if verbose {
+		for _, f := range results {
+			if legacyPrint {
+				f.PrintLegacy(noColor, redact)
+			} else {
+				f.Print(noColor, redact)
+			}
+		}
+	}
+
+	// Permanently redact before writing the report.
+	detect.RedactFindings(results, redact)
+
+	// Write report file if requested.
+	reporter, reportPath, err := buildReporter(cmd, cfg)
+	if err != nil {
+		return err
+	}
+	if reporter != nil {
+		var out io.WriteCloser
+		if reportPath == report.StdoutReportPath {
+			out = os.Stdout
+		} else {
+			if out, err = os.Create(reportPath); err != nil {
+				return fmt.Errorf("opening report path: %w", err)
+			}
+			defer func() { _ = out.Close() }()
+		}
+		if err = reporter.Write(out, results); err != nil {
+			return fmt.Errorf("writing report: %w", err)
+		}
+	}
+
+	// Summary and exit code (mirrors scan-command semantics).
+	elapsed := time.Since(start)
+	if len(results) == 0 {
+		logging.Info().Msgf("no findings after replay (%s)", FormatDuration(elapsed))
+	} else {
+		logging.Warn().Msgf("%d finding(s) after replay (%s)", len(results), FormatDuration(elapsed))
+		os.Exit(exitCode)
+	}
+	return nil
+}
+
+// loadReplayInput decodes a JSON findings report from path or stdin ("-").
+func loadReplayInput(path string) ([]report.Finding, error) {
+	var r io.Reader
+	if path == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	var findings []report.Finding
+	if err := json.NewDecoder(r).Decode(&findings); err != nil {
+		return nil, fmt.Errorf("decoding JSON: %w", err)
+	}
+	return findings, nil
+}
+
+// loadReplaySuppression builds a Suppression from the standard ignore/baseline flags.
+// inputDir is searched for ignore files in place of the scan source directory.
+func loadReplaySuppression(cmd *cobra.Command, inputDir string, redact uint) (*detect.Suppression, error) {
+	suppression := detect.NewSuppression()
+	suppression.Redact = redact
+
+	ignorePath, err := cmd.Flags().GetString("gitleaks-ignore-path")
+	if err != nil {
+		return nil, err
+	}
+
+	loadIgnoreFilesFrom(suppression.AddIgnoreFile, ignorePath, inputDir)
+
+	baselinePath, _ := cmd.Flags().GetString("baseline-path")
+	if baselinePath != "" {
+		baseline, err := detect.LoadBaseline(baselinePath)
+		if err != nil {
+			logging.Warn().Err(err).Msg("could not load baseline")
+		} else {
+			suppression.Baseline = baseline
+		}
+	}
+
+	return suppression, nil
+}

--- a/cmd/report_replay_test.go
+++ b/cmd/report_replay_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/detect"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/betterleaks/betterleaks/report"
+)
+
+func writeFixtureReport(t *testing.T, dir string, findings []report.Finding) string {
+	t.Helper()
+	data, err := json.Marshal(findings)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "input.json")
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}
+
+func TestLoadReplayInput(t *testing.T) {
+	fixture := []report.Finding{
+		{RuleID: "rule-a", Secret: "s3cr3t", Fingerprint: "fp1"},
+		{RuleID: "rule-b", Secret: "another", Fingerprint: "fp2"},
+	}
+	path := writeFixtureReport(t, t.TempDir(), fixture)
+
+	got, err := loadReplayInput(path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "rule-a", got[0].RuleID)
+	assert.Equal(t, "s3cr3t", got[0].Secret)
+	assert.Equal(t, "rule-b", got[1].RuleID)
+}
+
+func TestLoadReplayInputInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0600))
+
+	_, err := loadReplayInput(path)
+	assert.Error(t, err)
+}
+
+func TestLoadReplayInputMissingFile(t *testing.T) {
+	_, err := loadReplayInput(filepath.Join(t.TempDir(), "nonexistent.json"))
+	assert.Error(t, err)
+}
+
+// TestReplayCmdPipeline exercises the full path from JSON file → loadReplayInput →
+// report.Replay → result, simulating what runReplay does without invoking cobra.
+func TestReplayCmdPipeline(t *testing.T) {
+	fixture := []report.Finding{
+		{RuleID: "test-rule", Secret: "keep-me", Attributes: map[string]string{}},
+		{RuleID: "test-rule", Secret: "drop-me", Attributes: map[string]string{}},
+	}
+	path := writeFixtureReport(t, t.TempDir(), fixture)
+
+	findings, err := loadReplayInput(path)
+	require.NoError(t, err)
+
+	filterExpr := `finding["secret"] == "drop-me"`
+	cfg := &config.Config{
+		Filter: filterExpr,
+		Rules:  map[string]config.Rule{"test-rule": {RuleID: "test-rule", Filter: filterExpr}},
+	}
+	require.NoError(t, cfg.CompileFilters(nil))
+
+	rt, err := exprruntime.New(nil)
+	require.NoError(t, err)
+
+	results, err := report.Replay(findings, report.ReplayOptions{
+		Config:      cfg,
+		ExprRuntime: rt,
+		FilterSet:   detect.NewFilterSet(cfg, rt),
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "keep-me", results[0].Secret)
+}

--- a/cmd/report_replay_test.go
+++ b/cmd/report_replay_test.go
@@ -24,14 +24,14 @@ func writeFixtureReport(t *testing.T, dir string, findings []report.Finding) str
 	return path
 }
 
-func TestLoadReplayInput(t *testing.T) {
+func TestLoadFindings(t *testing.T) {
 	fixture := []report.Finding{
 		{RuleID: "rule-a", Secret: "s3cr3t", Fingerprint: "fp1"},
 		{RuleID: "rule-b", Secret: "another", Fingerprint: "fp2"},
 	}
 	path := writeFixtureReport(t, t.TempDir(), fixture)
 
-	got, err := loadReplayInput(path)
+	got, err := report.LoadFindings(path)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 	assert.Equal(t, "rule-a", got[0].RuleID)
@@ -39,20 +39,43 @@ func TestLoadReplayInput(t *testing.T) {
 	assert.Equal(t, "rule-b", got[1].RuleID)
 }
 
-func TestLoadReplayInputInvalidJSON(t *testing.T) {
+func TestLoadFindingsJSONL(t *testing.T) {
+	fixture := []report.Finding{
+		{RuleID: "rule-a", Secret: "s3cr3t", Fingerprint: "fp1"},
+		{RuleID: "rule-b", Secret: "another", Fingerprint: "fp2"},
+	}
+	var lines []byte
+	for _, f := range fixture {
+		b, err := json.Marshal(f)
+		require.NoError(t, err)
+		lines = append(lines, b...)
+		lines = append(lines, '\n')
+	}
+	path := filepath.Join(t.TempDir(), "input.jsonl")
+	require.NoError(t, os.WriteFile(path, lines, 0600))
+
+	got, err := report.LoadFindings(path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "rule-a", got[0].RuleID)
+	assert.Equal(t, "s3cr3t", got[0].Secret)
+	assert.Equal(t, "rule-b", got[1].RuleID)
+}
+
+func TestLoadFindingsInvalidJSON(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bad.json")
 	require.NoError(t, os.WriteFile(path, []byte("not json"), 0600))
 
-	_, err := loadReplayInput(path)
+	_, err := report.LoadFindings(path)
 	assert.Error(t, err)
 }
 
-func TestLoadReplayInputMissingFile(t *testing.T) {
-	_, err := loadReplayInput(filepath.Join(t.TempDir(), "nonexistent.json"))
+func TestLoadFindingsMissingFile(t *testing.T) {
+	_, err := report.LoadFindings(filepath.Join(t.TempDir(), "nonexistent.json"))
 	assert.Error(t, err)
 }
 
-// TestReplayCmdPipeline exercises the full path from JSON file → loadReplayInput →
+// TestReplayCmdPipeline exercises the full path from JSON file → report.LoadFindings →
 // report.Replay → result, simulating what runReplay does without invoking cobra.
 func TestReplayCmdPipeline(t *testing.T) {
 	fixture := []report.Finding{
@@ -61,7 +84,7 @@ func TestReplayCmdPipeline(t *testing.T) {
 	}
 	path := writeFixtureReport(t, t.TempDir(), fixture)
 
-	findings, err := loadReplayInput(path)
+	findings, err := report.LoadFindings(path)
 	require.NoError(t, err)
 
 	filterExpr := `finding["secret"] == "drop-me"`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -291,6 +291,25 @@ func findIgnoreFile(dir string) string {
 	return ""
 }
 
+// loadIgnoreFilesFrom calls addFn for ignore files found at the standard three locations:
+// flagPath directly (if a file), the flagPath directory, and searchDir.
+func loadIgnoreFilesFrom(addFn func(string) error, flagPath, searchDir string) {
+	try := func(path string) {
+		if err := addFn(path); err != nil {
+			logging.Warn().Err(err).Str("path", path).Msg("could not load ignore file")
+		}
+	}
+	if fileExists(flagPath) {
+		try(flagPath)
+	}
+	if f := findIgnoreFile(flagPath); f != "" {
+		try(f)
+	}
+	if f := findIgnoreFile(searchDir); f != "" {
+		try(f)
+	}
+}
+
 func initDiagnostics() {
 	// Initialize diagnostics manager
 	diagnosticsFlag, err := rootCmd.PersistentFlags().GetString("diagnostics")
@@ -450,27 +469,7 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 	if err != nil {
 		logging.Fatal().Err(err).Msg("could not get ignore path")
 	}
-
-	// If the flag points directly to an ignore file, use it
-	if fileExists(ignorePath) {
-		if err = detector.AddGitleaksIgnore(ignorePath); err != nil {
-			logging.Fatal().Err(err).Msg("could not load ignore file")
-		}
-	}
-
-	// Check for ignore file in the flag directory (.betterleaksignore first, then .gitleaksignore)
-	if ignoreFile := findIgnoreFile(ignorePath); ignoreFile != "" {
-		if err = detector.AddGitleaksIgnore(ignoreFile); err != nil {
-			logging.Fatal().Err(err).Msg("could not load ignore file")
-		}
-	}
-
-	// Check for ignore file in the source directory (.betterleaksignore first, then .gitleaksignore)
-	if ignoreFile := findIgnoreFile(source); ignoreFile != "" {
-		if err = detector.AddGitleaksIgnore(ignoreFile); err != nil {
-			logging.Fatal().Err(err).Msg("could not load ignore file")
-		}
-	}
+	loadIgnoreFilesFrom(detector.AddGitleaksIgnore, ignorePath, source)
 
 	// ignore findings from the baseline (an existing report in json format generated earlier)
 	baselinePath, _ := cmd.Flags().GetString("baseline-path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("report-path", "r", "", "report file (use \"-\" for stdout)")
 	rootCmd.PersistentFlags().StringP("report-format", "f", "", "output format (json, csv, junit, sarif, template; validate supports pretty or jsonl)")
 	rootCmd.PersistentFlags().StringP("report-template", "", "", "template file used to generate the report (implies --report-format=template)")
+	rootCmd.PersistentFlags().Bool("report-include-line", false, "include matched line text in JSON reports (enables `betterleaks report replay` to evaluate filters referencing finding.line)")
 	rootCmd.PersistentFlags().StringP("baseline-path", "b", "", "path to baseline with issues that can be ignored")
 	rootCmd.PersistentFlags().StringP("log-level", "l", "info", "log level (trace, debug, info, warn, error, fatal)")
 	rootCmd.PersistentFlags().String("confidence", "", "minimum confidence to include (low, medium, high)")
@@ -421,6 +422,9 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 		logging.Fatal().Err(err).Send()
 	}
 	if detector.LegacyPrint, err = cmd.Flags().GetBool("legacy-print"); err != nil {
+		logging.Fatal().Err(err).Send()
+	}
+	if detector.PersistLine, err = cmd.Flags().GetBool("report-include-line"); err != nil {
 		logging.Fatal().Err(err).Send()
 	}
 	if detector.MaxTargetMegaBytes, err = cmd.Flags().GetInt("max-target-megabytes"); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -482,67 +482,81 @@ func Detector(cmd *cobra.Command, cfg *config.Config, source string) *detect.Det
 	}
 
 	// Validate report settings.
-	reportPath := mustGetStringFlag(cmd, "report-path")
+	reporter, reportPath, err := buildReporter(cmd, cfg)
+	if err != nil {
+		logging.Fatal().Err(err).Send()
+	}
 	if reportPath != "" {
-		if reportPath != report.StdoutReportPath {
-			// Ensure the path is writable.
-			if f, err := os.Create(reportPath); err != nil {
-				logging.Fatal().Err(err).Msgf("Report path is not writable: %s", reportPath)
-			} else {
-				_ = f.Close()
-				_ = os.Remove(reportPath)
-			}
-		}
-
-		// Build report writer.
-		var (
-			reporter       report.Reporter
-			reportFormat   = mustGetStringFlag(cmd, "report-format")
-			reportTemplate = mustGetStringFlag(cmd, "report-template")
-		)
-		if reportFormat == "" {
-			ext := strings.ToLower(filepath.Ext(reportPath))
-			switch ext {
-			case ".csv":
-				reportFormat = "csv"
-			case ".json":
-				reportFormat = "json"
-			case ".sarif":
-				reportFormat = "sarif"
-			default:
-				logging.Fatal().Msgf("Unknown report format: %s", reportFormat)
-			}
-			logging.Debug().Msgf("No report format specified, inferred %q from %q", reportFormat, ext)
-		}
-		switch strings.TrimSpace(strings.ToLower(reportFormat)) {
-		case "csv":
-			reporter = &report.CsvReporter{}
-		case "json":
-			reporter = &report.JsonReporter{}
-		case "junit":
-			reporter = &report.JunitReporter{}
-		case "sarif":
-			reporter = &report.SarifReporter{
-				OrderedRules: cfg.GetOrderedRules(),
-			}
-		case "template":
-			if reporter, err = report.NewTemplateReporter(reportTemplate); err != nil {
-				logging.Fatal().Err(err).Msg("Invalid report template")
-			}
-		default:
-			logging.Fatal().Msgf("unknown report format %s", reportFormat)
-		}
-
-		// Sanity check.
-		if reportTemplate != "" && reportFormat != "template" {
-			logging.Fatal().Msgf("Report format must be 'template' if --report-template is specified")
-		}
-
 		detector.ReportPath = reportPath
 		detector.Reporter = reporter
 	}
 
 	return detector
+}
+
+// buildReporter constructs a report.Reporter from the standard
+// --report-format / --report-path / --report-template flags.
+// reportPath is returned so callers can also open the destination file.
+// Returns a nil reporter and empty path when --report-path is not set.
+func buildReporter(cmd *cobra.Command, cfg *config.Config) (report.Reporter, string, error) {
+	reportPath := mustGetStringFlag(cmd, "report-path")
+	if reportPath == "" {
+		return nil, "", nil
+	}
+
+	if reportPath != report.StdoutReportPath {
+		if f, err := os.Create(reportPath); err != nil {
+			return nil, "", fmt.Errorf("report path is not writable: %w", err)
+		} else {
+			_ = f.Close()
+			_ = os.Remove(reportPath)
+		}
+	}
+
+	reportFormat := mustGetStringFlag(cmd, "report-format")
+	reportTemplate := mustGetStringFlag(cmd, "report-template")
+
+	if reportTemplate != "" && reportFormat != "" && reportFormat != "template" {
+		return nil, "", fmt.Errorf("report format must be 'template' if --report-template is specified")
+	}
+
+	if reportFormat == "" {
+		ext := strings.ToLower(filepath.Ext(reportPath))
+		switch ext {
+		case ".csv":
+			reportFormat = "csv"
+		case ".json":
+			reportFormat = "json"
+		case ".sarif":
+			reportFormat = "sarif"
+		default:
+			return nil, "", fmt.Errorf("unknown report format for path %q (use --report-format)", reportPath)
+		}
+		logging.Debug().Msgf("No report format specified, inferred %q from %q", reportFormat, ext)
+	}
+
+	var reporter report.Reporter
+	switch strings.TrimSpace(strings.ToLower(reportFormat)) {
+	case "csv":
+		reporter = &report.CsvReporter{}
+	case "json":
+		reporter = &report.JsonReporter{}
+	case "junit":
+		reporter = &report.JunitReporter{}
+	case "sarif":
+		reporter = &report.SarifReporter{
+			OrderedRules: cfg.GetOrderedRules(),
+		}
+	case "template":
+		var err error
+		if reporter, err = report.NewTemplateReporter(reportTemplate); err != nil {
+			return nil, "", fmt.Errorf("invalid report template: %w", err)
+		}
+	default:
+		return nil, "", fmt.Errorf("unknown report format %q", reportFormat)
+	}
+
+	return reporter, reportPath, nil
 }
 
 func bytesConvert(bytes uint64) string {

--- a/detect/baseline.go
+++ b/detect/baseline.go
@@ -71,7 +71,7 @@ func (d *Detector) AddBaseline(baselinePath string, source string) error {
 			return err
 		}
 
-		d.baseline = baseline
+		d.suppression.Baseline = baseline
 		baselinePath = relativeBaseline
 
 	}

--- a/detect/baseline_test.go
+++ b/detect/baseline_test.go
@@ -223,7 +223,7 @@ func TestIgnoreIssuesInBaseline(t *testing.T) {
 	for _, test := range tests {
 		d, err := NewDetectorDefaultConfig()
 		require.NoError(t, err)
-		d.baseline = test.baseline
+		d.suppression.Baseline = test.baseline
 		for _, finding := range test.findings {
 			d.AddFinding(finding)
 		}

--- a/detect/deprecated.go
+++ b/detect/deprecated.go
@@ -146,14 +146,14 @@ func (d *Detector) AddFinding(finding report.Finding) {
 
 	// check if we should ignore this finding
 	logger := logging.With().Str("finding", finding.Secret).Logger()
-	if _, ok := d.gitleaksIgnore[globalFingerprint]; ok {
+	if _, ok := d.suppression.Ignore[globalFingerprint]; ok {
 		logger.Debug().
 			Str("fingerprint", globalFingerprint).
 			Msg("skipping finding: global fingerprint")
 		return
 	} else if finding.Commit != "" {
 		// Awkward nested if because I'm not sure how to chain these two conditions.
-		if _, ok := d.gitleaksIgnore[finding.Fingerprint]; ok {
+		if _, ok := d.suppression.Ignore[finding.Fingerprint]; ok {
 			logger.Debug().
 				Str("fingerprint", finding.Fingerprint).
 				Msgf("skipping finding: fingerprint")
@@ -161,7 +161,7 @@ func (d *Detector) AddFinding(finding report.Finding) {
 		}
 	}
 
-	if d.baseline != nil && !IsNew(finding, d.Redact, d.baseline) {
+	if d.suppression.Baseline != nil && !IsNew(finding, d.Redact, d.suppression.Baseline) {
 		logger.Debug().
 			Str("fingerprint", finding.Fingerprint).
 			Msgf("skipping finding: baseline")

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -1,13 +1,11 @@
 package detect
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"iter"
 	"net/http"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -121,13 +119,10 @@ type Detector struct {
 	prefilter *ahocorasick.Matcher
 
 	// a list of known findings that should be ignored
-	baseline []report.Finding
+	suppression *Suppression
 
 	// path to baseline
 	baselinePath string
-
-	// gitleaksIgnore
-	gitleaksIgnore map[string]struct{}
 
 	TotalBytes atomic.Uint64
 
@@ -263,7 +258,7 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 
 	keywords := maps.Keys(cfg.Keywords)
 	d := &Detector{
-		gitleaksIgnore:         make(map[string]struct{}),
+		suppression:            NewSuppression(),
 		findings:               make([]report.Finding, 0),
 		ValidationCounts:       make(map[report.ValidationStatus]int),
 		Config:                 cfg,
@@ -593,74 +588,19 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 	}
 }
 
-// ignore compares a finding against a baseline report or betterleaksignore
-// file entries.
+// ignore compares a finding against the ignore file and baseline.
 func (d *Detector) ignore(finding report.Finding) bool {
-	logger := logging.With().Str("finding", finding.Secret).Logger()
-	path := finding.Attributes[sources.AttrPath]
-	globalFingerprint := fmt.Sprintf("%s:%s:%d", path, finding.RuleID, finding.StartLine)
-
-	if _, ok := d.gitleaksIgnore[globalFingerprint]; ok {
-		logger.Debug().
-			Str("fingerprint", finding.Fingerprint).
-			Msg("skipping finding: global fingerprint")
-		return true
-	}
-
-	if _, ok := d.gitleaksIgnore[finding.Fingerprint]; ok {
-		logger.Debug().
-			Str("fingerprint", finding.Fingerprint).
-			Msg("skipping finding: fingerprint")
-		return true
-	}
-
-	if d.baseline != nil && !IsNew(finding, d.Redact, d.baseline) {
-		logger.Debug().
-			Str("fingerprint", finding.Fingerprint).
-			Msgf("skipping finding: baseline")
-		return true
-	}
-	return false
+	d.suppression.Redact = d.Redact
+	return d.suppression.Suppressed(finding)
 }
 
-func (d *Detector) AddGitleaksIgnore(gitleaksIgnorePath string) error {
-	logging.Debug().Str("path", gitleaksIgnorePath).Msgf("found .gitleaksignore file")
-	file, err := os.Open(gitleaksIgnorePath)
+func (d *Detector) AddGitleaksIgnore(path string) error {
+	entries, err := LoadIgnoreFile(path)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		// https://github.com/securego/gosec/issues/512
-		if err := file.Close(); err != nil {
-			logging.Warn().Err(err).Msgf("Error closing .gitleaksignore file")
-		}
-	}()
-
-	scanner := bufio.NewScanner(file)
-	replacer := strings.NewReplacer("\\", "/")
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		// Skip lines that start with a comment
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		// Normalize the path.
-		// TODO: Make this a breaking change in v9.
-		s := strings.Split(line, ":")
-		switch len(s) {
-		case 3:
-			// Global fingerprint.
-			// `file:rule-id:start-line`
-			s[0] = replacer.Replace(s[0])
-		case 4:
-			// Commit fingerprint.
-			// `commit:file:rule-id:start-line`
-			s[1] = replacer.Replace(s[1])
-		default:
-			logging.Warn().Str("fingerprint", line).Msg("Invalid .gitleaksignore entry")
-		}
-		d.gitleaksIgnore[strings.Join(s, ":")] = struct{}{}
+	for k := range entries {
+		d.suppression.Ignore[k] = struct{}{}
 	}
 	return nil
 }

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -595,14 +595,7 @@ func (d *Detector) ignore(finding report.Finding) bool {
 }
 
 func (d *Detector) AddGitleaksIgnore(path string) error {
-	entries, err := LoadIgnoreFile(path)
-	if err != nil {
-		return err
-	}
-	for k := range entries {
-		d.suppression.Ignore[k] = struct{}{}
-	}
-	return nil
+	return d.suppression.AddIgnoreFile(path)
 }
 
 // DetectString scans the given string and returns a list of findings

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -109,6 +109,10 @@ type Detector struct {
 	// are included in validation output.
 	ValidationExtractEmpty bool
 
+	// PersistLine, when true, preserves the matched Line field in emitted findings.
+	// Required for `betterleaks report replay` to evaluate filters referencing finding.line.
+	PersistLine bool
+
 	// IgnoreGitleaksAllow is a flag to ignore gitleaks:allow comments.
 	IgnoreGitleaksAllow bool
 
@@ -620,6 +624,10 @@ func (d *Detector) Run(ctx context.Context, source sources.Source) iter.Seq[Resu
 					} else if _, ok := d.ValidationStatusFilter["none"]; !ok {
 						continue
 					}
+				}
+
+				if !d.PersistLine {
+					res.Finding.Line = ""
 				}
 
 				if !d.SkipFindingAppend {

--- a/detect/detect.go
+++ b/detect/detect.go
@@ -145,9 +145,7 @@ type Detector struct {
 	validationRuntime  *exprruntime.Runtime
 	validationProgramM sync.Mutex
 	validationPrograms map[string]exprruntime.Program
-	globalFilter       exprruntime.Program
-	filterProgramM     sync.Mutex
-	filterPrograms     map[string]exprruntime.Program
+	filterSet          *FilterSet
 
 	// rulesBySpecificity contains every configured rule ID in descending
 	// specificity order. Its positions are the shared index space used by the
@@ -274,7 +272,7 @@ func NewDetectorContext(ctx context.Context, cfg *config.Config, valOpts Validat
 		exprRuntime:            exprRuntime,
 		validationRuntime:      validationRuntime,
 		validationPrograms:     make(map[string]exprruntime.Program),
-		filterPrograms:         make(map[string]exprruntime.Program),
+		filterSet:              NewFilterSet(cfg, exprRuntime),
 		ValidationExtractEmpty: valOpts.ExtractEmpty,
 	}
 	d.rulesBySpecificity = orderedRulesBySpecificity(cfg)
@@ -364,23 +362,6 @@ func (d *Detector) Tokenizer() *tiktoken.Tiktoken {
 	return d.tokenizer
 }
 
-func (d *Detector) globalFilterProgram() (exprruntime.Program, bool, error) {
-	if d.Config.Filter == "" {
-		return nil, false, nil
-	}
-	d.filterProgramM.Lock()
-	defer d.filterProgramM.Unlock()
-	if d.globalFilter != nil {
-		return d.globalFilter, true, nil
-	}
-	prg, err := d.exprRuntime.CompileFilter(d.Config.Filter, nil)
-	if err != nil {
-		return nil, false, fmt.Errorf("compiling global filter: %w", err)
-	}
-	d.globalFilter = prg
-	return prg, true, nil
-}
-
 func (d *Detector) validationProgram(ruleID string) (exprruntime.Program, bool, error) {
 	if d.validationRuntime == nil {
 		return nil, false, nil
@@ -400,37 +381,6 @@ func (d *Detector) validationProgram(ruleID string) (exprruntime.Program, bool, 
 		return nil, false, fmt.Errorf("compiling rule %s validation: %w", ruleID, err)
 	}
 	d.validationPrograms[ruleID] = prg
-	return prg, true, nil
-}
-
-func (d *Detector) ruleFilterProgram(r config.Rule) (exprruntime.Program, bool, error) {
-	d.filterProgramM.Lock()
-	defer d.filterProgramM.Unlock()
-
-	rule := r
-	cacheable := false
-	if cfgRule, ok := d.Config.Rules[r.RuleID]; ok {
-		rule = cfgRule
-		cacheable = true
-	}
-	if rule.Filter == "" {
-		return nil, false, nil
-	}
-	if cacheable {
-		if prg := d.filterPrograms[rule.RuleID]; prg != nil {
-			return prg, true, nil
-		}
-	}
-	if prg := rule.FilterProgram(); prg != nil {
-		return prg, true, nil
-	}
-	prg, err := d.exprRuntime.CompileFilter(rule.Filter, nil)
-	if err != nil {
-		return nil, false, fmt.Errorf("compiling rule %s filter: %w", rule.RuleID, err)
-	}
-	if cacheable {
-		d.filterPrograms[rule.RuleID] = prg
-	}
 	return prg, true, nil
 }
 
@@ -1065,7 +1015,7 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 			}
 		}
 		// Global filter: Expr path (attributes + finding).
-		if prg, ok, err := d.globalFilterProgram(); err != nil {
+		if prg, ok, err := d.filterSet.Global(); err != nil {
 			logger.Warn().Err(err).Msg("global filter compile error")
 		} else if ok {
 			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, finding.Attributes)
@@ -1080,7 +1030,7 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 		}
 
 		// Rule filter: Expr path (includes entropy, regex/stopword allowlists, tokenEfficiency).
-		if prg, ok, err := d.ruleFilterProgram(r); err != nil {
+		if prg, ok, err := d.filterSet.ForRule(r); err != nil {
 			logger.Warn().Err(err).Msg("rule filter compile error")
 		} else if ok {
 			skip, err := d.exprRuntime.EvalFilter(prg, findingMap, finding.Attributes)

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -3612,13 +3612,13 @@ func TestNormalizeGitleaksIgnorePaths(t *testing.T) {
 	err = d.AddGitleaksIgnore("../testdata/gitleaksignore/.windowspaths")
 	require.NoError(t, err)
 
-	assert.Len(t, d.gitleaksIgnore, 3)
+	assert.Len(t, d.suppression.Ignore, 3)
 	expected := map[string]struct{}{
 		"foo/bar/gitleaks-false-positive.yaml:aws-access-token:4":                                                 {},
 		"foo/bar/gitleaks-false-positive.yaml:aws-access-token:5":                                                 {},
 		"b55d88dc151f7022901cda41a03d43e0e508f2b7:test_data/test_local_repo_three_leaks.json:aws-access-token:73": {},
 	}
-	assert.ElementsMatch(t, maps.Keys(d.gitleaksIgnore), maps.Keys(expected))
+	assert.ElementsMatch(t, maps.Keys(d.suppression.Ignore), maps.Keys(expected))
 }
 
 func TestWindowsFileSeparator_RulePath(t *testing.T) {

--- a/detect/filter_set.go
+++ b/detect/filter_set.go
@@ -1,0 +1,78 @@
+package detect
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+)
+
+// FilterSet compiles and caches global and per-rule filter programs.
+type FilterSet struct {
+	cfg     *config.Config
+	runtime *exprruntime.Runtime
+
+	mu      sync.Mutex
+	global  exprruntime.Program
+	perRule map[string]exprruntime.Program
+}
+
+// NewFilterSet creates a FilterCache backed by cfg and rt.
+func NewFilterSet(cfg *config.Config, rt *exprruntime.Runtime) *FilterSet {
+	return &FilterSet{
+		cfg:     cfg,
+		runtime: rt,
+		perRule: make(map[string]exprruntime.Program),
+	}
+}
+
+// Global compiles (once) and returns the config's global filter program.
+func (fc *FilterSet) Global() (exprruntime.Program, bool, error) {
+	if fc.cfg.Filter == "" {
+		return nil, false, nil
+	}
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+	if fc.global != nil {
+		return fc.global, true, nil
+	}
+	prg, err := fc.runtime.CompileFilter(fc.cfg.Filter, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("compiling global filter: %w", err)
+	}
+	fc.global = prg
+	return prg, true, nil
+}
+
+// ForRule compiles (once) and returns the filter program for the given rule.
+func (fc *FilterSet) ForRule(r config.Rule) (exprruntime.Program, bool, error) {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	rule := r
+	cacheable := false
+	if cfgRule, ok := fc.cfg.Rules[r.RuleID]; ok {
+		rule = cfgRule
+		cacheable = true
+	}
+	if rule.Filter == "" {
+		return nil, false, nil
+	}
+	if cacheable {
+		if prg := fc.perRule[rule.RuleID]; prg != nil {
+			return prg, true, nil
+		}
+	}
+	if prg := rule.FilterProgram(); prg != nil {
+		return prg, true, nil
+	}
+	prg, err := fc.runtime.CompileFilter(rule.Filter, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("compiling rule %s filter: %w", rule.RuleID, err)
+	}
+	if cacheable {
+		fc.perRule[rule.RuleID] = prg
+	}
+	return prg, true, nil
+}

--- a/detect/suppression.go
+++ b/detect/suppression.go
@@ -24,6 +24,18 @@ func NewSuppression() *Suppression {
 	return &Suppression{Ignore: make(map[string]struct{})}
 }
 
+// AddIgnoreFile loads a .betterleaksignore / .gitleaksignore file and merges its entries.
+func (s *Suppression) AddIgnoreFile(path string) error {
+	entries, err := LoadIgnoreFile(path)
+	if err != nil {
+		return err
+	}
+	for k := range entries {
+		s.Ignore[k] = struct{}{}
+	}
+	return nil
+}
+
 // LoadIgnoreFile parses .betterleaksignore / .gitleaksignore entries into a fingerprint set.
 func LoadIgnoreFile(path string) (map[string]struct{}, error) {
 	logging.Debug().Str("path", path).Msgf("found .gitleaksignore file")

--- a/detect/suppression.go
+++ b/detect/suppression.go
@@ -1,0 +1,91 @@
+package detect
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/betterleaks/betterleaks/logging"
+	"github.com/betterleaks/betterleaks/report"
+	"github.com/betterleaks/betterleaks/sources"
+)
+
+// Suppression combines the ignore-file fingerprint set and baseline findings
+// so the replay engine can apply them without instantiating a Detector.
+type Suppression struct {
+	Ignore   map[string]struct{}
+	Baseline []report.Finding
+	Redact   uint
+}
+
+// NewSuppression creates an empty Suppression ready for use.
+func NewSuppression() *Suppression {
+	return &Suppression{Ignore: make(map[string]struct{})}
+}
+
+// LoadIgnoreFile parses .betterleaksignore / .gitleaksignore entries into a fingerprint set.
+func LoadIgnoreFile(path string) (map[string]struct{}, error) {
+	logging.Debug().Str("path", path).Msgf("found .gitleaksignore file")
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			logging.Warn().Err(err).Msgf("Error closing .gitleaksignore file")
+		}
+	}()
+
+	entries := make(map[string]struct{})
+	scanner := bufio.NewScanner(f)
+	replacer := strings.NewReplacer("\\", "/")
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Normalize the path.
+		// TODO: Make this a breaking change in v9.
+		s := strings.Split(line, ":")
+		switch len(s) {
+		case 3:
+			// Global fingerprint: file:rule-id:start-line
+			s[0] = replacer.Replace(s[0])
+		case 4:
+			// Commit fingerprint: commit:file:rule-id:start-line
+			s[1] = replacer.Replace(s[1])
+		default:
+			logging.Warn().Str("fingerprint", line).Msg("Invalid .gitleaksignore entry")
+		}
+		entries[strings.Join(s, ":")] = struct{}{}
+	}
+	return entries, nil
+}
+
+// Suppressed reports whether a finding matches the ignore set or the baseline.
+func (s *Suppression) Suppressed(f report.Finding) bool {
+	logger := logging.With().Str("finding", f.Secret).Logger()
+	path := f.Attributes[sources.AttrPath]
+	globalFingerprint := fmt.Sprintf("%s:%s:%d", path, f.RuleID, f.StartLine)
+
+	if _, ok := s.Ignore[globalFingerprint]; ok {
+		logger.Debug().
+			Str("fingerprint", f.Fingerprint).
+			Msg("skipping finding: global fingerprint")
+		return true
+	}
+	if _, ok := s.Ignore[f.Fingerprint]; ok {
+		logger.Debug().
+			Str("fingerprint", f.Fingerprint).
+			Msg("skipping finding: fingerprint")
+		return true
+	}
+	if s.Baseline != nil && !IsNew(f, s.Redact, s.Baseline) {
+		logger.Debug().
+			Str("fingerprint", f.Fingerprint).
+			Msg("skipping finding: baseline")
+		return true
+	}
+	return false
+}

--- a/report/finding.go
+++ b/report/finding.go
@@ -31,7 +31,7 @@ type Finding struct {
 	// MatchContext contains surrounding lines around the match
 	MatchContext string `json:",omitempty"`
 
-	Line string `json:"-"`
+	Line string `json:",omitempty"`
 
 	// CaptureGroups holds named regex capture groups from the match.
 	CaptureGroups map[string]string `json:",omitempty"`

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -83,3 +83,41 @@ func TestWriteJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONLineField(t *testing.T) {
+	reporter := JsonReporter{}
+
+	t.Run("omitted when empty", func(t *testing.T) {
+		f := simpleFinding // Line is zero-value ""
+		tmp, err := os.Create(filepath.Join(t.TempDir(), "out.json"))
+		require.NoError(t, err)
+		defer tmp.Close()
+
+		require.NoError(t, reporter.Write(tmp, []Finding{f}))
+		data, err := os.ReadFile(tmp.Name())
+		require.NoError(t, err)
+
+		var findings []map[string]any
+		require.NoError(t, json.Unmarshal(data, &findings))
+		require.Len(t, findings, 1)
+		_, hasLine := findings[0]["Line"]
+		assert.False(t, hasLine, "Line should be absent when empty")
+	})
+
+	t.Run("round-trips when set", func(t *testing.T) {
+		f := simpleFinding
+		f.Line = "secret=hunter2"
+		tmp, err := os.Create(filepath.Join(t.TempDir(), "out.json"))
+		require.NoError(t, err)
+		defer tmp.Close()
+
+		require.NoError(t, reporter.Write(tmp, []Finding{f}))
+		data, err := os.ReadFile(tmp.Name())
+		require.NoError(t, err)
+
+		var findings []Finding
+		require.NoError(t, json.Unmarshal(data, &findings))
+		require.Len(t, findings, 1)
+		assert.Equal(t, "secret=hunter2", findings[0].Line)
+	})
+}

--- a/report/load.go
+++ b/report/load.go
@@ -1,0 +1,74 @@
+package report
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// LoadFindings reads a JSON or JSONL findings report from path or stdin ("-").
+// Format is detected automatically: a leading "[" means a JSON array; otherwise JSONL.
+func LoadFindings(path string) ([]Finding, error) {
+	var r io.Reader
+	if path == "-" {
+		r = os.Stdin
+	} else {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = f.Close() }()
+		r = f
+	}
+	return decodeFindings(r)
+}
+
+func decodeFindings(r io.Reader) ([]Finding, error) {
+	br := bufio.NewReader(r)
+
+	// Peek past leading whitespace to detect JSON array vs JSONL.
+	first, err := peekFirstNonSpace(br)
+	if err == io.EOF {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading input: %w", err)
+	}
+
+	dec := json.NewDecoder(br)
+	if first == '[' {
+		var findings []Finding
+		if err := dec.Decode(&findings); err != nil {
+			return nil, fmt.Errorf("decoding JSON: %w", err)
+		}
+		return findings, nil
+	}
+
+	// JSONL: one Finding object per line.
+	var findings []Finding
+	for dec.More() {
+		var f Finding
+		if err := dec.Decode(&f); err != nil {
+			return nil, fmt.Errorf("decoding JSONL: %w", err)
+		}
+		findings = append(findings, f)
+	}
+	return findings, nil
+}
+
+func peekFirstNonSpace(br *bufio.Reader) (byte, error) {
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		if b != ' ' && b != '\t' && b != '\r' && b != '\n' {
+			if err := br.UnreadByte(); err != nil {
+				return 0, err
+			}
+			return b, nil
+		}
+	}
+}

--- a/report/load_test.go
+++ b/report/load_test.go
@@ -1,0 +1,69 @@
+package report
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var fixtureFindings = []Finding{
+	{RuleID: "rule-a", Secret: "s3cr3t", Fingerprint: "fp1"},
+	{RuleID: "rule-b", Secret: "another", Fingerprint: "fp2"},
+}
+
+func writeJSON(t *testing.T, dir string, findings []Finding) string {
+	t.Helper()
+	data, err := json.Marshal(findings)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "input.json")
+	require.NoError(t, os.WriteFile(path, data, 0600))
+	return path
+}
+
+func writeJSONL(t *testing.T, dir string, findings []Finding) string {
+	t.Helper()
+	var sb strings.Builder
+	enc := json.NewEncoder(&sb)
+	for _, f := range findings {
+		require.NoError(t, enc.Encode(f))
+	}
+	path := filepath.Join(dir, "input.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(sb.String()), 0600))
+	return path
+}
+
+func assertFixtureFindings(t *testing.T, path string) {
+	t.Helper()
+	got, err := LoadFindings(path)
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "rule-a", got[0].RuleID)
+	assert.Equal(t, "s3cr3t", got[0].Secret)
+	assert.Equal(t, "rule-b", got[1].RuleID)
+}
+
+func TestLoadFindings_JSON(t *testing.T) {
+	assertFixtureFindings(t, writeJSON(t, t.TempDir(), fixtureFindings))
+}
+
+func TestLoadFindings_JSONL(t *testing.T) {
+	assertFixtureFindings(t, writeJSONL(t, t.TempDir(), fixtureFindings))
+}
+
+func TestLoadFindings_InvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0600))
+
+	_, err := LoadFindings(path)
+	assert.Error(t, err)
+}
+
+func TestLoadFindings_MissingFile(t *testing.T) {
+	_, err := LoadFindings(filepath.Join(t.TempDir(), "nonexistent.json"))
+	assert.Error(t, err)
+}

--- a/report/replay.go
+++ b/report/replay.go
@@ -1,0 +1,159 @@
+package report
+
+import (
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/betterleaks/betterleaks/logging"
+)
+
+// FilterProvider is the interface Replay requires for compiled filter programs.
+// Satisfied by detect.FilterSet.
+type FilterProvider interface {
+	Global() (exprruntime.Program, bool, error)
+	ForRule(r config.Rule) (exprruntime.Program, bool, error)
+}
+
+// SuppressionProvider is the interface Replay requires for ignore/baseline checks.
+// Satisfied by detect.Suppression.
+type SuppressionProvider interface {
+	Suppressed(f Finding) bool
+}
+
+// ReplayOptions controls the behaviour of Replay.
+type ReplayOptions struct {
+	Config      *config.Config
+	ExprRuntime *exprruntime.Runtime
+	FilterSet   FilterProvider      // nil skips filter evaluation
+	Suppression SuppressionProvider // nil skips ignore/baseline suppression
+}
+
+// nonPersistableBindings are filter expression references that evaluate to
+// empty string / zero on replay because the underlying data is not in the report.
+var nonPersistableBindings = []string{
+	"finding.context",
+	"finding.fragment_raw",
+	"finding.match_start_idx",
+	"finding.match_end_idx",
+	"finding.match_line_start_idx",
+	"finding.match_line_end_idx",
+}
+
+// warnedExprs ensures the non-persistable-binding warning fires once per unique expression.
+var warnedExprs sync.Map
+
+// warnNonPersistable logs once if expr references bindings unavailable on replay.
+func warnNonPersistable(expr string) {
+	for _, binding := range nonPersistableBindings {
+		// This just does a substring check, not a full parse of the expression.
+		// It could produce false positives, but that's very unlikely and is simpler
+		// than parsing the expression to an AST and checking for identifiers.
+		if strings.Contains(expr, binding) {
+			if _, loaded := warnedExprs.LoadOrStore(expr, struct{}{}); !loaded {
+				logging.Warn().
+					Str("expression", expr).
+					Msg("filter references non-persistable bindings; they evaluate to empty/zero on replay — results may differ from scan time")
+			}
+			return
+		}
+	}
+}
+
+// Replay re-evaluates the config's prefilter + global filter + per-rule filters
+// against each input finding, applies Suppression if provided, and returns the
+// findings that pass. Findings whose RuleID is absent from the config are kept
+// and a debug message is emitted. Individual expression errors are warned, not fatal.
+func Replay(findings []Finding, opts ReplayOptions) ([]Finding, error) {
+	cfg := opts.Config
+	rt := opts.ExprRuntime
+	prefilterPrg := cfg.PrefilterProgram()
+
+	out := make([]Finding, 0, len(findings))
+	for _, f := range findings {
+		// 1. Backfill deprecated source fields so filters using path/commit/etc. work
+		//    even when the report was produced by an older betterleaks version.
+		f.SyncDeprecatedSourceFields()
+
+		// 2. Suppression: ignore file + baseline (applied before expressions).
+		if opts.Suppression != nil && opts.Suppression.Suppressed(f) {
+			continue
+		}
+
+		// 3. Prefilter (attributes only).
+		if prefilterPrg != nil {
+			skip, err := rt.EvalPrefilter(prefilterPrg, f.Attributes)
+			if err != nil {
+				logging.Warn().Err(err).Str("rule_id", f.RuleID).Msg("prefilter eval error on replay")
+			} else if skip {
+				continue
+			}
+		}
+
+		// 4. Determine which filters apply and build findingMap when needed.
+		rule, ruleOK := cfg.Rules[f.RuleID]
+		hasGlobalFilter := opts.FilterSet != nil && (cfg.Filter != "" || cfg.FilterProgram() != nil)
+		hasRuleFilter := opts.FilterSet != nil && ruleOK && (rule.Filter != "" || rule.FilterProgram() != nil)
+
+		var findingMap map[string]any
+		if hasGlobalFilter || hasRuleFilter {
+			if f.Attributes == nil {
+				f.Attributes = make(map[string]string)
+			}
+			findingMap = make(map[string]any, 12)
+			for key, value := range f.ToExprMap() {
+				findingMap[key] = value
+			}
+			// Convert entropy from float32 to string, the format needed for filter expressions.
+			findingMap["entropy"] = strconv.FormatFloat(float64(f.Entropy), 'g', -1, 64)
+			// Non-persistable bindings are set to their zero values (same as
+			// emptyFilterFinding in exprruntime) so expressions compile but see empties.
+			findingMap["fragment_raw"] = ""
+			findingMap["match_start_idx"] = 0
+			findingMap["match_end_idx"] = 0
+			findingMap["match_line_start_idx"] = 0
+			findingMap["match_line_end_idx"] = 0
+		}
+
+		// 5. Global filter.
+		if hasGlobalFilter {
+			warnNonPersistable(cfg.Filter)
+			prg, ok, err := opts.FilterSet.Global()
+			if err != nil {
+				logging.Warn().Err(err).Msg("global filter compile error on replay")
+			} else if ok {
+				skip, err := rt.EvalFilter(prg, findingMap, f.Attributes)
+				if err != nil {
+					logging.Warn().Err(err).Msg("global filter eval error on replay")
+				} else if skip {
+					continue
+				}
+			}
+		}
+
+		// 6. Per-rule filter.
+		if opts.FilterSet != nil {
+			if !ruleOK {
+				logging.Debug().Str("rule_id", f.RuleID).Msg("rule not in config on replay; keeping finding")
+			} else if hasRuleFilter {
+				warnNonPersistable(rule.Filter)
+				prg, ok, err := opts.FilterSet.ForRule(rule)
+				if err != nil {
+					logging.Warn().Err(err).Str("rule_id", f.RuleID).Msg("rule filter compile error on replay")
+				} else if ok {
+					skip, err := rt.EvalFilter(prg, findingMap, f.Attributes)
+					if err != nil {
+						logging.Warn().Err(err).Str("rule_id", f.RuleID).Msg("rule filter eval error on replay")
+					} else if skip {
+						continue
+					}
+				}
+			}
+		}
+
+		out = append(out, f)
+	}
+	return out, nil
+}

--- a/report/replay_test.go
+++ b/report/replay_test.go
@@ -1,0 +1,221 @@
+package report
+
+import (
+	"testing"
+
+	"github.com/betterleaks/betterleaks/config"
+	"github.com/betterleaks/betterleaks/internal/exprruntime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockFilterProvider implements FilterProvider for testing without importing detect.
+type mockFilterProvider struct {
+	global  exprruntime.Program
+	perRule map[string]exprruntime.Program
+}
+
+func (m *mockFilterProvider) Global() (exprruntime.Program, bool, error) {
+	if m.global == nil {
+		return nil, false, nil
+	}
+	return m.global, true, nil
+}
+
+func (m *mockFilterProvider) ForRule(r config.Rule) (exprruntime.Program, bool, error) {
+	if prg, ok := m.perRule[r.RuleID]; ok {
+		return prg, true, nil
+	}
+	return nil, false, nil
+}
+
+// mockSuppressor implements SuppressionProvider for testing.
+type mockSuppressor struct {
+	fn func(Finding) bool
+}
+
+func (m *mockSuppressor) Suppressed(f Finding) bool { return m.fn(f) }
+
+// replayRT returns a fresh exprruntime.Runtime for replay tests.
+func replayRT(t *testing.T) *exprruntime.Runtime {
+	t.Helper()
+	rt, err := exprruntime.New(nil)
+	require.NoError(t, err)
+	return rt
+}
+
+// compile compiles a filter expression using the given runtime.
+func compile(t *testing.T, rt *exprruntime.Runtime, expr string) exprruntime.Program {
+	t.Helper()
+	prg, err := rt.CompileFilter(expr, nil)
+	require.NoError(t, err)
+	return prg
+}
+
+func TestReplayPrefilter(t *testing.T) {
+	rt := replayRT(t)
+	cfg := &config.Config{
+		Prefilter: `attributes["path"] == "skip.env"`,
+		Rules:     map[string]config.Rule{"r": {RuleID: "r"}},
+	}
+	require.NoError(t, cfg.CompileFilters(nil))
+
+	findings := []Finding{
+		{RuleID: "r", Secret: "kept", Attributes: map[string]string{"path": "main.go"}},
+		{RuleID: "r", Secret: "dropped", Attributes: map[string]string{"path": "skip.env"}},
+	}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "kept", got[0].Secret)
+}
+
+func TestReplayGlobalFilter(t *testing.T) {
+	rt := replayRT(t)
+	cfg := &config.Config{
+		Filter: `finding["secret"] == "bad"`,
+		Rules:  map[string]config.Rule{"r": {RuleID: "r"}},
+	}
+	filters := &mockFilterProvider{global: compile(t, rt, cfg.Filter)}
+
+	findings := []Finding{
+		{RuleID: "r", Secret: "bad"},
+		{RuleID: "r", Secret: "good"},
+	}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "good", got[0].Secret)
+}
+
+func TestReplayRuleFilterByEntropy(t *testing.T) {
+	rt := replayRT(t)
+	// entropy() computes Shannon entropy of the secret string; "aaaaaa" is very low.
+	expr := `entropy(finding["secret"]) < 1.0`
+	cfg := &config.Config{
+		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
+	}
+	filters := &mockFilterProvider{
+		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
+	}
+
+	findings := []Finding{
+		{RuleID: "r", Secret: "aaaaaa"},   // entropy ≈ 0 — dropped
+		{RuleID: "r", Secret: "aB3!xZ@9"}, // high entropy — kept
+	}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "aB3!xZ@9", got[0].Secret)
+}
+
+func TestReplayRuleFilterByLine(t *testing.T) {
+	rt := replayRT(t)
+	expr := `finding["line"].contains("PRIVATE")`
+	cfg := &config.Config{
+		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
+	}
+	filters := &mockFilterProvider{
+		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
+	}
+
+	findings := []Finding{
+		{RuleID: "r", Secret: "s", Line: "PRIVATE KEY abc"},
+		{RuleID: "r", Secret: "s", Line: "public_key = abc"},
+	}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "public_key = abc", got[0].Line)
+}
+
+func TestReplayRuleFilterLineEmptyWhenNotPersisted(t *testing.T) {
+	rt := replayRT(t)
+	// This filter would drop a finding whose line contains "PRIVATE",
+	// but the finding has Line == "" (not persisted at scan time).
+	expr := `finding["line"].contains("PRIVATE")`
+	cfg := &config.Config{
+		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
+	}
+	filters := &mockFilterProvider{
+		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
+	}
+
+	// Line is empty: filter cannot match it, so the finding is kept.
+	findings := []Finding{{RuleID: "r", Secret: "s", Line: ""}}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "finding with empty Line should be kept when filter references finding[\"line\"]")
+}
+
+func TestReplayUnknownRuleKept(t *testing.T) {
+	rt := replayRT(t)
+	cfg := &config.Config{Rules: map[string]config.Rule{"known": {RuleID: "known"}}}
+	filters := &mockFilterProvider{}
+
+	findings := []Finding{
+		{RuleID: "unknown-rule", Secret: "s"},
+	}
+	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "finding with unknown rule ID should be kept")
+}
+
+func TestReplaySuppression(t *testing.T) {
+	rt := replayRT(t)
+	cfg := &config.Config{Rules: map[string]config.Rule{"r": {RuleID: "r"}}}
+
+	kept := Finding{RuleID: "r", Secret: "kept", Fingerprint: "fp-kept"}
+	dropped := Finding{RuleID: "r", Secret: "dropped", Fingerprint: "fp-drop"}
+
+	suppress := &mockSuppressor{fn: func(f Finding) bool {
+		return f.Fingerprint == "fp-drop"
+	}}
+
+	got, err := Replay([]Finding{kept, dropped}, ReplayOptions{
+		Config:      cfg,
+		ExprRuntime: rt,
+		Suppression: suppress,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "kept", got[0].Secret)
+}
+
+func TestReplaySuppressionBeforeFilterEval(t *testing.T) {
+	rt := replayRT(t)
+	// The filter expression is deliberately invalid to produce an eval error.
+	// The suppressed finding should be dropped before the filter ever runs.
+	expr := `finding["secret"] == "x"` // valid expression, but we want to prove order
+	cfg := &config.Config{
+		Filter: expr,
+		Rules:  map[string]config.Rule{"r": {RuleID: "r"}},
+	}
+
+	// Override: this filter always panics if called (to prove suppression runs first).
+	panickingFilter := &mockFilterProvider{
+		global: compile(t, rt, expr),
+	}
+	// Wrap it so Global() returns normally but we verify suppression fired first.
+	suppressed := false
+	suppress := &mockSuppressor{fn: func(f Finding) bool {
+		if f.Secret == "should-be-suppressed" {
+			suppressed = true
+			return true
+		}
+		return false
+	}}
+
+	findings := []Finding{
+		{RuleID: "r", Secret: "should-be-suppressed"},
+	}
+	got, err := Replay(findings, ReplayOptions{
+		Config:      cfg,
+		ExprRuntime: rt,
+		FilterSet:   panickingFilter,
+		Suppression: suppress,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+	assert.True(t, suppressed, "suppression should have been applied")
+}

--- a/report/replay_test.go
+++ b/report/replay_test.go
@@ -36,167 +36,177 @@ type mockSuppressor struct {
 
 func (m *mockSuppressor) Suppressed(f Finding) bool { return m.fn(f) }
 
-// replayRT returns a fresh exprruntime.Runtime for replay tests.
-func replayRT(t *testing.T) *exprruntime.Runtime {
-	t.Helper()
+func TestReplay(t *testing.T) {
 	rt, err := exprruntime.New(nil)
 	require.NoError(t, err)
-	return rt
+
+	compile := func(expr string) exprruntime.Program {
+		prg, err := rt.CompileFilter(expr, nil)
+		require.NoError(t, err)
+		return prg
+	}
+
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		filters   FilterProvider
+		suppress  SuppressionProvider
+		findings  []Finding
+		wantCount int
+		check     func(*testing.T, []Finding)
+	}{
+		{
+			name: "prefilter drops by path",
+			cfg: &config.Config{
+				Prefilter: `attributes["path"] == "skip.env"`,
+				Rules:     map[string]config.Rule{"r": {RuleID: "r"}},
+			},
+			findings: []Finding{
+				{RuleID: "r", Secret: "kept", Attributes: map[string]string{"path": "main.go"}},
+				{RuleID: "r", Secret: "dropped", Attributes: map[string]string{"path": "skip.env"}},
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "kept", got[0].Secret)
+			},
+		},
+		{
+			name: "global filter drops by secret",
+			cfg: &config.Config{
+				Filter: `finding["secret"] == "bad"`,
+				Rules:  map[string]config.Rule{"r": {RuleID: "r"}},
+			},
+			filters: &mockFilterProvider{global: compile(`finding["secret"] == "bad"`)},
+			findings: []Finding{
+				{RuleID: "r", Secret: "bad"},
+				{RuleID: "r", Secret: "good"},
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "good", got[0].Secret)
+			},
+		},
+		{
+			name: "per-rule filter drops by entropy",
+			cfg: &config.Config{
+				// entropy() computes Shannon entropy; "aaaaaa" is very low.
+				Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: `entropy(finding["secret"]) < 1.0`}},
+			},
+			filters: &mockFilterProvider{
+				perRule: map[string]exprruntime.Program{"r": compile(`entropy(finding["secret"]) < 1.0`)},
+			},
+			findings: []Finding{
+				{RuleID: "r", Secret: "aaaaaa"},   // entropy ≈ 0 — dropped
+				{RuleID: "r", Secret: "aB3!xZ@9"}, // high entropy — kept
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "aB3!xZ@9", got[0].Secret)
+			},
+		},
+		{
+			name: "per-rule filter drops by line when Line is set",
+			cfg: &config.Config{
+				Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: `finding["line"].contains("PRIVATE")`}},
+			},
+			filters: &mockFilterProvider{
+				perRule: map[string]exprruntime.Program{"r": compile(`finding["line"].contains("PRIVATE")`)},
+			},
+			findings: []Finding{
+				{RuleID: "r", Secret: "s", Line: "PRIVATE KEY abc"},
+				{RuleID: "r", Secret: "s", Line: "public_key = abc"},
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "public_key = abc", got[0].Line)
+			},
+		},
+		{
+			// Regression: filter references finding.line but Line was not persisted at scan time.
+			// The finding must be kept, not dropped, because finding["line"] == "".
+			name: "per-rule filter sees empty line when Line not persisted",
+			cfg: &config.Config{
+				Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: `finding["line"].contains("PRIVATE")`}},
+			},
+			filters: &mockFilterProvider{
+				perRule: map[string]exprruntime.Program{"r": compile(`finding["line"].contains("PRIVATE")`)},
+			},
+			findings:  []Finding{{RuleID: "r", Secret: "s", Line: ""}},
+			wantCount: 1,
+		},
+		{
+			name:      "finding with unknown rule ID is kept",
+			cfg:       &config.Config{Rules: map[string]config.Rule{"known": {RuleID: "known"}}},
+			filters:   &mockFilterProvider{},
+			findings:  []Finding{{RuleID: "unknown-rule", Secret: "s"}},
+			wantCount: 1,
+		},
+		{
+			name: "suppressed fingerprint is dropped",
+			cfg:  &config.Config{Rules: map[string]config.Rule{"r": {RuleID: "r"}}},
+			suppress: &mockSuppressor{fn: func(f Finding) bool {
+				return f.Fingerprint == "fp-drop"
+			}},
+			findings: []Finding{
+				{RuleID: "r", Secret: "kept", Fingerprint: "fp-keep"},
+				{RuleID: "r", Secret: "dropped", Fingerprint: "fp-drop"},
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "kept", got[0].Secret)
+			},
+		},
+		{
+			name: "baseline suppression drops matching finding",
+			cfg:  &config.Config{Rules: map[string]config.Rule{"r": {RuleID: "r"}}},
+			suppress: &mockSuppressor{fn: func(f Finding) bool {
+				return f.Secret == "baseline-secret"
+			}},
+			findings: []Finding{
+				{RuleID: "r", Secret: "new-secret"},
+				{RuleID: "r", Secret: "baseline-secret"},
+			},
+			wantCount: 1,
+			check: func(t *testing.T, got []Finding) {
+				assert.Equal(t, "new-secret", got[0].Secret)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, tt.cfg.CompileFilters(nil))
+			got, err := Replay(tt.findings, ReplayOptions{
+				Config:      tt.cfg,
+				ExprRuntime: rt,
+				FilterSet:   tt.filters,
+				Suppression: tt.suppress,
+			})
+			require.NoError(t, err)
+			require.Len(t, got, tt.wantCount)
+			if tt.wantCount > 0 && tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
 }
 
-// compile compiles a filter expression using the given runtime.
-func compile(t *testing.T, rt *exprruntime.Runtime, expr string) exprruntime.Program {
-	t.Helper()
-	prg, err := rt.CompileFilter(expr, nil)
-	require.NoError(t, err)
-	return prg
-}
-
-func TestReplayPrefilter(t *testing.T) {
-	rt := replayRT(t)
-	cfg := &config.Config{
-		Prefilter: `attributes["path"] == "skip.env"`,
-		Rules:     map[string]config.Rule{"r": {RuleID: "r"}},
-	}
-	require.NoError(t, cfg.CompileFilters(nil))
-
-	findings := []Finding{
-		{RuleID: "r", Secret: "kept", Attributes: map[string]string{"path": "main.go"}},
-		{RuleID: "r", Secret: "dropped", Attributes: map[string]string{"path": "skip.env"}},
-	}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt})
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, "kept", got[0].Secret)
-}
-
-func TestReplayGlobalFilter(t *testing.T) {
-	rt := replayRT(t)
-	cfg := &config.Config{
-		Filter: `finding["secret"] == "bad"`,
-		Rules:  map[string]config.Rule{"r": {RuleID: "r"}},
-	}
-	filters := &mockFilterProvider{global: compile(t, rt, cfg.Filter)}
-
-	findings := []Finding{
-		{RuleID: "r", Secret: "bad"},
-		{RuleID: "r", Secret: "good"},
-	}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, "good", got[0].Secret)
-}
-
-func TestReplayRuleFilterByEntropy(t *testing.T) {
-	rt := replayRT(t)
-	// entropy() computes Shannon entropy of the secret string; "aaaaaa" is very low.
-	expr := `entropy(finding["secret"]) < 1.0`
-	cfg := &config.Config{
-		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
-	}
-	filters := &mockFilterProvider{
-		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
-	}
-
-	findings := []Finding{
-		{RuleID: "r", Secret: "aaaaaa"},   // entropy ≈ 0 — dropped
-		{RuleID: "r", Secret: "aB3!xZ@9"}, // high entropy — kept
-	}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, "aB3!xZ@9", got[0].Secret)
-}
-
-func TestReplayRuleFilterByLine(t *testing.T) {
-	rt := replayRT(t)
-	expr := `finding["line"].contains("PRIVATE")`
-	cfg := &config.Config{
-		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
-	}
-	filters := &mockFilterProvider{
-		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
-	}
-
-	findings := []Finding{
-		{RuleID: "r", Secret: "s", Line: "PRIVATE KEY abc"},
-		{RuleID: "r", Secret: "s", Line: "public_key = abc"},
-	}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, "public_key = abc", got[0].Line)
-}
-
-func TestReplayRuleFilterLineEmptyWhenNotPersisted(t *testing.T) {
-	rt := replayRT(t)
-	// This filter would drop a finding whose line contains "PRIVATE",
-	// but the finding has Line == "" (not persisted at scan time).
-	expr := `finding["line"].contains("PRIVATE")`
-	cfg := &config.Config{
-		Rules: map[string]config.Rule{"r": {RuleID: "r", Filter: expr}},
-	}
-	filters := &mockFilterProvider{
-		perRule: map[string]exprruntime.Program{"r": compile(t, rt, expr)},
-	}
-
-	// Line is empty: filter cannot match it, so the finding is kept.
-	findings := []Finding{{RuleID: "r", Secret: "s", Line: ""}}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
-	require.NoError(t, err)
-	assert.Len(t, got, 1, "finding with empty Line should be kept when filter references finding[\"line\"]")
-}
-
-func TestReplayUnknownRuleKept(t *testing.T) {
-	rt := replayRT(t)
-	cfg := &config.Config{Rules: map[string]config.Rule{"known": {RuleID: "known"}}}
-	filters := &mockFilterProvider{}
-
-	findings := []Finding{
-		{RuleID: "unknown-rule", Secret: "s"},
-	}
-	got, err := Replay(findings, ReplayOptions{Config: cfg, ExprRuntime: rt, FilterSet: filters})
-	require.NoError(t, err)
-	assert.Len(t, got, 1, "finding with unknown rule ID should be kept")
-}
-
-func TestReplaySuppression(t *testing.T) {
-	rt := replayRT(t)
-	cfg := &config.Config{Rules: map[string]config.Rule{"r": {RuleID: "r"}}}
-
-	kept := Finding{RuleID: "r", Secret: "kept", Fingerprint: "fp-kept"}
-	dropped := Finding{RuleID: "r", Secret: "dropped", Fingerprint: "fp-drop"}
-
-	suppress := &mockSuppressor{fn: func(f Finding) bool {
-		return f.Fingerprint == "fp-drop"
-	}}
-
-	got, err := Replay([]Finding{kept, dropped}, ReplayOptions{
-		Config:      cfg,
-		ExprRuntime: rt,
-		Suppression: suppress,
-	})
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Equal(t, "kept", got[0].Secret)
-}
-
+// TestReplaySuppressionBeforeFilterEval is kept standalone because it verifies
+// ordering via a stateful mock: the suppressor must fire before the filter runs.
 func TestReplaySuppressionBeforeFilterEval(t *testing.T) {
-	rt := replayRT(t)
-	// The filter expression is deliberately invalid to produce an eval error.
-	// The suppressed finding should be dropped before the filter ever runs.
-	expr := `finding["secret"] == "x"` // valid expression, but we want to prove order
+	rt, err := exprruntime.New(nil)
+	require.NoError(t, err)
+
+	expr := `finding["secret"] == "x"`
 	cfg := &config.Config{
 		Filter: expr,
 		Rules:  map[string]config.Rule{"r": {RuleID: "r"}},
 	}
+	require.NoError(t, cfg.CompileFilters(nil))
 
-	// Override: this filter always panics if called (to prove suppression runs first).
-	panickingFilter := &mockFilterProvider{
-		global: compile(t, rt, expr),
-	}
-	// Wrap it so Global() returns normally but we verify suppression fired first.
+	prg, err := rt.CompileFilter(expr, nil)
+	require.NoError(t, err)
+
 	suppressed := false
 	suppress := &mockSuppressor{fn: func(f Finding) bool {
 		if f.Secret == "should-be-suppressed" {
@@ -206,16 +216,16 @@ func TestReplaySuppressionBeforeFilterEval(t *testing.T) {
 		return false
 	}}
 
-	findings := []Finding{
-		{RuleID: "r", Secret: "should-be-suppressed"},
-	}
-	got, err := Replay(findings, ReplayOptions{
-		Config:      cfg,
-		ExprRuntime: rt,
-		FilterSet:   panickingFilter,
-		Suppression: suppress,
-	})
+	got, err := Replay(
+		[]Finding{{RuleID: "r", Secret: "should-be-suppressed"}},
+		ReplayOptions{
+			Config:      cfg,
+			ExprRuntime: rt,
+			FilterSet:   &mockFilterProvider{global: prg},
+			Suppression: suppress,
+		},
+	)
 	require.NoError(t, err)
 	assert.Empty(t, got)
-	assert.True(t, suppressed, "suppression should have been applied")
+	assert.True(t, suppressed, "suppression must fire before filter evaluation")
 }


### PR DESCRIPTION
Adds a new `report` command with two new subcommands for working with existing report files without re-scanning.

I scan large data sets that take a few hours. The `report replay` command lets me revise my filters and quickly reprocess the findings without having to rescan.

## New commands

**`betterleaks report replay [report.json]`**

Re-evaluates the current config's prefilter, filters, and ignore/baseline suppression against every finding in a saved JSON or JSONL report, producing a new report containing only the findings that still pass. Useful for testing filter changes against a known result set. Validation results are not re-evaluated; they are copied verbatim from the input.

To run some filters effectively, the original report must be created with the new `--report-include-line` option, which stores the `Line` attribute in the report.

**`betterleaks report convert [report.json]`**

Reads a JSON or JSONL report and writes it in any supported output format (`--verbose`, `--report-format`, `--report-template`). No filtering or suppression is applied.

Both commands read from stdin when no argument is provided, and support the standard `--report-path`, `--report-format`, `--verbose`, `--redact`, and `--baseline-path` flags.

## Refactoring

To enable the replay engine to apply filters and suppression independently of a full scan, the relevant logic was extracted from `Detector` into two new, publicly accessible types:

- **`detect.FilterSet`** — compiles and caches global and per-rule filter programs
- **`detect.Suppression`** — handles `.gitleaksignore` parsing and baseline comparison

`Detector` now holds instances of these types and delegates to them. `LoadBaseline` and `buildReporter` were similarly decoupled for reuse outside the scan path.

`report.LoadFindings` was added to auto-detect and parse both JSON array and JSONL report formats.

## AI disclosure

Written with Claude Sonnet 4.6. I reviewed all changes, revised, and tested with real data.