### PR TITLE
Fix GitHub refresh token detection

### DIFF
--- a/cmd/generate/config/rules/github.go
+++ b/cmd/generate/config/rules/github.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"strings"
+
 	"github.com/betterleaks/betterleaks/cmd/generate/config/utils"
 	"github.com/betterleaks/betterleaks/cmd/generate/secrets"
 	"github.com/betterleaks/betterleaks/config"
@@ -127,16 +129,21 @@ func GitHubRefresh() *config.Rule {
 		RuleID:       "github-refresh-token",
 		Confidence:   "high",
 		Description:  "Detected a GitHub Refresh Token, which could allow prolonged unauthorized access to GitHub services.",
-		Regex:        regexp.MustCompile(`ghr_[0-9a-zA-Z]{36}`),
+		Regex:        regexp.MustCompile(`(ghr_[0-9a-zA-Z]{76})(?:[^0-9a-zA-Z]|$)`),
 		Keywords:     []string{"ghr_"},
+		SecretGroup:  1,
 		ValidateExpr: githubTokenExpr,
 		Filter:       `entropy(finding["secret"]) <= 3.0`,
 	}
 
 	// validate
-	tps := utils.GenerateSampleSecrets("github", "ghr_"+secrets.NewSecretWithEntropy(utils.AlphaNumeric("36"), 3))
+	secret := "ghr_" + secrets.NewSecretWithEntropy(utils.AlphaNumeric("76"), 3)
+	tps := append(utils.GenerateSampleSecrets("github", secret), secret)
 	fps := []string{
-		"ghr_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		"ghr_" + secrets.NewSecretWithEntropy(utils.AlphaNumeric("36"), 3),
+		"ghr_" + secrets.NewSecretWithEntropy(utils.AlphaNumeric("75"), 3),
+		"ghr_" + secrets.NewSecretWithEntropy(utils.AlphaNumeric("77"), 3),
+		"ghr_" + strings.Repeat("x", 76),
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/cmd/generate/config/rules/github_test.go
+++ b/cmd/generate/config/rules/github_test.go
@@ -1,0 +1,35 @@
+package rules
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitHubRefreshTokenBoundaries(t *testing.T) {
+	rule := GitHubRefresh()
+	token := "ghr_" + strings.Repeat("A", 76)
+
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{name: "delimiter", input: token + ","},
+		{name: "end of input", input: token},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			match := rule.Regex.FindStringSubmatch(tc.input)
+			require.NotNil(t, match)
+			require.Equal(t, token, match[rule.SecretGroup])
+		})
+	}
+
+	for _, length := range []int{36, 75, 77} {
+		t.Run("reject length "+strconv.Itoa(length), func(t *testing.T) {
+			input := "ghr_" + strings.Repeat("A", length)
+			require.False(t, rule.Regex.MatchString(input))
+		})
+	}
+}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -5471,7 +5471,8 @@ entropy(finding["secret"]) <= 3.0
 [[rules]]
 id = "github-refresh-token"
 description = "Detected a GitHub Refresh Token, which could allow prolonged unauthorized access to GitHub services."
-regex = '''ghr_[0-9a-zA-Z]{36}'''
+regex = '''(ghr_[0-9a-zA-Z]{76})(?:[^0-9a-zA-Z]|$)'''
+secretGroup = 1
 confidence = "high"
 keywords = ["ghr_"]
 validate = '''


### PR DESCRIPTION
## What changed

- Match the documented 76-character body used by `ghr_` refresh tokens
- Require a delimiter or end of input so longer values are not partially matched
- Extract only the token and exclude any trailing delimiter
- Add coverage for delimiter and EOF cases, plus incorrect lengths

## Testing

- `GOMAXPROCS=2 go test -p 1 ./...`

Fixes #305