### PR TITLE
fix(config): preserve targeted allowlists across extensions

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -735,6 +735,11 @@ func (c *Config) extend(extensionConfig *Config) {
 			c.pendingRuleAllowlists = make(map[string][]*Allowlist)
 		}
 		for ruleID, allowlists := range extensionConfig.pendingRuleAllowlists {
+			if _, disabled := disabledRuleIDs[ruleID]; disabled {
+				if _, inherited := extensionConfig.Rules[ruleID]; inherited {
+					continue
+				}
+			}
 			c.pendingRuleAllowlists[ruleID] = append(c.pendingRuleAllowlists[ruleID], allowlists...)
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,11 @@ type Config struct {
 	// Translated from global Allowlists regex/stopword checks.
 	Filter string
 
+	// pendingRuleAllowlists carries targeted global allowlists through config
+	// extensions until all rules have been assembled. It is consumed and
+	// cleared before the translated config is returned to callers.
+	pendingRuleAllowlists map[string][]*Allowlist
+
 	// prefilterProgram and filterProgram hold global programs compiled by
 	// CompileFilters. Per-rule filter and validation compilation is lazy.
 	prefilterProgram exprruntime.Program
@@ -183,10 +188,10 @@ func Default() (*Config, error) {
 
 func (rc *rawConfig) translate(depth int) (*Config, error) {
 	var (
-		keywords       = make(map[string]struct{})
-		orderedRules   []string
-		rulesMap       = make(map[string]Rule)
-		ruleAllowlists = make(map[string][]*Allowlist)
+		keywords              = make(map[string]struct{})
+		orderedRules          []string
+		rulesMap              = make(map[string]Rule)
+		pendingRuleAllowlists = make(map[string][]*Allowlist)
 	)
 
 	// Validate individual rules.
@@ -309,6 +314,7 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 		BetterleaksMinVersion: rc.BetterleaksMinVersion,
 		Prefilter:             rc.Prefilter,
 		Filter:                rc.Filter,
+		pendingRuleAllowlists: pendingRuleAllowlists,
 	}
 
 	c.Path = rc.path
@@ -337,7 +343,7 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 		if len(a.TargetRules) > 0 {
 			for _, ruleID := range a.TargetRules {
 				// It's not possible to validate |ruleID| until after extend.
-				ruleAllowlists[ruleID] = append(ruleAllowlists[ruleID], allowlist)
+				pendingRuleAllowlists[ruleID] = append(pendingRuleAllowlists[ruleID], allowlist)
 			}
 		} else {
 			c.Allowlists = append(c.Allowlists, allowlist)
@@ -374,7 +380,7 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 		}
 
 		// Populate targeted configs.
-		for ruleID, allowlists := range ruleAllowlists {
+		for ruleID, allowlists := range c.pendingRuleAllowlists {
 			rule, ok := c.Rules[ruleID]
 			if !ok {
 				return nil, fmt.Errorf("[[allowlists]] target rule ID '%s' does not exist", ruleID)
@@ -382,6 +388,9 @@ func (rc *rawConfig) translate(depth int) (*Config, error) {
 			rule.Allowlists = append(rule.Allowlists, allowlists...)
 			c.Rules[ruleID] = rule
 		}
+		// Pending allowlists are only needed while assembling the config. Do not
+		// retain extension bookkeeping in the runtime config.
+		c.pendingRuleAllowlists = nil
 
 	}
 
@@ -718,6 +727,17 @@ func (c *Config) extend(extensionConfig *Config) {
 
 	// append allowlists, not attempting to merge
 	c.Allowlists = append(c.Allowlists, extensionConfig.Allowlists...)
+
+	// Carry targeted global allowlists across extensions. They cannot be
+	// attached until all extension layers have contributed their rules.
+	if len(extensionConfig.pendingRuleAllowlists) > 0 {
+		if c.pendingRuleAllowlists == nil {
+			c.pendingRuleAllowlists = make(map[string][]*Allowlist)
+		}
+		for ruleID, allowlists := range extensionConfig.pendingRuleAllowlists {
+			c.pendingRuleAllowlists[ruleID] = append(c.pendingRuleAllowlists[ruleID], allowlists...)
+		}
+	}
 
 	// Current config's global Prefilter/Filter wins over extension's if set.
 	if c.Prefilter == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -747,6 +747,138 @@ components = [{ id = "component" }]
 	require.Len(t, cfg.Rules["child-primary"].Components, 1, "references should resolve after extension")
 }
 
+func TestTargetedGlobalAllowlistsAcrossExtends(t *testing.T) {
+	tempDir := t.TempDir()
+	writeConfig := func(name, content string) string {
+		path := filepath.Join(tempDir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+		return path
+	}
+
+	t.Run("allowlist and target rule in extended config", func(t *testing.T) {
+		basePath := writeConfig("base.toml", `
+[[rules]]
+id = "base-rule"
+regex = "secret"
+
+[[allowlists]]
+targetRules = ["base-rule"]
+regexes = ["example"]
+`)
+
+		cfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+`, basePath), filepath.Join(tempDir, "child.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Rules["base-rule"].Filter, "example")
+		assert.Nil(t, cfg.Rules["base-rule"].Allowlists)
+		assert.Nil(t, cfg.pendingRuleAllowlists)
+	})
+
+	t.Run("target rule in outer config", func(t *testing.T) {
+		basePath := writeConfig("base-outer-rule.toml", `
+[[allowlists]]
+targetRules = ["outer-rule"]
+regexes = ["example"]
+`)
+
+		cfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+
+[[rules]]
+id = "outer-rule"
+regex = "secret"
+`, basePath), filepath.Join(tempDir, "outer.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Rules["outer-rule"].Filter, "example")
+		assert.Nil(t, cfg.Rules["outer-rule"].Allowlists)
+		assert.Nil(t, cfg.pendingRuleAllowlists)
+	})
+
+	t.Run("default extension", func(t *testing.T) {
+		parentPath := writeConfig("default-parent.toml", `
+[extend]
+useDefault = true
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+regexes = ["example"]
+`)
+
+		cfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+`, parentPath), filepath.Join(tempDir, "default-child.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Rules["generic-api-key"].Filter, "example")
+		assert.Nil(t, cfg.Rules["generic-api-key"].Allowlists)
+		assert.Nil(t, cfg.pendingRuleAllowlists)
+	})
+
+	t.Run("nested extends", func(t *testing.T) {
+		basePath := writeConfig("nested-base.toml", `
+[[allowlists]]
+targetRules = ["nested-rule"]
+regexes = ["example"]
+`)
+		middlePath := writeConfig("nested-middle.toml", fmt.Sprintf(`[extend]
+path = %q
+`, basePath))
+
+		cfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+
+[[rules]]
+id = "nested-rule"
+regex = "secret"
+`, middlePath), filepath.Join(tempDir, "nested-outer.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Rules["nested-rule"].Filter, "example")
+		assert.Nil(t, cfg.Rules["nested-rule"].Allowlists)
+		assert.Nil(t, cfg.pendingRuleAllowlists)
+	})
+
+	t.Run("invalid target rule is rejected after extension", func(t *testing.T) {
+		basePath := writeConfig("invalid-target-base.toml", `
+[[allowlists]]
+targetRules = ["missing-rule"]
+regexes = ["example"]
+`)
+
+		_, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+`, basePath), filepath.Join(tempDir, "invalid-target-outer.toml"))
+		require.EqualError(t, err, "[[allowlists]] target rule ID 'missing-rule' does not exist")
+	})
+
+	t.Run("unscoped and rule-level allowlists remain unchanged", func(t *testing.T) {
+		globalPath := writeConfig("unscoped-base.toml", `
+[[allowlists]]
+regexes = ["example"]
+`)
+		globalCfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+`, globalPath), filepath.Join(tempDir, "unscoped-outer.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, globalCfg.Filter, "example")
+		assert.Nil(t, globalCfg.pendingRuleAllowlists)
+
+		rulePath := writeConfig("rule-base.toml", `
+[[rules]]
+id = "rule-level"
+regex = "secret"
+
+[[rules.allowlists]]
+regexes = ["example"]
+`)
+		ruleCfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+`, rulePath), filepath.Join(tempDir, "rule-outer.toml"))
+		require.NoError(t, err)
+		assert.Contains(t, ruleCfg.Rules["rule-level"].Filter, "example")
+		assert.Nil(t, ruleCfg.pendingRuleAllowlists)
+	})
+}
+
 func loadTestConfig(cfgName string) (*Config, error) {
 	return LoadFile(filepath.Join(configPath, cfgName+".toml"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -814,6 +814,25 @@ path = %q
 		assert.Nil(t, cfg.pendingRuleAllowlists)
 	})
 
+	t.Run("disabled inherited target drops its pending allowlist", func(t *testing.T) {
+		parentPath := writeConfig("disabled-target-parent.toml", `
+[extend]
+useDefault = true
+
+[[allowlists]]
+targetRules = ["generic-api-key"]
+regexes = ["example"]
+`)
+
+		cfg, err := ParseTOMLString(fmt.Sprintf(`[extend]
+path = %q
+disabledRules = ["generic-api-key"]
+`, parentPath), filepath.Join(tempDir, "disabled-target-child.toml"))
+		require.NoError(t, err)
+		assert.NotContains(t, cfg.Rules, "generic-api-key")
+		assert.Nil(t, cfg.pendingRuleAllowlists)
+	})
+
 	t.Run("nested extends", func(t *testing.T) {
 		basePath := writeConfig("nested-base.toml", `
 [[allowlists]]
@@ -846,6 +865,7 @@ regexes = ["example"]
 
 		_, err := ParseTOMLString(fmt.Sprintf(`[extend]
 path = %q
+disabledRules = ["missing-rule"]
 `, basePath), filepath.Join(tempDir, "invalid-target-outer.toml"))
 		require.EqualError(t, err, "[[allowlists]] target rule ID 'missing-rule' does not exist")
 	})


### PR DESCRIPTION
Fixes #300.

Preserve targeted global allowlists until path, default, and nested extensions finish assembling, then validate and attach them to the final rules. This prevents extended configs from silently dropping `targetRules` filters.

Validation:
- `go test -race -p 2 ./config`
- `go test -p 2 ./...`
- `go build -p 2 ./...`
- `go vet ./config`