### PR TITLE
add Bitbucket Data Center token rule

### DIFF
--- a/cmd/generate/config/main.go
+++ b/cmd/generate/config/main.go
@@ -126,6 +126,7 @@ func main() {
 		rules.AzureServiceBusConnectionString(),
 		rules.BitBucketClientID(),
 		rules.BitBucketClientSecret(),
+		rules.BitBucketDataCenterToken(),
 		rules.BitriseAccessToken(),
 		rules.BitlyAccessToken(),
 		rules.BittrexAccessKey(),

--- a/cmd/generate/config/rules/bitbucket.go
+++ b/cmd/generate/config/rules/bitbucket.go
@@ -38,3 +38,28 @@ func BitBucketClientSecret() *config.Rule {
 	tps := utils.GenerateSampleSecrets("bitbucket", secrets.NewSecretWithEntropy(utils.AlphaNumeric("64"), 3.5))
 	return utils.Validate(r, tps, nil)
 }
+
+func BitBucketDataCenterToken() *config.Rule {
+	// BBDC- prefix, then base64 of "<token id>:<random bytes>"
+	r := config.Rule{
+		Description: "Discovered a Bitbucket Data Center HTTP access token, risking unauthorized repository and project access.",
+		RuleID:      "bitbucket-data-center-token",
+		Confidence:  "high",
+		Regex:       utils.GenerateUniqueTokenRegex(`BBDC-[A-Za-z0-9+/=]{32,}`, false),
+		Keywords:    []string{"bbdc"},
+		Filter:      `filter.entropy(finding["secret"]) < 3.5 || filter.tokenRatio(finding["secret"]) >= 2.5`,
+	}
+
+	tps := []string{
+		`BITBUCKET_TOKEN = "BBDC-` + secrets.NewSecretWithEntropy(`[A-Za-z0-9+/=]{44}`, 3.5) + `"`,
+		`token=BBDC-` + secrets.NewSecretWithEntropy(`[A-Za-z0-9+/=]{60}`, 3.5),
+		`BBDC-ODU3MDkzMTU4MDk1OiKqsM8HOsW1XhaMu33mVB6bLJea`,
+	}
+
+	fps := []string{
+		`BITBUCKET_TOKEN = "BBDC-` + secrets.NewSecret(`[A-Za-z0-9+/=]{20}`) + `"`,
+		`bbdc-config-name = "staging"`,
+	}
+
+	return utils.Validate(r, tps, fps)
+}

--- a/config/betterleaks.toml
+++ b/config/betterleaks.toml
@@ -1144,6 +1144,19 @@ filter.entropy(finding["secret"]) < 3.5 || filter.tokenRatio(finding["secret"]) 
 '''
 
 # ──────────────────────────────────────────────────────────────────────────────
+# bitbucket-data-center-token
+# ──────────────────────────────────────────────────────────────────────────────
+[[rules]]
+id = "bitbucket-data-center-token"
+description = "Discovered a Bitbucket Data Center HTTP access token, risking unauthorized repository and project access."
+regex = '''\b(BBDC-[A-Za-z0-9+/=]{32,})(?:\\?['"\x60]|[\s;]|\\[nr]|$)'''
+confidence = "high"
+keywords = ["bbdc"]
+filter = '''
+filter.entropy(finding["secret"]) < 3.5 || filter.tokenRatio(finding["secret"]) >= 2.5
+'''
+
+# ──────────────────────────────────────────────────────────────────────────────
 # bitly-access-token
 # ──────────────────────────────────────────────────────────────────────────────
 [[rules]]


### PR DESCRIPTION
Matches the BBDC- prefix used by Bitbucket Data Center HTTP access tokens. Previously these were only caught by generic-api-key, and only when a keyword happened to sit nearby.