### PR TITLE
fix: make sumoLogic accessID prefix case-sensitive

### DIFF
--- a/cmd/generate/config/rules/sumologic.go
+++ b/cmd/generate/config/rules/sumologic.go
@@ -12,8 +12,7 @@ func SumoLogicAccessID() *config.Rule {
 		RuleID:      "sumologic-access-id",
 		Confidence:  "medium",
 		Description: "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity.",
-		// TODO: Make 'su' case-sensitive.
-		Regex: utils.GenerateSemiGenericRegex([]string{"(?-i:[Ss]umo|SUMO)"}, "su[a-zA-Z0-9]{12}", false),
+		Regex:       utils.GenerateSemiGenericRegex([]string{"(?-i:[Ss]umo|SUMO)"}, "(?-i:su)[a-zA-Z0-9]{12}", true),
 		Keywords: []string{
 			"sumo",
 		},
@@ -39,6 +38,7 @@ func SumoLogicAccessID() *config.Rule {
 		`SUMOLOGIC_ACCESSID: ${SUMOLOGIC_ACCESSID}`,
 		`export SUMOLOGIC_ACCESSID=XXXXXXXXXXXXXX`, // gitleaks:allow
 		`sumObj = suGyI5imvADdvU`,
+		`sumologic.accessId = "SU9OL59biWiJu7"`,
 	}
 	return utils.Validate(r, tps, fps)
 }

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -9716,7 +9716,7 @@ filter.matchesAny(finding["secret"], ["^sk_live_a2V5Xz"])
 [[rules]]
 id = "sumologic-access-id"
 description = "Discovered a SumoLogic Access ID, potentially compromising log management services and data analytics integrity."
-regex = '''(?i:(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"]{0,3})(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}(su[a-zA-Z0-9]{12})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+regex = '''(?i)(?:(?-i:[Ss]umo|SUMO))(?:[ \t\w.-]{0,20})[\s'"]{0,3}(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}((?-i:su)[a-zA-Z0-9]{12})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 confidence = "medium"
 keywords = ["sumo"]
 filter = '''


### PR DESCRIPTION
fixes #321 

This updates the flag to `true` and updates the regex to use `(?-i:su)`.