### PR TITLE
Reuse config across directory scan paths

### DIFF
--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/betterleaks/betterleaks/config"
 	"github.com/betterleaks/betterleaks/detect"
 	"github.com/betterleaks/betterleaks/logging"
 	"github.com/betterleaks/betterleaks/sources"
@@ -26,6 +27,11 @@ var directoryCmd = &cobra.Command{
 }
 
 func runDirectory(cmd *cobra.Command, args []string) {
+	// A directory scan can receive thousands of individual file paths. Keep
+	// config discovery per source, but reuse each resolved config for the
+	// duration of this invocation.
+	configCache = make(map[string]*config.Config)
+
 	sourcesList := args
 	if len(sourcesList) == 0 {
 		sourcesList = []string{"."}

--- a/cmd/directory.go
+++ b/cmd/directory.go
@@ -31,6 +31,7 @@ func runDirectory(cmd *cobra.Command, args []string) {
 	// config discovery per source, but reuse each resolved config for the
 	// duration of this invocation.
 	configCache = make(map[string]*config.Config)
+	defer func() { configCache = nil }()
 
 	sourcesList := args
 	if len(sourcesList) == 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -279,7 +279,10 @@ func initConfig(source string) {
 
 func cachedConfig(key string, load func() *config.Config) *config.Config {
 	if configCache == nil {
-		configCache = make(map[string]*config.Config)
+		// Caching is enabled explicitly by runDirectory for the lifetime of a
+		// single directory scan. Other commands must not retain configs across
+		// same-process invocations.
+		return load()
 	}
 
 	if cfg, ok := configCache[key]; ok {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -187,6 +187,7 @@ var (
 	bannerPrinted      bool
 	resolvedConfigPath string // set by initConfig to the actual config file path that was loaded
 	loadedConfig       *config.Config
+	configCache        map[string]*config.Config
 )
 
 func initConfig(source string) {
@@ -211,19 +212,25 @@ func initConfig(source string) {
 	if cfgPath != "" {
 		resolvedConfigPath = cfgPath
 		logging.Debug().Msgf("using config %s from `--config`", cfgPath)
-		loadedConfig = mustLoadConfigFile(cfgPath)
+		loadedConfig = cachedConfig("file:"+cfgPath, func() *config.Config {
+			return mustLoadConfigFile(cfgPath)
+		})
 	} else if envPath := getEnvWithFallback("BETTERLEAKS_CONFIG", "GITLEAKS_CONFIG"); envPath != "" {
 		resolvedConfigPath = envPath
 		logging.Debug().Msgf("using config from env var: %s", envPath)
-		loadedConfig = mustLoadConfigFile(envPath)
+		loadedConfig = cachedConfig("file:"+envPath, func() *config.Config {
+			return mustLoadConfigFile(envPath)
+		})
 	} else if configContent := getEnvWithFallback("BETTERLEAKS_CONFIG_TOML", "GITLEAKS_CONFIG_TOML"); configContent != "" {
-		cfg, err := config.ParseTOMLString(configContent, "")
-		if err != nil {
-			logging.Fatal().Err(err).Str("content", configContent).Msg("unable to load config from env var")
-		}
-		logging.Debug().Str("content", configContent).Msg("using config from env var content")
+		loadedConfig = cachedConfig("content:"+configContent, func() *config.Config {
+			cfg, err := config.ParseTOMLString(configContent, "")
+			if err != nil {
+				logging.Fatal().Err(err).Str("content", configContent).Msg("unable to load config from env var")
+			}
+			logging.Debug().Str("content", configContent).Msg("using config from env var content")
+			return cfg
+		})
 		// resolvedConfigPath stays "" — inline content, no file to skip.
-		loadedConfig = cfg
 		return
 	} else {
 		fileInfo, err := os.Stat(source)
@@ -234,10 +241,13 @@ func initConfig(source string) {
 		if !fileInfo.IsDir() {
 			logging.Debug().Msgf("unable to load config from %s since --source=%s is a file, using default config",
 				filepath.Join(source, ".betterleaks.toml"), source)
-			loadedConfig, err = config.Default()
-			if err != nil {
-				logging.Fatal().Msgf("err reading toml %s", err.Error())
-			}
+			loadedConfig = cachedConfig("default", func() *config.Config {
+				cfg, loadErr := config.Default()
+				if loadErr != nil {
+					logging.Fatal().Msgf("err reading toml %s", loadErr)
+				}
+				return cfg
+			})
 			// resolvedConfigPath stays "" — using embedded default config.
 			return
 		}
@@ -247,10 +257,13 @@ func initConfig(source string) {
 		if configFile == "" {
 			logging.Debug().Msgf("no config found in path %s, using default config", source)
 
-			loadedConfig, err = config.Default()
-			if err != nil {
-				logging.Fatal().Msgf("err reading default config toml %s", err.Error())
-			}
+			loadedConfig = cachedConfig("default", func() *config.Config {
+				cfg, loadErr := config.Default()
+				if loadErr != nil {
+					logging.Fatal().Msgf("err reading default config toml %s", loadErr)
+				}
+				return cfg
+			})
 			// resolvedConfigPath stays "" — using embedded default config.
 			return
 		} else {
@@ -258,8 +271,25 @@ func initConfig(source string) {
 			logging.Debug().Msgf("using existing config %s", configFile)
 		}
 
-		loadedConfig = mustLoadConfigFile(configFile)
+		loadedConfig = cachedConfig("file:"+configFile, func() *config.Config {
+			return mustLoadConfigFile(configFile)
+		})
 	}
+}
+
+func cachedConfig(key string, load func() *config.Config) *config.Config {
+	if configCache == nil {
+		configCache = make(map[string]*config.Config)
+	}
+
+	if cfg, ok := configCache[key]; ok {
+		logging.Debug().Msgf("reusing cached config %s", key)
+		return cfg
+	}
+
+	cfg := load()
+	configCache[key] = cfg
+	return cfg
 }
 
 func mustLoadConfigFile(path string) *config.Config {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -9,7 +9,7 @@ import (
 func TestCachedConfigReusesConfigForSameSource(t *testing.T) {
 	previousCache := configCache
 	t.Cleanup(func() { configCache = previousCache })
-	configCache = nil
+	configCache = make(map[string]*config.Config)
 
 	loads := 0
 	load := func() *config.Config {
@@ -26,6 +26,28 @@ func TestCachedConfigReusesConfigForSameSource(t *testing.T) {
 	}
 	if first == third {
 		t.Fatal("expected different config sources to use different configs")
+	}
+	if loads != 2 {
+		t.Fatalf("loaded %d configs, want 2", loads)
+	}
+}
+
+func TestCachedConfigDoesNotPersistWithoutInvocationCache(t *testing.T) {
+	previousCache := configCache
+	t.Cleanup(func() { configCache = previousCache })
+	configCache = nil
+
+	loads := 0
+	load := func() *config.Config {
+		loads++
+		return &config.Config{}
+	}
+
+	first := cachedConfig("default", load)
+	second := cachedConfig("default", load)
+
+	if first == second {
+		t.Fatal("expected configs not to be cached outside an invocation")
 	}
 	if loads != 2 {
 		t.Fatalf("loaded %d configs, want 2", loads)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/betterleaks/betterleaks/config"
+)
+
+func TestCachedConfigReusesConfigForSameSource(t *testing.T) {
+	previousCache := configCache
+	t.Cleanup(func() { configCache = previousCache })
+	configCache = nil
+
+	loads := 0
+	load := func() *config.Config {
+		loads++
+		return &config.Config{}
+	}
+
+	first := cachedConfig("file:config.toml", load)
+	second := cachedConfig("file:config.toml", load)
+	third := cachedConfig("file:other.toml", load)
+
+	if first != second {
+		t.Fatal("expected identical config sources to reuse the cached config")
+	}
+	if first == third {
+		t.Fatal("expected different config sources to use different configs")
+	}
+	if loads != 2 {
+		t.Fatalf("loaded %d configs, want 2", loads)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #343.

`betterleaks dir` previously reloaded and recompiled the same configuration once for every path argument. This made scans with thousands of explicit files much slower than scanning the same files through a directory path.

Add an invocation-scoped cache keyed by the effective configuration source. This preserves per-directory config discovery while reusing identical configs during one directory scan.

## Testing

- `go test ./cmd ./config`
- `git diff --check`