### PR TITLE
add git pre-receive hook mode with custom error message

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -97,7 +97,7 @@ func runGit(cmd *cobra.Command, args []string) {
 		if parseErr != nil {
 			logging.Fatal().Err(parseErr).Msg("could not read pre-receive input")
 		}
-		logArgs := sources.PreReceiveLogArgs(updates)
+		logArgs := sources.PreReceiveLogArgs(updates, sources.NewGitCommitResolver(cmd.Context(), source))
 		if len(logArgs) == 0 {
 			// Nothing to scan (e.g. only ref deletions). Report cleanly.
 			logging.Info().Msg("pre-receive: no new commits to scan")

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -26,6 +28,10 @@ func init() {
 	gitCmd.Flags().String("platform", "", "the target platform used to generate links (github, gitlab)")
 	gitCmd.Flags().Bool("staged", false, "scan staged commits (good for pre-commit)")
 	gitCmd.Flags().Bool("pre-commit", false, "scan using git diff")
+	gitCmd.Flags().Bool("pre-receive", false, "run as a git pre-receive hook, scanning pushed commits read from stdin")
+	gitCmd.Flags().String("pre-receive-error-message", "",
+		"error message printed to stderr when the pre-receive hook finds leaks; "+
+			"$VAR and ${VAR} are expanded from the environment")
 	gitCmd.Flags().String("log-opts", "", "git log options")
 	gitCmd.Flags().Int("git-workers", 0, "alias for --source-workers when scanning Git")
 }
@@ -64,6 +70,7 @@ func runGit(cmd *cobra.Command, args []string) {
 	logOpts := mustGetStringFlag(cmd, "log-opts")
 	staged := mustGetBoolFlag(cmd, "staged")
 	preCommit := mustGetBoolFlag(cmd, "pre-commit")
+	preReceive := mustGetBoolFlag(cmd, "pre-receive")
 	maxArchiveDepth := mustGetIntFlag(cmd, "max-archive-depth")
 	gitWorkers := mustGetIntFlag(cmd, "git-workers")
 	sourceWorkers := mustGetIntFlag(cmd, "source-workers")
@@ -73,12 +80,40 @@ func runGit(cmd *cobra.Command, args []string) {
 	}
 	findings := newFindingCollector(mustGetStringFlag(cmd, "report-path") != "")
 
+	if preReceive && (preCommit || staged) {
+		logging.Fatal().Msg("--pre-receive cannot be combined with --pre-commit or --staged")
+	}
+	if preReceive && logOpts != "" {
+		logging.Fatal().Msg("--log-opts cannot be combined with --pre-receive")
+	}
+
 	var (
 		err error
 		src sources.Source
 	)
 
-	if preCommit || staged {
+	if preReceive {
+		updates, parseErr := sources.ParsePreReceiveInput(cmd.InOrStdin())
+		if parseErr != nil {
+			logging.Fatal().Err(parseErr).Msg("could not read pre-receive input")
+		}
+		logArgs := sources.PreReceiveLogArgs(updates)
+		if len(logArgs) == 0 {
+			// Nothing to scan (e.g. only ref deletions). Report cleanly.
+			logging.Info().Msg("pre-receive: no new commits to scan")
+			findingSummaryAndExit(cmd, detector, findings, exitCode, start, nil)
+			return
+		}
+		// Remote info + links are irrelevant for server-side hook scans.
+		src = &sources.Git{
+			RepoPath:        source,
+			ShouldSkip:      detector.SkipFunc(),
+			Platform:        scm.NoPlatform,
+			MaxArchiveDepth: maxArchiveDepth,
+			LogOpts:         strings.Join(logArgs, " "),
+			Workers:         workers,
+		}
+	} else if preCommit || staged {
 		gitCmd, cmdErr := sources.NewGitDiffCmdContext(cmd.Context(), source, staged)
 		if cmdErr != nil {
 			logging.Fatal().Err(cmdErr).Msg("could not create Git diff cmd")
@@ -125,6 +160,14 @@ func runGit(cmd *cobra.Command, args []string) {
 		err = &multipleErrors{
 			msg:  fmt.Sprintf("%d error(s) encountered during scan", n),
 			errs: scanErrs,
+		}
+	}
+
+	// When running as a pre-receive hook, print the custom error message
+	// (with environment variables expanded) so the pushing client sees it.
+	if preReceive && findings.Count() != 0 {
+		if msg := mustGetStringFlag(cmd, "pre-receive-error-message"); msg != "" {
+			fmt.Fprintln(os.Stderr, os.ExpandEnv(msg))
 		}
 	}
 

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,4 +19,80 @@ func TestPreReceiveFlagsRegistered(t *testing.T) {
 
 	errMsg := gitCmd.Flags().Lookup("pre-receive-error-message")
 	require.Equal(t, "", errMsg.DefValue)
+}
+
+// buildBetterleaksBinary compiles the CLI once for the current test so the
+// pre-receive flow can be exercised end to end, including the os.Exit reject
+// path that cannot be observed from an in-process call.
+func buildBetterleaksBinary(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	bin := filepath.Join(t.TempDir(), "betterleaks")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	build.Dir = ".." // module root
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build betterleaks: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func gitCmdT(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+	return strings.TrimSpace(string(out))
+}
+
+// TestPreReceiveHookRejectsPushWithLeak drives the full pre-receive flow: it
+// feeds a ref update on stdin, confirms the command exits non-zero when the
+// pushed commit contains a secret, and confirms the custom error message is
+// printed with environment variables expanded.
+func TestPreReceiveHookRejectsPushWithLeak(t *testing.T) {
+	bin := buildBetterleaksBinary(t)
+	repo := t.TempDir()
+
+	gitCmdT(t, repo, "-C", repo, "init", "--quiet")
+	gitCmdT(t, repo, "-C", repo, "config", "user.email", "test@example.com")
+	gitCmdT(t, repo, "-C", repo, "config", "user.name", "Test User")
+
+	// Clean base commit.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "clean.txt"), []byte("nothing here\n"), 0o600))
+	gitCmdT(t, repo, "-C", repo, "add", ".")
+	gitCmdT(t, repo, "-C", repo, "commit", "--quiet", "-m", "base")
+	oldSHA := gitCmdT(t, repo, "-C", repo, "rev-parse", "HEAD")
+
+	// Second commit introduces a detectable secret.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "creds.txt"),
+		[]byte("token = \"glpat-ABCDEFGHIJKLMNOPQRST\"\n"), 0o600))
+	gitCmdT(t, repo, "-C", repo, "add", ".")
+	gitCmdT(t, repo, "-C", repo, "commit", "--quiet", "-m", "leak")
+	newSHA := gitCmdT(t, repo, "-C", repo, "rev-parse", "HEAD")
+
+	run := func(stdin string) (string, error) {
+		cmd := exec.Command(bin, "git", repo, "--pre-receive", "--no-banner",
+			"--pre-receive-error-message", "BLOCKED on ${PROJECT}")
+		cmd.Dir = repo
+		cmd.Stdin = strings.NewReader(stdin)
+		cmd.Env = append(os.Environ(), "PROJECT=my-service")
+		out, err := cmd.CombinedOutput()
+		return string(out), err
+	}
+
+	// Update push (old..new) with a leak must be rejected.
+	out, err := run(oldSHA + " " + newSHA + " refs/heads/main\n")
+	require.Error(t, err, "push with a leak should exit non-zero")
+	require.Contains(t, out, "BLOCKED on my-service", "custom message with expanded env var")
+	require.Contains(t, out, "leaks found")
+
+	// Delete-only push has nothing to scan and must succeed.
+	zero := strings.Repeat("0", 40)
+	out, err = run(newSHA + " " + zero + " refs/heads/main\n")
+	require.NoError(t, err, "delete-only push should succeed:\n%s", out)
+	require.Contains(t, out, "no new commits to scan")
 }

--- a/cmd/git_test.go
+++ b/cmd/git_test.go
@@ -1,0 +1,18 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreReceiveFlagsRegistered(t *testing.T) {
+	require.NotNil(t, gitCmd.Flags().Lookup("pre-receive"))
+	require.NotNil(t, gitCmd.Flags().Lookup("pre-receive-error-message"))
+
+	preReceive := gitCmd.Flags().Lookup("pre-receive")
+	require.Equal(t, "false", preReceive.DefValue)
+
+	errMsg := gitCmd.Flags().Lookup("pre-receive-error-message")
+	require.Equal(t, "", errMsg.DefValue)
+}

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -31,6 +31,7 @@ historical defaults.
 | Files on disk | `betterleaks dir` |
 | Git history | `betterleaks git` |
 | Staged or pre-commit diffs | `betterleaks git --pre-commit [--staged]` |
+| Commits pushed to a server (pre-receive hook) | `betterleaks git --pre-receive` |
 | GitHub repos, Issues, PRs, Actions, Releases, Discussions, Gists | `betterleaks github <url>` |
 | GitLab projects, Issues, MRs, Snippets, Releases, CI jobs/artifacts | `betterleaks gitlab <url>` |
 | Hugging Face models, datasets, Spaces, discussions, PRs, buckets | `betterleaks huggingface <url>` or `betterleaks hf <url>` |
@@ -98,6 +99,36 @@ betterleaks git . --platform github
 # history scan with JSON output
 betterleaks git . --source-workers 8 --report-path findings.json --report-format json
 ```
+
+### Pre-receive hook
+
+Use `--pre-receive` to run betterleaks as a server-side [Git `pre-receive`
+hook](https://git-scm.com/docs/githooks#pre-receive). The hook reads the ref
+updates Git supplies on stdin (`<old-value> <new-value> <ref-name>` per line),
+scans only the newly pushed commits, and exits non-zero when leaks are found,
+which makes Git reject the push.
+
+- Updated refs are scanned as the `<old>..<new>` range.
+- Newly created refs are scanned excluding history already in the repository
+  (so a new branch or tag is not re-scanned back to the root commit).
+- Deleted refs contribute nothing; a push that only deletes refs is allowed.
+
+`--pre-receive` cannot be combined with `--pre-commit`, `--staged`, or
+`--log-opts`.
+
+Install it by placing an executable `hooks/pre-receive` in the (bare) server
+repository:
+
+```sh
+#!/bin/sh
+exec betterleaks git --pre-receive --no-banner \
+	--pre-receive-error-message "Push rejected on ${CI_PROJECT}: secrets detected. Contact ${SECURITY_TEAM}."
+```
+
+`--pre-receive-error-message` is printed to stderr (visible to the pushing
+client as `remote:` output) only when leaks are found. `$VAR` and `${VAR}`
+references in the message are expanded from the hook process environment, so you
+can surface repository, project, or contact details configured for the server.
 
 ---
 

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -111,6 +111,8 @@ which makes Git reject the push.
 - Updated refs are scanned as the `<old>..<new>` range.
 - Newly created refs are scanned excluding history already in the repository
   (so a new branch or tag is not re-scanned back to the root commit).
+- Annotated tags are peeled to the commit they target; refs that do not point
+  at a commit (for example a tag on a blob or tree) are skipped.
 - Deleted refs contribute nothing; a push that only deletes refs is allowed.
 
 `--pre-receive` cannot be combined with `--pre-commit`, `--staged`, or

--- a/sources/pre_receive.go
+++ b/sources/pre_receive.go
@@ -38,6 +38,28 @@ func isZeroOID(value string) bool {
 	return true
 }
 
+// isHexOID reports whether value is a syntactically valid git object id: a
+// lowercase or uppercase hex string of SHA-1 (40) or SHA-256 (64) length.
+// Ref updates read from hook stdin are untrusted, so validating them before
+// they are passed to git rejects option- or revision-injection attempts (for
+// example a value beginning with "-" or containing ".." or "^") and any other
+// non-object-id input.
+func isHexOID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // IsDelete reports whether the update deletes the ref (new value is zero).
 func (u PreReceiveRefUpdate) IsDelete() bool { return isZeroOID(u.NewValue) }
 
@@ -105,6 +127,15 @@ func PreReceiveLogArgs(updates []PreReceiveRefUpdate, resolve CommitResolver) []
 		if u.IsDelete() {
 			continue
 		}
+		// Reject updates whose object ids are not syntactically valid so no
+		// attacker-controlled value from hook stdin can reach git as an
+		// option or revision expression.
+		if !isHexOID(u.NewValue) {
+			continue
+		}
+		if !u.IsCreate() && !isHexOID(u.OldValue) {
+			continue
+		}
 
 		newValue := u.NewValue
 		if resolve != nil {
@@ -137,11 +168,18 @@ func PreReceiveLogArgs(updates []PreReceiveRefUpdate, resolve CommitResolver) []
 // (`<oid>^{commit}`), which handles both plain commits and annotated tags that
 // target a commit. Tags that point directly at a tree or blob do not peel and
 // are reported as non-commits.
+//
+// The object id is validated as hex before use, so the value handed to git can
+// never be interpreted as an option or a broader revision expression even
+// though it originates from untrusted hook stdin.
 func NewGitCommitResolver(ctx context.Context, repoPath string) CommitResolver {
 	sourceClean := filepath.Clean(repoPath)
 	return func(oid string) (string, bool) {
+		if !isHexOID(oid) {
+			return "", false
+		}
 		cmd := exec.CommandContext(ctx, "git", "-C", sourceClean,
-			"rev-parse", "--verify", "--quiet", oid+"^{commit}")
+			"rev-parse", "--verify", "--quiet", "--end-of-options", oid+"^{commit}")
 		cmd.Env = gitConfigIsolationEnv()
 		out, err := cmd.Output()
 		if err != nil {

--- a/sources/pre_receive.go
+++ b/sources/pre_receive.go
@@ -2,7 +2,10 @@ package sources
 
 import (
 	"bufio"
+	"context"
 	"io"
+	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -71,6 +74,12 @@ func ParsePreReceiveInput(r io.Reader) ([]PreReceiveRefUpdate, error) {
 	return updates, nil
 }
 
+// CommitResolver peels a ref object id to the commit it points at. It returns
+// the resolved commit id and true when the object is (or peels to) a commit,
+// and false when it does not — for example a tag that points directly at a
+// tree or blob, which has no commit history to scan.
+type CommitResolver func(oid string) (string, bool)
+
 // PreReceiveLogArgs converts ref updates into `git log` revision arguments that
 // select only the newly pushed commits.
 //
@@ -80,9 +89,14 @@ func ParsePreReceiveInput(r io.Reader) ([]PreReceiveRefUpdate, error) {
 //     single trailing "--not --all", which excludes every commit already
 //     reachable from an existing ref so only genuinely new commits are scanned.
 //
+// resolve peels each new value to a commit; ref updates whose new value does
+// not resolve to a commit (for example a tag pointing at a tree or blob) are
+// skipped so their object ids are never handed to `git log`. When resolve is
+// nil the new values are used verbatim.
+//
 // The returned slice is empty when there is nothing to scan (for example a
 // push that only deletes refs).
-func PreReceiveLogArgs(updates []PreReceiveRefUpdate) []string {
+func PreReceiveLogArgs(updates []PreReceiveRefUpdate, resolve CommitResolver) []string {
 	var (
 		args      []string
 		hasCreate bool
@@ -91,12 +105,24 @@ func PreReceiveLogArgs(updates []PreReceiveRefUpdate) []string {
 		if u.IsDelete() {
 			continue
 		}
+
+		newValue := u.NewValue
+		if resolve != nil {
+			commit, ok := resolve(u.NewValue)
+			if !ok {
+				// The pushed ref does not point at a commit; there is no
+				// history to scan.
+				continue
+			}
+			newValue = commit
+		}
+
 		if u.IsCreate() {
-			args = append(args, u.NewValue)
+			args = append(args, newValue)
 			hasCreate = true
 			continue
 		}
-		args = append(args, u.OldValue+".."+u.NewValue)
+		args = append(args, u.OldValue+".."+newValue)
 	}
 	if hasCreate {
 		// Exclude commits already present in the repository so a newly created
@@ -104,4 +130,27 @@ func PreReceiveLogArgs(updates []PreReceiveRefUpdate) []string {
 		args = append(args, "--not", "--all")
 	}
 	return args
+}
+
+// NewGitCommitResolver returns a CommitResolver backed by `git rev-parse` in
+// the given repository. An object id resolves when it peels to a commit
+// (`<oid>^{commit}`), which handles both plain commits and annotated tags that
+// target a commit. Tags that point directly at a tree or blob do not peel and
+// are reported as non-commits.
+func NewGitCommitResolver(ctx context.Context, repoPath string) CommitResolver {
+	sourceClean := filepath.Clean(repoPath)
+	return func(oid string) (string, bool) {
+		cmd := exec.CommandContext(ctx, "git", "-C", sourceClean,
+			"rev-parse", "--verify", "--quiet", oid+"^{commit}")
+		cmd.Env = gitConfigIsolationEnv()
+		out, err := cmd.Output()
+		if err != nil {
+			return "", false
+		}
+		commit := strings.TrimSpace(string(out))
+		if commit == "" {
+			return "", false
+		}
+		return commit, true
+	}
 }

--- a/sources/pre_receive.go
+++ b/sources/pre_receive.go
@@ -1,0 +1,107 @@
+package sources
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// zeroOID is the all-zero object id git uses to represent a missing ref
+// (a created or deleted ref) in pre-receive/update hook input.
+const zeroOID = "0000000000000000000000000000000000000000"
+
+// PreReceiveRefUpdate is a single ref update as reported to a pre-receive hook
+// on stdin in the form "<old-value> SP <new-value> SP <ref-name> LF".
+type PreReceiveRefUpdate struct {
+	OldValue string
+	NewValue string
+	RefName  string
+}
+
+// isZeroOID reports whether value is git's all-zero object id (any length,
+// to tolerate both SHA-1 and SHA-256 repositories).
+func isZeroOID(value string) bool {
+	if value == "" {
+		return true
+	}
+	if value == zeroOID {
+		return true
+	}
+	for _, r := range value {
+		if r != '0' {
+			return false
+		}
+	}
+	return true
+}
+
+// IsDelete reports whether the update deletes the ref (new value is zero).
+func (u PreReceiveRefUpdate) IsDelete() bool { return isZeroOID(u.NewValue) }
+
+// IsCreate reports whether the update creates the ref (old value is zero).
+func (u PreReceiveRefUpdate) IsCreate() bool { return isZeroOID(u.OldValue) }
+
+// ParsePreReceiveInput parses the ref updates a pre-receive hook receives on
+// stdin. Each non-empty line must contain three whitespace-separated fields:
+// old-value, new-value, and ref-name. Blank lines are ignored.
+func ParsePreReceiveInput(r io.Reader) ([]PreReceiveRefUpdate, error) {
+	var updates []PreReceiveRefUpdate
+	scanner := bufio.NewScanner(r)
+	// Ref update lines are short, but raise the buffer to be safe with long
+	// ref names.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		updates = append(updates, PreReceiveRefUpdate{
+			OldValue: fields[0],
+			NewValue: fields[1],
+			RefName:  strings.Join(fields[2:], " "),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return updates, nil
+}
+
+// PreReceiveLogArgs converts ref updates into `git log` revision arguments that
+// select only the newly pushed commits.
+//
+//   - Deleted refs (new value is zero) contribute nothing.
+//   - Updated refs contribute "<old>..<new>".
+//   - Created refs (old value is zero) contribute "<new>" together with a
+//     single trailing "--not --all", which excludes every commit already
+//     reachable from an existing ref so only genuinely new commits are scanned.
+//
+// The returned slice is empty when there is nothing to scan (for example a
+// push that only deletes refs).
+func PreReceiveLogArgs(updates []PreReceiveRefUpdate) []string {
+	var (
+		args      []string
+		hasCreate bool
+	)
+	for _, u := range updates {
+		if u.IsDelete() {
+			continue
+		}
+		if u.IsCreate() {
+			args = append(args, u.NewValue)
+			hasCreate = true
+			continue
+		}
+		args = append(args, u.OldValue+".."+u.NewValue)
+	}
+	if hasCreate {
+		// Exclude commits already present in the repository so a newly created
+		// branch or tag is not scanned back to the root commit.
+		args = append(args, "--not", "--all")
+	}
+	return args
+}

--- a/sources/pre_receive.go
+++ b/sources/pre_receive.go
@@ -111,10 +111,13 @@ type CommitResolver func(oid string) (string, bool)
 //     single trailing "--not --all", which excludes every commit already
 //     reachable from an existing ref so only genuinely new commits are scanned.
 //
-// resolve peels each new value to a commit; ref updates whose new value does
-// not resolve to a commit (for example a tag pointing at a tree or blob) are
-// skipped so their object ids are never handed to `git log`. When resolve is
-// nil the new values are used verbatim.
+// resolve peels each old and new value to a commit. Ref updates whose new value
+// does not resolve to a commit (for example a tag pointing at a tree or blob)
+// are skipped so their object ids are never handed to `git log`. If only the
+// old value fails to resolve — a ref retagged from a non-commit target to a
+// commit — the update is scanned like a create ("<new>" bounded by
+// "--not --all") rather than emitting an invalid "<old>..<new>" range. When
+// resolve is nil the values are used verbatim.
 //
 // The returned slice is empty when there is nothing to scan (for example a
 // push that only deletes refs).
@@ -148,12 +151,31 @@ func PreReceiveLogArgs(updates []PreReceiveRefUpdate, resolve CommitResolver) []
 			newValue = commit
 		}
 
+		// A create has no old commit to bound the range, so scan the new
+		// commit and exclude existing history below via "--not --all".
 		if u.IsCreate() {
 			args = append(args, newValue)
 			hasCreate = true
 			continue
 		}
-		args = append(args, u.OldValue+".."+newValue)
+
+		// For an update, bound the scan with "<old>..<new>". The old value
+		// must also peel to a commit — a ref retagged from a non-commit
+		// (blob/tree) target to a commit would otherwise hand a non-commit id
+		// to git log and fail the scan. When the old value is not a commit,
+		// fall back to scanning just the new commit excluding existing
+		// history, exactly as for a create.
+		oldValue := u.OldValue
+		if resolve != nil {
+			commit, ok := resolve(u.OldValue)
+			if !ok {
+				args = append(args, newValue)
+				hasCreate = true
+				continue
+			}
+			oldValue = commit
+		}
+		args = append(args, oldValue+".."+newValue)
 	}
 	if hasCreate {
 		// Exclude commits already present in the repository so a newly created

--- a/sources/pre_receive_test.go
+++ b/sources/pre_receive_test.go
@@ -134,6 +134,35 @@ func TestIsZeroOID(t *testing.T) {
 	require.False(t, isZeroOID("0000000000000000000000000000000000000001"))
 }
 
+func TestIsHexOID(t *testing.T) {
+	require.True(t, isHexOID(strings.Repeat("a", 40)), "sha-1 length")
+	require.True(t, isHexOID(strings.Repeat("A", 40)), "uppercase hex")
+	require.True(t, isHexOID(strings.Repeat("f", 64)), "sha-256 length")
+
+	require.False(t, isHexOID(""), "empty")
+	require.False(t, isHexOID(strings.Repeat("a", 39)), "too short")
+	require.False(t, isHexOID(strings.Repeat("a", 41)), "wrong length")
+	require.False(t, isHexOID("--all"), "option-like value")
+	require.False(t, isHexOID(strings.Repeat("g", 40)), "non-hex char")
+	require.False(t, isHexOID("HEAD"), "revision expression")
+}
+
+func TestPreReceiveLogArgsRejectsNonOIDInput(t *testing.T) {
+	const newSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	// A malicious/malformed new value must never reach git.
+	got := PreReceiveLogArgs([]PreReceiveRefUpdate{
+		{OldValue: zeroOID, NewValue: "--all", RefName: "refs/heads/evil"},
+	}, nil)
+	require.Nil(t, got, "option-like new value is dropped")
+
+	// A malformed old value on an update is dropped too.
+	got = PreReceiveLogArgs([]PreReceiveRefUpdate{
+		{OldValue: "$(rm -rf /)", NewValue: newSHA, RefName: "refs/heads/main"},
+	}, nil)
+	require.Nil(t, got, "malformed old value is dropped")
+}
+
 func TestNewGitCommitResolver(t *testing.T) {
 	repo := newGitTestRepo(t, 1)
 

--- a/sources/pre_receive_test.go
+++ b/sources/pre_receive_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -35,7 +36,18 @@ func TestPreReceiveLogArgs(t *testing.T) {
 	const (
 		oldSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 		newSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+		// blobSHA stands in for a tag that points directly at a blob/tree and
+		// therefore does not peel to a commit.
+		blobSHA = "cccccccccccccccccccccccccccccccccccccccc"
 	)
+
+	// resolve treats every value as a commit except blobSHA.
+	resolve := func(oid string) (string, bool) {
+		if oid == blobSHA {
+			return "", false
+		}
+		return oid, true
+	}
 
 	tests := []struct {
 		name    string
@@ -77,13 +89,41 @@ func TestPreReceiveLogArgs(t *testing.T) {
 			},
 			want: []string{oldSHA + ".." + newSHA, newSHA, "--not", "--all"},
 		},
+		{
+			name: "non-commit ref is skipped",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: zeroOID, NewValue: blobSHA, RefName: "refs/tags/blob-tag"},
+			},
+			want: nil,
+		},
+		{
+			name: "non-commit ref does not trigger not-all",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"},
+				{OldValue: zeroOID, NewValue: blobSHA, RefName: "refs/tags/blob-tag"},
+			},
+			want: []string{oldSHA + ".." + newSHA},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, PreReceiveLogArgs(tt.updates))
+			require.Equal(t, tt.want, PreReceiveLogArgs(tt.updates, resolve))
 		})
 	}
+}
+
+func TestPreReceiveLogArgsNilResolver(t *testing.T) {
+	const (
+		oldSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		newSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	// A nil resolver uses new values verbatim.
+	got := PreReceiveLogArgs([]PreReceiveRefUpdate{
+		{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"},
+	}, nil)
+	require.Equal(t, []string{oldSHA + ".." + newSHA}, got)
 }
 
 func TestIsZeroOID(t *testing.T) {
@@ -92,4 +132,42 @@ func TestIsZeroOID(t *testing.T) {
 	require.True(t, isZeroOID(strings.Repeat("0", 64)))
 	require.False(t, isZeroOID("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 	require.False(t, isZeroOID("0000000000000000000000000000000000000001"))
+}
+
+func TestNewGitCommitResolver(t *testing.T) {
+	repo := newGitTestRepo(t, 1)
+
+	revParse := func(rev string) string {
+		t.Helper()
+		out, err := exec.Command("git", "-C", repo, "rev-parse", rev).Output()
+		require.NoError(t, err)
+		return strings.TrimSpace(string(out))
+	}
+
+	commitSHA := revParse("HEAD")
+
+	// A tag object pointing directly at a blob has no commit to scan.
+	blobSHA := revParse("HEAD:file-0.txt")
+	runGitTestCommand(t, repo, "tag", "-a", "blob-tag", "-m", "blob tag", blobSHA)
+	blobTagSHA := revParse("blob-tag")
+
+	// An annotated tag pointing at a commit should peel to that commit.
+	runGitTestCommand(t, repo, "tag", "-a", "commit-tag", "-m", "commit tag", commitSHA)
+	commitTagSHA := revParse("commit-tag")
+
+	resolve := NewGitCommitResolver(t.Context(), repo)
+
+	got, ok := resolve(commitSHA)
+	require.True(t, ok)
+	require.Equal(t, commitSHA, got)
+
+	got, ok = resolve(commitTagSHA)
+	require.True(t, ok, "annotated tag on a commit should peel to the commit")
+	require.Equal(t, commitSHA, got)
+
+	_, ok = resolve(blobTagSHA)
+	require.False(t, ok, "tag pointing at a blob should not resolve to a commit")
+
+	_, ok = resolve(strings.Repeat("0", 40))
+	require.False(t, ok, "unknown object should not resolve")
 }

--- a/sources/pre_receive_test.go
+++ b/sources/pre_receive_test.go
@@ -104,6 +104,21 @@ func TestPreReceiveLogArgs(t *testing.T) {
 			},
 			want: []string{oldSHA + ".." + newSHA},
 		},
+		{
+			name: "update from non-commit old value scans new like a create",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: blobSHA, NewValue: newSHA, RefName: "refs/tags/retagged"},
+			},
+			want: []string{newSHA, "--not", "--all"},
+		},
+		{
+			name: "update from non-commit old value alongside a real update",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"},
+				{OldValue: blobSHA, NewValue: newSHA, RefName: "refs/tags/retagged"},
+			},
+			want: []string{oldSHA + ".." + newSHA, newSHA, "--not", "--all"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/sources/pre_receive_test.go
+++ b/sources/pre_receive_test.go
@@ -1,0 +1,95 @@
+package sources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePreReceiveInput(t *testing.T) {
+	const (
+		oldSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		newSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	input := strings.Join([]string{
+		oldSHA + " " + newSHA + " refs/heads/main",
+		"",
+		"  " + zeroOID + " " + newSHA + " refs/heads/feature  ",
+		oldSHA + " " + zeroOID + " refs/heads/stale",
+		"only two",
+	}, "\n")
+
+	updates, err := ParsePreReceiveInput(strings.NewReader(input))
+	require.NoError(t, err)
+	require.Len(t, updates, 3)
+
+	require.Equal(t, PreReceiveRefUpdate{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"}, updates[0])
+	require.True(t, updates[1].IsCreate())
+	require.Equal(t, "refs/heads/feature", updates[1].RefName)
+	require.True(t, updates[2].IsDelete())
+}
+
+func TestPreReceiveLogArgs(t *testing.T) {
+	const (
+		oldSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		newSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	)
+
+	tests := []struct {
+		name    string
+		updates []PreReceiveRefUpdate
+		want    []string
+	}{
+		{
+			name:    "empty",
+			updates: nil,
+			want:    nil,
+		},
+		{
+			name: "delete only",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: oldSHA, NewValue: zeroOID, RefName: "refs/heads/stale"},
+			},
+			want: nil,
+		},
+		{
+			name: "update",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"},
+			},
+			want: []string{oldSHA + ".." + newSHA},
+		},
+		{
+			name: "create excludes existing history",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: zeroOID, NewValue: newSHA, RefName: "refs/heads/feature"},
+			},
+			want: []string{newSHA, "--not", "--all"},
+		},
+		{
+			name: "mixed update, create, and delete",
+			updates: []PreReceiveRefUpdate{
+				{OldValue: oldSHA, NewValue: newSHA, RefName: "refs/heads/main"},
+				{OldValue: zeroOID, NewValue: newSHA, RefName: "refs/heads/feature"},
+				{OldValue: oldSHA, NewValue: zeroOID, RefName: "refs/heads/stale"},
+			},
+			want: []string{oldSHA + ".." + newSHA, newSHA, "--not", "--all"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, PreReceiveLogArgs(tt.updates))
+		})
+	}
+}
+
+func TestIsZeroOID(t *testing.T) {
+	require.True(t, isZeroOID(""))
+	require.True(t, isZeroOID("0000000000000000000000000000000000000000"))
+	require.True(t, isZeroOID(strings.Repeat("0", 64)))
+	require.False(t, isZeroOID("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+	require.False(t, isZeroOID("0000000000000000000000000000000000000001"))
+}


### PR DESCRIPTION
Add `betterleaks git --pre-receive` to run as a server-side pre-receive hook. It reads ref updates from stdin, scans only the newly pushed commits (old..new for updates, new excluding existing history for creates, nothing for deletes), and exits non-zero to reject the push when leaks are found.

`--pre-receive-error-message` prints a custom message to stderr when leaks are found, expanding `$VAR` and `${VAR}` from the hook environment.