### PR TITLE
fix: use Git-compatible null config path on Windows

### DIFF
--- a/sources/git.go
+++ b/sources/git.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"time"
 	"unicode"
@@ -38,12 +37,9 @@ type GitCmd struct {
 // gitConfigIsolationEnv contains the standard Git configuration isolation environment variables.
 // These settings prevent Git from reading user or system configuration files.
 func gitConfigIsolationEnv() []string {
-	var nullDevice string
-	if runtime.GOOS == "windows" {
-		nullDevice = "NUL"
-	} else {
-		nullDevice = "/dev/null"
-	}
+	// Git for Windows accepts its POSIX null path, while recent releases reject
+	// the Win32 NUL device name when it is used as a config-file path.
+	nullDevice := "/dev/null"
 	overrides := map[string]string{
 		"GIT_CONFIG_GLOBAL":      nullDevice,
 		"GIT_CONFIG_NOSYSTEM":    "1",

--- a/sources/git_test.go
+++ b/sources/git_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,6 +18,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
+
+func TestGitConfigIsolationEnvCanRunGit(t *testing.T) {
+	repo := newGitTestRepo(t, 1)
+	cmd := exec.Command("git", "-C", repo, "rev-parse", "--is-inside-work-tree")
+	cmd.Env = gitConfigIsolationEnv()
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git must accept the isolated config paths: %s", output)
+	require.Equal(t, "true", strings.TrimSpace(string(output)))
+}
 
 func TestGitRepoWorkersHaveSameCoverage(t *testing.T) {
 	repo := newGitTestRepo(t, 4)

--- a/sources/scm/clone.go
+++ b/sources/scm/clone.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"runtime"
 	"strings"
 )
 
@@ -149,12 +148,9 @@ func isSSHRemote(s string) bool {
 }
 
 func gitCloneEnv(configs []GitConfig) []string {
-	var nullDevice string
-	if runtime.GOOS == "windows" {
-		nullDevice = "NUL"
-	} else {
-		nullDevice = "/dev/null"
-	}
+	// Git for Windows accepts its POSIX null path, while recent releases reject
+	// the Win32 NUL device name when it is used as a config-file path.
+	nullDevice := "/dev/null"
 	overrides := map[string]string{
 		"GIT_CONFIG_GLOBAL":      nullDevice,
 		"GIT_CONFIG_NOSYSTEM":    "1",

--- a/sources/scm/clone_test.go
+++ b/sources/scm/clone_test.go
@@ -90,6 +90,8 @@ func TestGitCloneEnv(t *testing.T) {
 	joined := strings.Join(env, "\n")
 
 	for _, want := range []string{
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
 		"GIT_CONFIG_COUNT=1",
 		"GIT_CONFIG_KEY_0=http.extraheader",
 		"GIT_CONFIG_VALUE_0=Authorization: basic abc",


### PR DESCRIPTION
Git history scans fail before reading any commits on Git for Windows 2.53 because the isolated child environment points both Git config files at `NUL`, which Git now rejects as a config path.

Use `/dev/null`, which Git for Windows maps correctly, for history and clone subprocesses on every platform. The new integration test runs a real Git command under the isolated environment, so Windows CI covers the reported failure rather than only comparing environment strings.

Closes #352.

Validation:

- `git diff --check`
- Full Linux and Windows test matrices run in CI
