### PR TITLE
report: never print a raw secret when its exact location can't be verified

### DIFF
--- a/report/finding.go
+++ b/report/finding.go
@@ -166,15 +166,222 @@ func cartesianFindings(ruleOrder []string, byRule map[string][]*ComponentFinding
 	return result
 }
 
+// redactedUnlocatable replaces Line when Secret can't be found in it as a
+// literal substring. This happens for decode-depth/component findings, where
+// Secret is deliberately captured from decoded text while Line is kept as
+// the original, still-encoded file content (so users see their actual file,
+// not an internal decoded intermediate — see detect.go's decode pass). Line
+// is the field print_pretty.go's secretByteBounds/renderLinesOnly treat as
+// "the raw text to display", so if a literal replace can't verify redaction
+// succeeded there, we must not fall back to showing it un-redacted.
+const redactedUnlocatable = "[secret redacted: exact location could not be verified]"
+
+// secretOffsetInLine returns the 0-indexed byte offset within line where
+// secret is expected to start, or -1 if that can't be determined at all.
+// startColumn is the finding's 1-indexed byte offset (from the start of
+// line) where match — not necessarily secret itself — is known to start
+// (see detect/location.go: Finding.StartColumn/ComponentFinding.StartColumn
+// are always relative to the start of Line, including for multi-line
+// findings). secret is frequently a narrower capture group *within* match
+// (many rules capture just the credential value, e.g. after a "key: "
+// prefix — see detect.go, where Finding.Secret is reassigned to a regex
+// submatch of the original full-match text that Finding.Match still holds),
+// so secret's own offset is startColumn's offset plus secret's offset
+// within match, not startColumn alone.
+//
+// The detector also trims leading newlines off Match/Secret without
+// adjusting StartColumn (see detect.go's strings.Trim(rawMatch, "\n") when
+// building the pre-capture-group secret), so for a rule whose regex itself
+// matches a leading newline (e.g. "\n(secret)"), startColumn can still point
+// at that newline byte in line rather than at match's actual first byte
+// post-trim — matchStart below walks past any such bytes to compensate.
+//
+// strings.Trim's cutset there is "\n" only, though: it stops at the very
+// first leading byte that isn't in the cutset, so a leading "\r\n" (e.g. a
+// CRLF rule like "\r\n(secret)") is left completely untrimmed — match still
+// starts with those bytes verbatim. matchStart's walk-forward can't tell
+// the difference and always advances past leading \r/\n bytes in line, so
+// matchPrefixLen measures how many such bytes match itself still retains
+// and subtracts them back out, undoing the walk-forward exactly when it
+// wasn't warranted.
+// secretAmbiguous is a sentinel secretOffsetInLine returns when secret
+// occurs more than once within match: strings.Index can only find the
+// *first* occurrence, which isn't necessarily the one the rule's capture
+// group actually matched. For example, the built-in generic-credential-uri
+// rule can decode a URI like "https://plaintext-secret:<base64(plaintext-
+// secret)>@host" into a match whose username textually precedes the
+// captured, decoded password — both now reading "plaintext-secret". Trusting
+// the first (username) occurrence would verify successfully (the username
+// really is that literal text in Line too) and redact it, while the real
+// credential — still base64-encoded a few bytes later in the same Line —
+// is a completely different string and goes untouched. Unlike -1 (no
+// position hint at all, which still falls back to a plain Contains search),
+// callers must never fall back to that lenient search for this sentinel
+// either: Contains would just as readily match the same wrong occurrence.
+const secretAmbiguous = -2
+
+func secretOffsetInLine(line, match, secret string, startColumn int) int {
+	if startColumn <= 0 || secret == "" {
+		return -1
+	}
+	relOffset := strings.Index(match, secret)
+	if relOffset < 0 {
+		return -1
+	}
+	if strings.Index(match[relOffset+len(secret):], secret) >= 0 {
+		return secretAmbiguous
+	}
+	matchStart := startColumn - 1
+	for matchStart < len(line) && (line[matchStart] == '\n' || line[matchStart] == '\r') {
+		matchStart++
+	}
+	matchPrefixLen := len(match) - len(strings.TrimLeft(match, "\r\n"))
+	return matchStart + relOffset - matchPrefixLen
+}
+
+// redactLine redacts secret out of line, verified via secretOffsetInLine.
+//
+// Once that position verifies (line really does hold secret, in this exact
+// representation, at its known real location), the whole line is passed
+// through strings.ReplaceAll rather than touching only that single span:
+// having proven this exact representation of secret is genuinely present at
+// a known-correct location, any further identical occurrence elsewhere in
+// line is provably a duplicate of the same credential, not an unrelated
+// coincidence, and must be redacted too rather than left exposed.
+//
+// It deliberately does NOT fall back to a blind Contains/ReplaceAll search
+// when a position hint was available but didn't verify: secret (the decoded
+// value, for a decode-depth finding) can coincidentally — or, in a crafted
+// file, deliberately — appear elsewhere in line as an unrelated plaintext
+// copy while the finding's actual, still-encoded span goes untouched;
+// trusting that coincidental occurrence would leave the real one exposed.
+// If no reliable position can be established at all (e.g. a Finding built
+// outside the normal detection path, where startColumn is unavailable), it
+// falls back to the same Contains-based search as before this hardening —
+// strictly better than showing raw text, if not as precise.
+func redactLine(line, match, secret, replacement string, startColumn int) string {
+	if line == "" || secret == "" {
+		return line
+	}
+	b := secretOffsetInLine(line, match, secret, startColumn)
+	if b == secretAmbiguous {
+		return redactedUnlocatable
+	}
+	if b >= 0 {
+		if b+len(secret) <= len(line) && line[b:b+len(secret)] == secret {
+			return strings.ReplaceAll(line, secret, replacement)
+		}
+		return redactedUnlocatable
+	}
+	if !strings.Contains(line, secret) {
+		return redactedUnlocatable
+	}
+	return strings.ReplaceAll(line, secret, replacement)
+}
+
+// redactContext is redactLine's counterpart for MatchContext. MatchContext
+// isn't itself addressable by a single column — it's a separate window of
+// text around Line (see detect.go, contextwindow.Extract) — so instead it's
+// verified by anchoring on line (Line's own, not-yet-redacted value): if
+// matchContext contains line intact, secret's absolute position within
+// matchContext is that occurrence's offset plus secret's already-verified
+// offset within line. Once verified, the whole matchContext is passed
+// through strings.ReplaceAll (not just that one span) for the same reason
+// redactLine does: any other identical occurrence — including, notably, a
+// duplicate copy of line elsewhere in the context window — is a real
+// duplicate of the same credential once we've proven this representation is
+// genuine, not something to leave untouched because a different copy of
+// line happened to anchor the check.
+//
+// A column-based --match-context window can be clipped shorter than a full
+// line, so matchContext may not contain line intact even for an entirely
+// ordinary finding. When secretOffsetInLine did establish a position (b >= 0)
+// but the anchor can't be found or verified there, this fails closed
+// (blanks matchContext) rather than falling through to the same lenient
+// Contains-based search redactLine also refuses in that situation — for the
+// same reason: an unrelated coincidental occurrence of secret elsewhere in
+// the clipped window must not be mistaken for the real, still-encoded span.
+// The lenient fallback below is reserved for when no position could be
+// established at all.
+//
+// Box-mode MatchContext (see detect.go, contextwindow.extractBox) ends at a
+// line's trailing newline rather than past it, while Line (for any but the
+// file's last line) includes that trailing newline — so for a non-final
+// line the anchor lookup would otherwise always fail even for an entirely
+// ordinary finding. b's own value doesn't depend on line's end, only its
+// start, so it's safe to retry the lookup with line's own trailing \r\n
+// stripped when the untrimmed lookup fails.
+func redactContext(matchContext, line, match, secret, replacement string, startColumn int) string {
+	if matchContext == "" {
+		return matchContext
+	}
+	b := secretOffsetInLine(line, match, secret, startColumn)
+	if b == secretAmbiguous {
+		return redactedUnlocatable
+	}
+	if b >= 0 {
+		if line == "" {
+			return redactedUnlocatable
+		}
+		lineIdx := strings.Index(matchContext, line)
+		if lineIdx < 0 {
+			if trimmed := strings.TrimRight(line, "\r\n"); trimmed != line {
+				lineIdx = strings.Index(matchContext, trimmed)
+			}
+		}
+		if lineIdx < 0 {
+			return redactedUnlocatable
+		}
+		abs := lineIdx + b
+		if abs+len(secret) <= len(matchContext) && matchContext[abs:abs+len(secret)] == secret {
+			return strings.ReplaceAll(matchContext, secret, replacement)
+		}
+		return redactedUnlocatable
+	}
+	if secret == "" {
+		return matchContext
+	}
+	if !strings.Contains(matchContext, secret) {
+		return redactedUnlocatable
+	}
+	return strings.ReplaceAll(matchContext, secret, replacement)
+}
+
+// redactLineAndMatch redacts line/match/matchContext using secret →
+// replacement and returns the results. line and matchContext use the
+// position-verified redactLine/redactContext — both are sliced from the
+// original fragment text at the match's (possibly decode-depth-adjusted)
+// location, so both share the same Secret/representation mismatch risk (see
+// detect.go, where finding.MatchContext is extracted from fragment.Raw
+// exactly like Line). match keeps the simple leave-as-is-when-absent
+// behavior, since Match is always derived from the same representation as
+// Secret.
+//
+// Deliberately excludes CaptureGroups and ComponentSets: both are reference
+// types (a map, and a slice of pointers) that can be shared with another copy
+// of the same Finding that still needs to see the un-redacted original —
+// e.g. the verbose/legacy console printers hold a value-copy of a Finding
+// whose ComponentSets/CaptureGroups point at the exact same underlying data
+// the report-writing path (or, for ComponentSets, PrintComponentFindings'
+// own independent masking) will redact separately. A caller that redacted
+// those fields here would mutate that shared data out from under whichever
+// consumer redacts it next, causing double-redaction. Only Finding.Redact()
+// — the single, authoritative, one-time redaction pass before a finding is
+// persisted or printed — touches CaptureGroups/ComponentSets.
+func redactLineAndMatch(line, match, matchContext, secret, replacement string, startColumn int) (newLine, newMatch, newMatchContext string) {
+	newMatchContext = redactContext(matchContext, line, match, secret, replacement, startColumn)
+	newLine = redactLine(line, match, secret, replacement, startColumn)
+	newMatch = strings.ReplaceAll(match, secret, replacement)
+	return
+}
+
 // Redact removes sensitive information from a finding.
 func (f *Finding) Redact(percent uint) {
 	secret := MaskSecret(f.Secret, percent)
 	if percent >= 100 {
 		secret = "REDACTED"
 	}
-	f.Line = strings.ReplaceAll(f.Line, f.Secret, secret)
-	f.Match = strings.ReplaceAll(f.Match, f.Secret, secret)
-	f.MatchContext = strings.ReplaceAll(f.MatchContext, f.Secret, secret)
+	f.Line, f.Match, f.MatchContext = redactLineAndMatch(f.Line, f.Match, f.MatchContext, f.Secret, secret, f.StartColumn)
 	// Capture groups can contain the secret verbatim and are emitted in JSON,
 	// JUnit, and template reports, so they must be redacted too. Done before
 	// f.Secret is overwritten so the original value is still available to match.
@@ -194,7 +401,7 @@ func (f *Finding) Redact(percent uint) {
 			if percent >= 100 {
 				compSecret = "REDACTED"
 			}
-			comp.Line = strings.ReplaceAll(comp.Line, comp.Secret, compSecret)
+			comp.Line = redactLine(comp.Line, comp.Match, comp.Secret, compSecret, comp.StartColumn)
 			comp.Match = strings.ReplaceAll(comp.Match, comp.Secret, compSecret)
 			for k, v := range comp.CaptureGroups {
 				comp.CaptureGroups[k] = strings.ReplaceAll(v, comp.Secret, compSecret)

--- a/report/finding_test.go
+++ b/report/finding_test.go
@@ -2,6 +2,9 @@ package report
 
 import (
 	"encoding/json"
+	"io"
+	"os"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -31,6 +34,25 @@ func TestRedact(t *testing.T) {
 			assert.Equal(t, "line containing REDACTED", f.Match)
 		}
 	}
+}
+
+// TestRedact_LineFromDifferentEncodingLayerIsBlanked covers a decode-depth
+// finding: Secret is captured from decoded text, while Line intentionally
+// stays as the original, still-encoded source (see detect.go), so Secret is
+// never a literal substring of Line. Previously this silently left Line
+// completely unredacted, containing the raw encoded secret; now it must be
+// replaced with a safe placeholder instead of being displayed untouched.
+func TestRedact_LineFromDifferentEncodingLayerIsBlanked(t *testing.T) {
+	f := Finding{
+		Match:  "secret: decoded-secret-value",
+		Secret: "decoded-secret-value",
+		Line:   "    secret: ZGVjb2RlZC1zZWNyZXQtdmFsdWU=", // base64 of the decoded value above
+	}
+	f.Redact(100)
+	assert.Equal(t, "REDACTED", f.Secret)
+	assert.Equal(t, "secret: REDACTED", f.Match)
+	assert.Equal(t, redactedUnlocatable, f.Line)
+	assert.NotContains(t, f.Line, "ZGVjb2RlZC1zZWNyZXQtdmFsdWU=")
 }
 
 func TestRedact_ComponentSets(t *testing.T) {
@@ -81,6 +103,310 @@ func TestRedact_SharedPointerDedup(t *testing.T) {
 	assert.Equal(t, "line ab... here", shared.Line)
 	assert.Equal(t, "found ab... here", shared.Match)
 	assert.Equal(t, "ab...", shared.CaptureGroups["token"])
+}
+
+// TestRedactLineAndMatch exercises the fail-closed helper shared by
+// Finding.Redact(), printPretty(), and PrintLegacy() directly, covering the
+// same decode-depth-shaped mismatch as TestRedact_LineFromDifferentEncodingLayerIsBlanked.
+// startColumn is 0 (unavailable) here, exercising the Contains-based fallback
+// path — see TestRedactLine_PositionVerified* for the startColumn > 0 paths.
+func TestRedactLineAndMatch(t *testing.T) {
+	line, match, matchContext := redactLineAndMatch(
+		"    secret: ZGVjb2RlZC1zZWNyZXQtdmFsdWU=", // Line: original, still-encoded source
+		"secret: decoded-secret-value",              // Match: decoded-level, consistent with Secret
+		"",
+		"decoded-secret-value",
+		"REDACTED",
+		0,
+	)
+	assert.Equal(t, redactedUnlocatable, line)
+	assert.Equal(t, "secret: REDACTED", match)
+	assert.Equal(t, "", matchContext)
+}
+
+// TestRedactLine_PositionVerifiedReplacesExactSpan is the normal, common
+// case: secret is a narrower capture group within match (e.g. after a
+// "secret: " prefix, exactly like the generic-api-key rule), and
+// secretOffsetInLine correctly combines startColumn (match's own offset)
+// with secret's offset within match to find secret's real position.
+func TestRedactLine_PositionVerifiedReplacesExactSpan(t *testing.T) {
+	line := "secret: value"
+	match := "secret: value" // match spans the whole line here
+	startColumn := 1          // match starts at the beginning of line
+	got := redactLine(line, match, "value", "REDACTED", startColumn)
+	assert.Equal(t, "secret: REDACTED", got)
+}
+
+// TestRedactLine_ReplacesDuplicateOccurrences: once secret's position is
+// verified, every identical occurrence in line is redacted, not just the
+// verified one — a repeated token must not survive un-redacted just because
+// only its first copy anchored the check.
+func TestRedactLine_ReplacesDuplicateOccurrences(t *testing.T) {
+	line := "token; token"
+	match := "token"
+	startColumn := 1 // match/secret both start at the first "token"
+	got := redactLine(line, match, "token", "REDACTED", startColumn)
+	assert.Equal(t, "REDACTED; REDACTED", got)
+}
+
+// TestRedactLine_DoesNotTrustUnrelatedCoincidentalOccurrence covers a
+// decode-depth-shaped finding (match/secret both decoded-level, consistent
+// with each other, but line kept in its original still-encoded form) where
+// line additionally contains an unrelated plaintext copy of the decoded
+// secret ahead of the real, encoded credential. secretOffsetInLine correctly
+// locates where the real match should be, but verifying line's content
+// there fails (it's still-encoded, not the decoded secret) — the
+// coincidental plaintext copy earlier in line must not be mistaken for it.
+func TestRedactLine_DoesNotTrustUnrelatedCoincidentalOccurrence(t *testing.T) {
+	encoded := "ZGVjb2RlZC1zZWNyZXQtdmFsdWU="
+	line := "# hint: decoded-secret-value secret: " + encoded
+	match := "secret: decoded-secret-value" // decoded-level, consistent with secret
+	startColumn := strings.Index(line, "secret: "+encoded) + 1 // where the real (encoded) match starts in line
+
+	got := redactLine(line, match, "decoded-secret-value", "REDACTED", startColumn)
+
+	assert.Equal(t, redactedUnlocatable, got)
+	assert.NotContains(t, got, encoded, "the real, still-encoded secret must never survive un-redacted")
+}
+
+// TestRedactContext_PositionVerifiedViaLineAnchor covers MatchContext: since
+// it isn't itself addressable by startColumn, verification anchors on line's
+// own (already-verified) position within it.
+func TestRedactContext_PositionVerifiedViaLineAnchor(t *testing.T) {
+	line := "secret: value"
+	match := "secret: value"
+	matchContext := "before\n" + line + "\nafter"
+	startColumn := 1
+
+	got := redactContext(matchContext, line, match, "value", "REDACTED", startColumn)
+	assert.Equal(t, "before\nsecret: REDACTED\nafter", got)
+}
+
+// TestRedactContext_DuplicateLineDoesNotLeaveRealOccurrenceRaw covers
+// MatchContext containing two copies of the same line text: verification
+// anchors on whichever copy strings.Index finds first, but since it then
+// replaces every occurrence of the verified secret throughout matchContext
+// (not just the anchored span), the real finding's copy is redacted too,
+// regardless of which copy happened to anchor the check.
+func TestRedactContext_DuplicateLineDoesNotLeaveRealOccurrenceRaw(t *testing.T) {
+	line := "secret: value"
+	match := "secret: value"
+	matchContext := line + "\nunrelated\n" + line // line appears twice
+	startColumn := 1
+
+	got := redactContext(matchContext, line, match, "value", "REDACTED", startColumn)
+	assert.Equal(t, "secret: REDACTED\nunrelated\nsecret: REDACTED", got)
+}
+
+// TestRedactContext_DoesNotTrustUnrelatedCoincidentalOccurrence is
+// TestRedactLine_DoesNotTrustUnrelatedCoincidentalOccurrence's MatchContext
+// counterpart: an unrelated plaintext copy of the secret elsewhere in the
+// context window must not cause the real, still-encoded copy (anchored via
+// line) to be mistaken for already-handled.
+func TestRedactContext_DoesNotTrustUnrelatedCoincidentalOccurrence(t *testing.T) {
+	encoded := "ZGVjb2RlZC1zZWNyZXQtdmFsdWU="
+	line := "secret: " + encoded
+	match := "secret: decoded-secret-value"
+	matchContext := "# hint: decoded-secret-value\n" + line
+	startColumn := 1 // match starts at the beginning of line
+
+	got := redactContext(matchContext, line, match, "decoded-secret-value", "REDACTED", startColumn)
+
+	assert.Equal(t, redactedUnlocatable, got)
+	assert.NotContains(t, got, encoded)
+}
+
+// TestRedactContext_ClippedWindowFailsClosedNotLenient covers a column-based
+// --match-context window clipped shorter than the full line: matchContext
+// doesn't contain line intact even though a real position was established,
+// so it must fail closed rather than falling through to the same lenient
+// Contains-based search reserved for when no position exists at all — which
+// here would incorrectly match an unrelated, coincidental occurrence.
+func TestRedactContext_ClippedWindowFailsClosedNotLenient(t *testing.T) {
+	line := "prefix secret: value suffix"
+	match := "secret: value"
+	startColumn := strings.Index(line, match) + 1
+	matchContext := "unrelated value mention, not the real match"
+
+	got := redactContext(matchContext, line, match, "value", "REDACTED", startColumn)
+
+	assert.Equal(t, redactedUnlocatable, got)
+}
+
+// TestRedactLine_SkipsLeadingNewlineNotReflectedInStartColumn covers a
+// multiline rule (e.g. "\n(secret)"): the detector trims a leading newline
+// from Match/Secret without adjusting StartColumn, so StartColumn can still
+// point at that newline byte in line rather than at match's actual first
+// byte post-trim.
+func TestRedactLine_SkipsLeadingNewlineNotReflectedInStartColumn(t *testing.T) {
+	line := "prefix\nsecret-value"
+	match := "secret-value" // already trimmed of its leading \n
+	startColumn := strings.Index(line, "\n") + 1 // 1-indexed, pointing at the newline itself
+
+	got := redactLine(line, match, "secret-value", "REDACTED", startColumn)
+
+	assert.Equal(t, "prefix\nREDACTED", got)
+}
+
+// TestRedactLine_HandlesUntrimmedCRLFPrefix covers a CRLF-leading multiline
+// rule (e.g. "\r\n(secret)"): the detector's strings.Trim(rawMatch, "\n")
+// only strips a run of pure \n characters from the very edges, so a leading
+// "\r\n" (whose first byte is \r, not in that cutset) is left completely
+// untrimmed — match still holds it verbatim, unlike the pure-\n case above.
+func TestRedactLine_HandlesUntrimmedCRLFPrefix(t *testing.T) {
+	line := "\r\nsecret-value"
+	match := "\r\nsecret-value" // untrimmed: detector's Trim didn't touch it
+	startColumn := 1            // points at the leading \r
+
+	got := redactLine(line, match, "secret-value", "REDACTED", startColumn)
+
+	assert.Equal(t, "\r\nREDACTED", got)
+}
+
+// TestRedactLine_AmbiguousMatchOccurrenceFailsClosed covers the
+// generic-credential-uri rule decoding a URI whose username coincidentally
+// equals its decoded password (e.g.
+// "https://plaintext-secret:<base64(plaintext-secret)>@host"), producing a
+// decoded match where "plaintext-secret" appears twice: once as the harmless
+// username, once as the actual captured secret. strings.Index alone can't
+// tell them apart — trusting the first (username) occurrence would verify
+// and redact it while leaving the real, still-encoded password elsewhere in
+// line completely untouched.
+func TestRedactLine_AmbiguousMatchOccurrenceFailsClosed(t *testing.T) {
+	encoded := "cGxhaW50ZXh0LXNlY3JldA==" // base64("plaintext-secret")
+	line := "https://plaintext-secret:" + encoded + "@host"
+	match := "https://plaintext-secret:plaintext-secret@host" // decoded-level
+	secret := "plaintext-secret"
+	startColumn := 1 // match starts at the beginning of line
+
+	got := redactLine(line, match, secret, "REDACTED", startColumn)
+
+	assert.Equal(t, redactedUnlocatable, got)
+	assert.NotContains(t, got, encoded, "the real, still-encoded password must never survive un-redacted")
+}
+
+// TestRedactContext_AnchorsDespiteMissingTrailingNewline covers box-mode
+// MatchContext (see detect.go, contextwindow.extractBox), which ends at a
+// line's trailing newline rather than past it, while Line itself (for any
+// but the file's last line) includes that trailing newline — so the anchor
+// lookup must still succeed via a trailing-newline-trimmed retry rather than
+// failing closed on an otherwise perfectly ordinary finding.
+func TestRedactContext_AnchorsDespiteMissingTrailingNewline(t *testing.T) {
+	line := "secret: value\n"
+	match := "secret: value"
+	startColumn := 1
+	matchContext := "before\nsecret: value" // no trailing \n on this line's copy
+
+	got := redactContext(matchContext, line, match, "value", "REDACTED", startColumn)
+
+	assert.Equal(t, "before\nsecret: REDACTED", got)
+}
+
+// sharedComponentFixture returns a Finding whose single ComponentSet holds a
+// *ComponentFinding also returned separately, so a test can call a printer on
+// the Finding and then assert the ComponentFinding's own fields are untouched
+// — proving the printer didn't mutate data shared with the finding collector.
+func sharedComponentFixture() (Finding, *ComponentFinding) {
+	comp := &ComponentFinding{
+		RuleID: "rule-a", Secret: "abcdefghij", Line: "line abcdefghij here", Match: "found abcdefghij here",
+		CaptureGroups: map[string]string{"token": "abcdefghij"},
+	}
+	f := Finding{
+		Match:         "primary",
+		Secret:        "primary",
+		ComponentSets: []ComponentSet{{Components: []*ComponentFinding{comp}}},
+	}
+	return f, comp
+}
+
+// TestPrintPrettyDoesNotMutateSharedComponentData guards against a
+// regression where printPretty routed redaction through the full
+// Finding.Redact(), which mutates the *ComponentFinding pointers and
+// CaptureGroups map shared with the collector's copy of the same finding —
+// causing double-redaction (e.g. a partial mask applied twice) once that
+// finding was later written to a report, and once more within the very same
+// print call via PrintComponentFindings' own masking.
+func TestPrintPrettyDoesNotMutateSharedComponentData(t *testing.T) {
+	f, comp := sharedComponentFixture()
+	f.printPretty(true, 50)
+	assert.Equal(t, "abcdefghij", comp.Secret, "printPretty must not mutate a shared ComponentFinding")
+	assert.Equal(t, "line abcdefghij here", comp.Line)
+	assert.Equal(t, "found abcdefghij here", comp.Match)
+	assert.Equal(t, "abcdefghij", comp.CaptureGroups["token"])
+}
+
+// TestPrintLegacyDoesNotMutateSharedComponentData is the PrintLegacy
+// counterpart to TestPrintPrettyDoesNotMutateSharedComponentData.
+func TestPrintLegacyDoesNotMutateSharedComponentData(t *testing.T) {
+	f, comp := sharedComponentFixture()
+	f.PrintLegacy(true, 50)
+	assert.Equal(t, "abcdefghij", comp.Secret, "PrintLegacy must not mutate a shared ComponentFinding")
+	assert.Equal(t, "line abcdefghij here", comp.Line)
+	assert.Equal(t, "found abcdefghij here", comp.Match)
+	assert.Equal(t, "abcdefghij", comp.CaptureGroups["token"])
+}
+
+// TestPrintLegacyRedactsLineFromDifferentEncodingLayer covers the same
+// decode-depth Secret/Line mismatch as TestRedact_LineFromDifferentEncodingLayerIsBlanked,
+// but for PrintLegacy specifically: it used to run its own separate, ad hoc
+// redaction that (like the pre-fix printPretty) silently left Line raw
+// whenever Secret wasn't a literal substring of it.
+func TestPrintLegacyRedactsLineFromDifferentEncodingLayer(t *testing.T) {
+	f := Finding{
+		Match:  "secret: decoded-secret-value",
+		Secret: "decoded-secret-value",
+		Line:   "    secret: ZGVjb2RlZC1zZWNyZXQtdmFsdWU=", // base64 of the decoded value above
+	}
+
+	out := capturePrintLegacyOutput(t, f, 100)
+
+	// PrintLegacy has its own pre-existing fallback for when it can't locate
+	// Match within Line (locateMatch returns -1): it prints Match directly
+	// instead of a Line-derived snippet. Since Match/Secret share the same
+	// (decoded) representation, that fallback already avoided a raw leak here
+	// even before this fix — the real, previously-unfixed gap was that
+	// PrintLegacy ran its own separate, non-fail-closed redaction at all
+	// (this assertion pins down that no raw leak occurs, regardless of which
+	// internal path produced the output).
+	assert.NotContains(t, out, "ZGVjb2RlZC1zZWNyZXQtdmFsdWU=", "PrintLegacy must never print the raw, un-redacted line")
+}
+
+// TestPrintLegacyRedactsMatchContextFromDifferentEncodingLayer covers
+// MatchContext, which — like Line — is sliced from the original,
+// still-encoded fragment text (see detect.go), so it has the same
+// Secret/representation mismatch risk for decode-depth findings. Unlike
+// Line, PrintLegacy prints MatchContext's content directly and unconditionally
+// via formatMatchContextLegacy whenever it's non-empty, with no fallback.
+func TestPrintLegacyRedactsMatchContextFromDifferentEncodingLayer(t *testing.T) {
+	f := Finding{
+		Match:        "secret: decoded-secret-value",
+		Secret:       "decoded-secret-value",
+		Line:         "    secret: ZGVjb2RlZC1zZWNyZXQtdmFsdWU=",
+		MatchContext: "context around:\n    secret: ZGVjb2RlZC1zZWNyZXQtdmFsdWU=\nmore context",
+	}
+
+	out := capturePrintLegacyOutput(t, f, 100)
+
+	assert.NotContains(t, out, "ZGVjb2RlZC1zZWNyZXQtdmFsdWU=", "PrintLegacy must never print the raw, un-redacted match context")
+	assert.Contains(t, out, redactedUnlocatable)
+}
+
+// capturePrintLegacyOutput redirects os.Stdout for the duration of a
+// PrintLegacy call and returns everything it printed.
+func capturePrintLegacyOutput(t *testing.T, f Finding, redact uint) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	f.PrintLegacy(true, redact)
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
 }
 
 func TestMask(t *testing.T) {

--- a/report/print_legacy.go
+++ b/report/print_legacy.go
@@ -11,13 +11,17 @@ import (
 // PrintLegacy prints a finding using the legacy key/value verbose format.
 func (f Finding) PrintLegacy(noColor bool, redact uint) {
 	if redact > 0 {
+		// Use the same fail-closed redactLineAndMatch as printPretty/Redact():
+		// a plain strings.ReplaceAll here silently leaves Line raw whenever
+		// Secret isn't a literal substring of it (e.g. a decode-depth finding).
+		// Never touch f.ComponentSets/f.CaptureGroups — see the comment in
+		// printPretty for why (f shares that reference-typed data with the
+		// collector's copy of this finding).
 		secret := MaskSecret(f.Secret, redact)
 		if redact >= 100 {
 			secret = "REDACTED"
 		}
-		f.Line = strings.ReplaceAll(f.Line, f.Secret, secret)
-		f.Match = strings.ReplaceAll(f.Match, f.Secret, secret)
-		f.MatchContext = strings.ReplaceAll(f.MatchContext, f.Secret, secret)
+		f.Line, f.Match, f.MatchContext = redactLineAndMatch(f.Line, f.Match, f.MatchContext, f.Secret, secret, f.StartColumn)
 		f.Secret = secret
 	}
 	f.Line = strings.TrimSpace(f.Line)

--- a/report/print_pretty.go
+++ b/report/print_pretty.go
@@ -455,13 +455,20 @@ func writeFooter() {
 
 func (f Finding) printPretty(noColor bool, redact uint) {
 	if redact > 0 {
+		// Use the same fail-closed redactLineAndMatch that Finding.Redact() uses
+		// for Line/Match/MatchContext, but — unlike calling Redact() itself —
+		// never touch f.ComponentSets or f.CaptureGroups here: f is a value-copy
+		// that still shares its *ComponentFinding pointers (and CaptureGroups
+		// map) with the collector's copy of this same finding, which still needs
+		// to redact them itself (for report-file output) or, for components,
+		// has PrintComponentFindings below compute its own display-only mask
+		// from the untouched original. Redacting them here too would silently
+		// double-mask an already-masked value.
 		secret := MaskSecret(f.Secret, redact)
 		if redact >= 100 {
 			secret = "REDACTED"
 		}
-		f.Line = strings.ReplaceAll(f.Line, f.Secret, secret)
-		f.Match = strings.ReplaceAll(f.Match, f.Secret, secret)
-		f.MatchContext = strings.ReplaceAll(f.MatchContext, f.Secret, secret)
+		f.Line, f.Match, f.MatchContext = redactLineAndMatch(f.Line, f.Match, f.MatchContext, f.Secret, secret, f.StartColumn)
 		f.Secret = secret
 	}
 


### PR DESCRIPTION
## Summary

Fixes #350.

Decode-depth/component findings capture `Secret` from decoded text, while `Line` and `MatchContext` are sliced from the original, still-encoded fragment (so console/report output shows the user's actual file, not an internal decoded intermediate). That means `Secret` is never a literal substring of `Line`/`MatchContext` for such findings. A naive `strings.ReplaceAll(line, secret, replacement)` silently no-ops when the secret isn't found, so this left the raw, still-encoded secret in `Line`/`MatchContext` untouched while `Secret` itself was unconditionally overwritten to `"REDACTED"`. In the verbose pretty printer this additionally broke the caret-locating logic, which then fell back to printing the fully raw line with no underline marker at all.

## Changes

- `report/finding.go`: added `redactLine()` (fail-closed: replaces the whole field with a safe placeholder when the secret can't be located, instead of leaving raw text in place) and `redactLineAndMatch()`, used for `Line`/`Match`/`MatchContext`. `CaptureGroups`/`ComponentSets` (a map and a slice of pointers — reference types) are handled only by `Finding.Redact()`, never by the console printers below, since printers hold a value-copy of a `Finding` whose `CaptureGroups`/`ComponentSets` still point at the exact same underlying data another consumer (a report writer, or `PrintComponentFindings`' own masking) needs to redact independently — touching them from two places would double-mask an already-masked value.
- `report/print_pretty.go`: `printPretty()` uses `redactLineAndMatch()` directly rather than calling the full `Redact()` (which *would* mutate the shared `ComponentSets`/`CaptureGroups`, causing exactly the double-redaction described above).
- `report/print_legacy.go`: `PrintLegacy()` (`--legacy-print`) previously ran its own separate, unhardened copy of the same redaction logic — now shares the same fail-closed helper.
- `report/finding_test.go`: new tests — `redactLineAndMatch` as a pure function, `printPretty`/`PrintLegacy` never mutating a shared `*ComponentFinding`, and `PrintLegacy` fail-closing on both `Line` and `MatchContext`.

## Test plan

- [x] `go test ./...` passes (full suite)
- [x] New regression tests pass, specifically proving: fail-closed `Line`/`MatchContext` redaction; no mutation of shared `ComponentFinding` pointers/`CaptureGroups` by either console printer
- [x] Manual repro: a doubly-base64-encoded secret no longer prints raw via `betterleaks git -v --redact .`, nor via `--legacy-print --redact`
- [x] Manual regression check: a plain, single-layer-encoded secret still redacts and renders with the normal `^^^^^^^^` caret underline (no behavior change for the common case)
