### PR TITLE
Return an empty array for JSON reports without findings

### DIFF
--- a/report/json.go
+++ b/report/json.go
@@ -11,6 +11,9 @@ type JsonReporter struct {
 var _ Reporter = (*JsonReporter)(nil)
 
 func (t *JsonReporter) Write(w io.WriteCloser, findings []Finding) error {
+	if findings == nil {
+		findings = []Finding{}
+	}
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", " ")
 	return encoder.Encode(findings)

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -47,6 +47,11 @@ func TestWriteJSON(t *testing.T) {
 			testReportName: "empty",
 			expected:       filepath.Join(expectPath, "report", "empty.json"),
 			findings:       []Finding{}},
+		{
+			testReportName: "nil",
+			expected:       filepath.Join(expectPath, "report", "empty.json"),
+			findings:       nil,
+		},
 	}
 
 	reporter := JsonReporter{}


### PR DESCRIPTION
## Summary

- Normalize nil findings before JSON encoding so successful reports always contain an array
- Cover nil findings separately from an initialized empty slice

Closes #339

## Testing

- `go test -race -p 2 ./...`
- `go build -p 2 ./...`
- `go run -p 2 . config check config/betterleaks.toml`
- `go run -p 2 . --regex-engine stdlib config check config/betterleaks.toml`
- `git diff --check`