### PR TITLE
stop running pkcs12-file on every fragment

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -698,6 +698,12 @@ ScanLoop:
 					break ScanLoop
 				default:
 					rule := d.Config.Rules[ruleID]
+					// A path-only rule cannot produce a new result after decoding content
+					// or for later chunks of the same file. Keep missing attributes eligible
+					// so fragments from sources other than File retain their existing behavior.
+					if rule.Regex == nil && (currentDecodeDepth > 0 || fragment.Attr(sources.AttrFSFirstFragment) == "false") {
+						continue
+					}
 					for _, finding := range d.detectFragmentWithRuleTimed(fragment, currentRaw, rule, encodedSegments, findings) {
 						if confidence.Meets(finding.Attr(confidence.Attribute), d.MinConfidence) {
 							findings = append(findings, finding)
@@ -784,23 +790,20 @@ func (d *Detector) detectFragmentWithRule(fragment sources.Fragment,
 	// Ensure default fields are properly set
 	fragment.SetDefaults()
 
-	if r.Path != nil {
-		if r.Regex == nil && len(encodedSegments) == 0 {
-			if rulePathMatchesFragment(r.Path, fragment) {
-				return append(findings, newPathOnlyFinding(r, fragment))
-			}
+	if r.Regex == nil {
+		// Decoding content cannot change a path-only result.
+		if len(encodedSegments) > 0 {
 			return findings
 		}
-
-		if !rulePathMatchesFragment(r.Path, fragment) {
-			// If a rule defines both `path` and `regex`, the normalized fragment path
-			// must match before we spend time checking the content regex.
-			return findings
+		if rulePathMatchesFragment(r.Path, fragment) {
+			return append(findings, newPathOnlyFinding(r, fragment))
 		}
+		return findings
 	}
 
-	// if path only rule, skip content checks
-	if r.Regex == nil {
+	if r.Path != nil && !rulePathMatchesFragment(r.Path, fragment) {
+		// If a rule defines both `path` and `regex`, the normalized fragment path
+		// must match before we spend time checking the content regex.
 		return findings
 	}
 

--- a/detect/detect_test.go
+++ b/detect/detect_test.go
@@ -93,6 +93,36 @@ func TestRunStreamsFindings(t *testing.T) {
 	require.Len(t, findings, 1)
 }
 
+func TestPathOnlyRuleRunsOnFirstFileFragment(t *testing.T) {
+	rule := config.Rule{
+		RuleID: "path-only",
+		Path:   regexp.MustCompile(`\.p12$`),
+	}
+	cfg := &config.Config{
+		Rules:          map[string]config.Rule{rule.RuleID: rule},
+		NoKeywordRules: []string{rule.RuleID},
+		OrderedRules:   []string{rule.RuleID},
+	}
+	detector := NewDetector(cfg)
+	detector.RuleTimings = NewRuleTimingCollector()
+	source := &sources.File{
+		Content: strings.NewReader("aa\n\nbb\n\n"),
+		Path:    "bundle.p12",
+		Buffer:  make([]byte, 4),
+	}
+
+	var findings []report.Finding
+	for result := range detector.Run(t.Context(), source) {
+		require.NoError(t, result.Err)
+		findings = append(findings, result.Finding)
+	}
+
+	require.Len(t, findings, 1)
+	timings := detector.RuleTimings.Snapshot()
+	require.Len(t, timings, 1)
+	require.Equal(t, uint64(1), timings[0].Hits)
+}
+
 func TestCandidateBitmap(t *testing.T) {
 	rules := map[string]config.Rule{
 		"high":   {RuleID: "high", Specificity: 30, Keywords: []string{"shared", "alias"}, Regex: regexp.MustCompile(`HIGHSECRET`)},

--- a/docs/config.md
+++ b/docs/config.md
@@ -52,7 +52,7 @@ r.json?.login ?? ""
 
 | Name | Scope | Description |
 | :--- | :--- | :--- |
-| `attributes` | prefilter, filter, validate | Source metadata. Common keys include `path`, `git.sha`, `git.author_name`, `git.author_email`, `git.date`, `git.message`, `git.remote_url`, `git.platform`, and `fs.symlink`. |
+| `attributes` | prefilter, filter, validate | Source metadata. Common keys include `path`, `git.sha`, `git.author_name`, `git.author_email`, `git.date`, `git.message`, `git.remote_url`, `git.platform`, `fs.symlink`, and the read-only `fs.first_fragment` (`"true"` for a file's first chunk and `"false"` thereafter). |
 | `finding` | filter, validate | Matched secret data. Common keys include `secret`, `match`, `line`, `rule_id`, and `description`. In validation, `finding["captures"]` contains the primary rule's named regex groups. |
 | `components` | validate | Matched component findings, keyed by the referenced component rule ID. Each has `secret` and `captures` fields. |
 

--- a/sources/attribute.go
+++ b/sources/attribute.go
@@ -49,7 +49,8 @@ const (
 	AttrGitPlatform    = "git.platform"
 
 	// Filesystem
-	AttrFSSymlink = "fs.symlink"
+	AttrFSSymlink       = "fs.symlink"
+	AttrFSFirstFragment = "fs.first_fragment"
 
 	// GitHub
 	AttrGitHubOwner       = "github.owner"

--- a/sources/file.go
+++ b/sources/file.go
@@ -259,6 +259,7 @@ func (s *File) fileFragments(ctx context.Context, reader *bufio.Reader, isArchiv
 	}
 
 	prevFragmentEndLine := 0
+	firstFragmentAttr := "true"
 	for {
 		select {
 		case <-ctx.Done():
@@ -271,8 +272,9 @@ func (s *File) fileFragments(ctx context.Context, reader *bufio.Reader, isArchiv
 				fragPath = filepath.ToSlash(fullPath)
 			}
 			attr := map[string]string{
-				AttrPath:     fragPath,
-				AttrResource: ResourceFileContent,
+				AttrPath:            fragPath,
+				AttrResource:        ResourceFileContent,
+				AttrFSFirstFragment: firstFragmentAttr,
 			}
 			fragment := Fragment{
 				Attributes: attr,
@@ -363,6 +365,7 @@ func (s *File) fileFragments(ctx context.Context, reader *bufio.Reader, isArchiv
 				return yield(fragment, nil)
 			}
 
+			firstFragmentAttr = "false"
 			if err := yield(fragment, err); err != nil {
 				return err
 			}

--- a/sources/file_test.go
+++ b/sources/file_test.go
@@ -179,3 +179,22 @@ func TestFile_Fragments_malformedGzipDoesNotPanic(t *testing.T) {
 	})
 	require.False(t, yielded)
 }
+
+func TestFile_Fragments_marksFirstFragment(t *testing.T) {
+	s := &File{
+		Content: strings.NewReader("aa\n\nbb\n\n"),
+		Path:    "example.txt",
+		Buffer:  make([]byte, 4),
+	}
+
+	var fragments []Fragment
+	require.NoError(t, s.Fragments(t.Context(), func(fragment Fragment, err error) error {
+		require.NoError(t, err)
+		fragments = append(fragments, fragment)
+		return nil
+	}))
+
+	require.Len(t, fragments, 2)
+	require.Equal(t, "true", fragments[0].Attr(AttrFSFirstFragment))
+	require.Equal(t, "false", fragments[1].Attr(AttrFSFirstFragment))
+}

--- a/sources/stdin.go
+++ b/sources/stdin.go
@@ -24,10 +24,14 @@ func (s *Stdin) Fragments(ctx context.Context, yield FragmentsFunc) error {
 
 	return file.Fragments(ctx, func(fragment Fragment, err error) error {
 		if len(s.Attributes) > 0 {
+			firstFragment := fragment.Attr(AttrFSFirstFragment)
 			if fragment.Attributes == nil {
 				fragment.Attributes = make(map[string]string, len(s.Attributes))
 			}
 			maps.Copy(fragment.Attributes, s.Attributes)
+			// AttrFSFirstFragment is owned by the File source and cannot be
+			// overridden by caller-provided stdin attributes.
+			fragment.SetAttr(AttrFSFirstFragment, firstFragment)
 		}
 
 		if err == nil && s.ShouldSkip != nil && s.ShouldSkip(fragment.Attributes) {


### PR DESCRIPTION
cmd: `./betterleaks dir ../benchmarks/gitlab --diagnostics=rules`

OLD (warm):
```
Rule Timings

Rules timed: 255

Rule ID                                               Total      Hits         Average
generic-api-key                               15.772003714s     71601       220.276µs
generic-credential-uri                         4.001554551s     26363       151.786µs
generic-password                               3.469196092s      8197       423.227µs
pkcs12-file                                    3.430184967s    125015        27.438µs
```

NEW (warm):
```
Rule Timings

Rules timed: 255

Rule ID                                               Total      Hits         Average
generic-api-key                               10.491474341s     71601       146.526µs
generic-password                               4.423099011s      8197       539.599µs
generic-credential-uri                         3.234718908s     26363       122.699µs
pkcs12-file                                    1.331317954s     88669        15.014µs
```