### PR TITLE
Add VoyageAI API key rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -511,6 +511,7 @@ func main() {
 		rules.VaultBatchToken(),
 		rules.VaultServiceToken(),
 		rules.VirusTotalAPIKey(),
+		rules.VoyageAIAPIKey(),
 		rules.VultrAPIKey(),
 		rules.WakaTimeAPIKeyV1(),
 		rules.WakaTimeAPIKeyV2(),

--- a/cmd/generate/config/rules/voyageai.go
+++ b/cmd/generate/config/rules/voyageai.go
@@ -1,0 +1,43 @@
+package rules
+
+import (
+	"github.com/betterleaks/betterleaks/cmd/generate/config/utils"
+	"github.com/betterleaks/betterleaks/cmd/generate/secrets"
+	"github.com/betterleaks/betterleaks/config"
+)
+
+func VoyageAIAPIKey() *config.Rule {
+	r := config.Rule{
+		RuleID:      "voyageai-api-key",
+		Confidence:  "medium",
+		Description: "Detected a Voyage AI API key, which may expose embedding and retrieval model access to unauthorized parties.",
+		Regex:       utils.GenerateUniqueTokenRegex(`(?:pa|al)-[A-Za-z0-9_-]{43}`, false),
+		Keywords:    []string{"pa-", "al-"},
+		ValidateExpr: `let r = http.post("https://api.voyageai.com/v1/embeddings", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Content-Type": "application/json"
+  }, "{\"input\":\"hi\",\"model\":\"nonexistent-model-xyz-12345\"}");
+  let invalidResponse = (r.body contains "Provided API key is invalid") ||
+    (r.body contains "cannot access this endpoint");
+  r.status == 401 || invalidResponse ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : r.status in [200, 400, 403] ? {
+    "result": "valid"
+  } : validate.unknown(r)`,
+		Filter: utils.MinEntropy(4.0),
+	}
+
+	paKey := "pa-" + secrets.NewSecretWithEntropy(`[A-Za-z0-9_-]{43}`, 4.0)
+	alKey := "al-" + secrets.NewSecretWithEntropy(`[A-Za-z0-9_-]{43}`, 4.0)
+	tps := []string{
+		`VOYAGEAI_API_KEY=` + paKey,
+		`VOYAGEAI_API_KEY=` + alKey,
+	}
+	fps := []string{
+		`VOYAGEAI_API_KEY=pa-short`,
+		`VOYAGEAI_API_KEY=qa-` + secrets.NewSecret(`[A-Za-z0-9_-]{43}`),
+		`VOYAGEAI_API_KEY=pa-` + "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	}
+	return utils.Validate(r, tps, fps)
+}

--- a/cmd/generate/config/rules/voyageai.go
+++ b/cmd/generate/config/rules/voyageai.go
@@ -11,8 +11,8 @@ func VoyageAIAPIKey() *config.Rule {
 		RuleID:      "voyageai-api-key",
 		Confidence:  "medium",
 		Description: "Detected a Voyage AI API key, which may expose embedding and retrieval model access to unauthorized parties.",
-		Regex:       utils.GenerateUniqueTokenRegex(`(?:pa|al)-[A-Za-z0-9_-]{43}`, false),
-		Keywords:    []string{"pa-", "al-"},
+		Regex:       utils.GenerateSemiGenericRegex([]string{"voyage"}, `(?:pa|al)-[A-Za-z0-9_-]{43}`, false),
+		Keywords:    []string{"voyage"},
 		ValidateExpr: `let r = http.post("https://api.voyageai.com/v1/embeddings", {
     "Authorization": "Bearer " + finding["secret"],
     "Content-Type": "application/json"

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -10452,6 +10452,36 @@ entropy(finding["secret"]) < 3.5
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# voyageai-api-key
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "voyageai-api-key"
+description = "Detected a Voyage AI API key, which may expose embedding and retrieval model access to unauthorized parties."
+regex = '''\b((?:pa|al)-[A-Za-z0-9_-]{43})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+confidence = "medium"
+keywords = [
+    "pa-",
+    "al-",
+]
+validate = '''
+let r = http.post("https://api.voyageai.com/v1/embeddings", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Content-Type": "application/json"
+  }, "{\"input\":\"hi\",\"model\":\"nonexistent-model-xyz-12345\"}");
+  let invalidResponse = (r.body contains "Provided API key is invalid") ||
+    (r.body contains "cannot access this endpoint");
+  r.status == 401 || invalidResponse ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : r.status in [200, 400, 403] ? {
+    "result": "valid"
+  } : validate.unknown(r)
+'''
+filter = '''
+entropy(finding["secret"]) < 4.0
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # vultr-api-key.1
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -10457,12 +10457,9 @@ entropy(finding["secret"]) < 3.5
 [[rules]]
 id = "voyageai-api-key"
 description = "Detected a Voyage AI API key, which may expose embedding and retrieval model access to unauthorized parties."
-regex = '''\b((?:pa|al)-[A-Za-z0-9_-]{43})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+regex = '''(?i:(?:voyage)(?:[ \t\w.-]{0,20})[\s'"]{0,3})(?:=|>|:{1,3}=|\|\||:|=>|\?=|,)[\x60'"\s=]{0,5}((?:pa|al)-[A-Za-z0-9_-]{43})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
 confidence = "medium"
-keywords = [
-    "pa-",
-    "al-",
-]
+keywords = ["voyage"]
 validate = '''
 let r = http.post("https://api.voyageai.com/v1/embeddings", {
     "Authorization": "Bearer " + finding["secret"],

--- a/internal/exprruntime/cel_test.go
+++ b/internal/exprruntime/cel_test.go
@@ -296,6 +296,23 @@ var compatExpressions = []struct {
 )`,
 	},
 	{
+		"voyageai-api-key",
+		`cel.bind(r,
+  http.post("https://api.voyageai.com/v1/embeddings", {
+    "Authorization": "Bearer " + finding["secret"],
+    "Content-Type": "application/json"
+  }, "{\"input\":\"hi\",\"model\":\"nonexistent-model-xyz-12345\"}"),
+  let invalidResponse = (r.body contains "Provided API key is invalid") ||
+    (r.body contains "cannot access this endpoint");
+  r.status == 401 || invalidResponse ? {
+    "result": "invalid",
+    "reason": "Unauthorized"
+  } : r.status in [200, 400, 403] ? {
+    "result": "valid"
+  } : validate.unknown(r)
+)`,
+	},
+	{
 		"polymarket-api-key",
 		`cel.bind(ts, time.now_unix(),
   cel.bind(sig,


### PR DESCRIPTION
I added support for MongoDB Voyage AI API key detection and validation. NOTE: I work for MongoDB and personally authored this detector.

This pull request adds support for detecting Voyage AI API keys across the codebase. The main changes include introducing a new detection rule for Voyage AI API keys, updating configuration files, and adding test coverage for the new rule.

**Voyage AI API Key Detection**

* Added a new rule in `rules/voyageai.go` to detect and validate Voyage AI API keys, including regex matching, entropy filtering, and live validation logic using the Voyage AI API.
* Registered the new `VoyageAIAPIKey` rule in the main ruleset in `cmd/generate/config/main.go`.

**Configuration Updates**

* Updated `config/betterleaks.toml` to include the new `voyageai-api-key` rule, with its regex, validation logic, keywords, and entropy filter.

**Test Coverage**

* Added a test case for the `voyageai-api-key` rule in `internal/exprruntime/cel_test.go` to ensure the validation logic executes as expected.