### PR TITLE
Allow human-readable object sizes (1G, 5MiB, etc.)

### DIFF
--- a/cmd/flag_retrievers.go
+++ b/cmd/flag_retrievers.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
-	"github.com/dustin/go-humanize"
+	"fmt"
+	"math"
+
 	"github.com/betterleaks/betterleaks/logging"
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +59,13 @@ func parseSize(s string) (int64, error) {
 		return 0, nil
 	}
 	n, err := humanize.ParseBytes(s)
-	return int64(n), err
+	if err != nil {
+		return 0, err
+	}
+	if n > math.MaxInt64 {
+		return 0, fmt.Errorf("size %q overflows int64 (max %d bytes)", s, int64(math.MaxInt64))
+	}
+	return int64(n), nil
 }
 
 func mustGetFloat64Flag(cmd *cobra.Command, name string) float64 {

--- a/cmd/flag_retrievers.go
+++ b/cmd/flag_retrievers.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/dustin/go-humanize"
 	"github.com/betterleaks/betterleaks/logging"
 	"github.com/spf13/cobra"
 )
@@ -37,12 +38,25 @@ func mustGetStringFlag(cmd *cobra.Command, name string) string {
 	return value
 }
 
-func mustGetInt64Flag(cmd *cobra.Command, name string) int64 {
-	value, err := cmd.Flags().GetInt64(name)
+func mustGetSizeFlag(cmd *cobra.Command, name string) int64 {
+	value, err := cmd.Flags().GetString(name)
 	if err != nil {
 		logging.Fatal().Err(err).Msgf("could not get flag: %s", name)
 	}
-	return value
+	n, err := parseSize(value)
+	if err != nil {
+		logging.Fatal().Err(err).Msgf("invalid size for flag --%s: %q", name, value)
+	}
+	return n
+}
+
+// parseSize converts a human-readable size string to bytes. Empty string returns 0.
+func parseSize(s string) (int64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	n, err := humanize.ParseBytes(s)
+	return int64(n), err
 }
 
 func mustGetFloat64Flag(cmd *cobra.Command, name string) float64 {

--- a/cmd/flag_retrievers_test.go
+++ b/cmd/flag_retrievers_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{input: "", want: 0},
+		{input: "0", want: 0},
+		{input: "250MiB", want: 250 * 1024 * 1024},
+		{input: "1GiB", want: 1024 * 1024 * 1024},
+		{input: "1GB", want: 1_000_000_000},
+		{input: "512kB", want: 512_000},
+		{input: "notasize", wantErr: true},
+		{input: "12 zettabytes", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseSize(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/flag_retrievers_test.go
+++ b/cmd/flag_retrievers_test.go
@@ -21,6 +21,7 @@ func TestParseSize(t *testing.T) {
 		{input: "512kB", want: 512_000},
 		{input: "notasize", wantErr: true},
 		{input: "12 zettabytes", wantErr: true},
+		{input: "10EB", wantErr: true}, // overflows int64
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/cmd/huggingface.go
+++ b/cmd/huggingface.go
@@ -18,7 +18,7 @@ func init() {
 	huggingFaceCmd.Flags().StringSlice("exclude", nil, "resource types to skip: repos, discussions, prs, buckets")
 	huggingFaceCmd.Flags().StringSlice("exclude-repo", nil, "glob patterns to exclude repos by owner/name")
 	huggingFaceCmd.Flags().String("log-opts", "", "git log options passed to each repo scan")
-	huggingFaceCmd.Flags().Int64("max-bucket-object-size", 0, "bucket objects larger than this many bytes are skipped (0 = 250 MiB default)")
+	huggingFaceCmd.Flags().String("max-bucket-object-size", "", "bucket objects larger than this size are skipped (e.g. 250MiB, 1GB; 0 = 250 MiB default)")
 }
 
 var huggingFaceCmd = &cobra.Command{
@@ -80,7 +80,7 @@ func runHuggingFace(cmd *cobra.Command, args []string) {
 		MaxArchiveDepth:     mustGetIntFlag(cmd, "max-archive-depth"),
 		Workers:             mustGetIntFlag(cmd, "source-workers"),
 		LogOpts:             mustGetStringFlag(cmd, "log-opts"),
-		MaxBucketObjectSize: mustGetInt64Flag(cmd, "max-bucket-object-size"),
+		MaxBucketObjectSize: mustGetSizeFlag(cmd, "max-bucket-object-size"),
 	}
 
 	if err := src.Validate(); err != nil {

--- a/cmd/s3.go
+++ b/cmd/s3.go
@@ -17,7 +17,7 @@ func init() {
 	s3Cmd.Flags().String("access-key", "", "AWS access key (overrides AWS_ACCESS_KEY_ID)")
 	s3Cmd.Flags().String("secret-key", "", "AWS secret key (overrides AWS_SECRET_ACCESS_KEY)")
 	s3Cmd.Flags().String("session-token", "", "AWS session token (overrides AWS_SESSION_TOKEN)")
-	s3Cmd.Flags().Int64("max-object-size", 0, "objects larger than this many bytes are skipped (0 = 250 MiB default)")
+	s3Cmd.Flags().String("max-object-size", "", "objects larger than this size are skipped (e.g. 250MiB, 1GB; 0 = 250 MiB default)")
 	s3Cmd.Flags().Int("workers", 0, "concurrent object fetches (0 = --source-workers or source default)")
 }
 
@@ -75,7 +75,7 @@ func runS3(cmd *cobra.Command, args []string) {
 		AccessKey:       mustGetStringFlag(cmd, "access-key"),
 		SecretKey:       mustGetStringFlag(cmd, "secret-key"),
 		SessionToken:    mustGetStringFlag(cmd, "session-token"),
-		MaxObjectSize:   mustGetInt64Flag(cmd, "max-object-size"),
+		MaxObjectSize:   mustGetSizeFlag(cmd, "max-object-size"),
 		Workers:         workers,
 		ShouldSkip:      detector.SkipFunc(),
 		MaxArchiveDepth: mustGetIntFlag(cmd, "max-archive-depth"),

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cn
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 h1:2tV76y6Q9BB+NEBasnqvs7e49aEBFI8ejC89PSnWH+4=
 github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707/go.mod h1:qssHWj60/X5sZFNxpG4HBPDHVqxNm4DfnCKgrbZOT+s=
 github.com/dsnet/golib v0.0.0-20171103203638-1ea166775780/go.mod h1:Lj+Z9rebOhdfkVLjJ8T6VcRQv3SXugXy999NBtR9aFY=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
 github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=


### PR DESCRIPTION
Adds human-readable size support to `s3 --max-object-size` and `huggingface --max-bucket-object-size` options. Integers still work.

```
--max-object-size 5G
--max-object-size "1 GiB"
--max-object-size 100000
```